### PR TITLE
ci: run only external deps tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -109,7 +109,7 @@ jobs:
         run: docker compose up -d
 
       - name: Test
-        run: cargo nextest run --all-features -- --include-ignored
+        run: cargo nextest run --all-features --run-ignored only
 
       - name: Test docs
         run: cargo test --doc


### PR DESCRIPTION
This is done to fix https://github.com/cot-rs/cot/actions/runs/12728982874/job/35480378199#step:8:441

Also, it runs *only* ignored tests to speed up the pipeline.