### PR TITLE
feat: various fixes for writing actual projects with the framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
 dependencies = [
  "serde",
 ]
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.24"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9560b07a799281c7e0958b9296854d6fafd4c5f31444a7e5bb1ad6dde5ccf1bd"
+checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -361,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.24"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874e0dd3eb68bf99058751ac9712f622e61e6f393a94f7128fa26e3f02f5c7cd"
+checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
 dependencies = [
  "anstream",
  "anstyle",
@@ -479,10 +479,11 @@ dependencies = [
  "sqlx",
  "subtle",
  "sync_wrapper",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "time",
  "tokio",
  "tower",
+ "tower-livereload",
  "tower-sessions",
  "tracing",
 ]
@@ -829,6 +830,7 @@ name = "example-admin"
 version = "0.1.0"
 dependencies = [
  "cot",
+ "rinja",
 ]
 
 [[package]]
@@ -2289,7 +2291,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "smallvec",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2373,7 +2375,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "tracing",
  "whoami",
 ]
@@ -2411,7 +2413,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "tracing",
  "whoami",
 ]
@@ -2471,9 +2473,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.95"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2543,11 +2545,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "a3ac7f54ca534db81081ef1c1e7f6ea8a3ef428d2fc069097c079443d24124d3"
 dependencies = [
- "thiserror-impl 2.0.9",
+ "thiserror-impl 2.0.10",
 ]
 
 [[package]]
@@ -2563,9 +2565,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "9e9465d30713b56a37ede7185763c3492a91be2f5fa68d958c44e41ab9248beb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2747,6 +2749,19 @@ name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-livereload"
+version = "0.9.6-wip"
+source = "git+https://github.com/leotaku/tower-livereload.git?rev=106cc96f91b11a1eca6d3dfc86be4e766a90a415#106cc96f91b11a1eca6d3dfc86be4e766a90a415"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tokio",
+ "tower",
+]
 
 [[package]]
 name = "tower-service"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,8 @@ thiserror = "2"
 time = { version = "0.3.35", default-features = false }
 tokio = { version = "1.41", default-features = false }
 tower = "0.5.2"
+# TODO switch back to the published version when https://github.com/leotaku/tower-livereload/pull/24 is released
+tower-livereload = { git = "https://github.com/leotaku/tower-livereload.git", rev = "106cc96f91b11a1eca6d3dfc86be4e766a90a415" }
 tower-sessions = { version = "0.13", default-features = false }
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = "0.3"

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Cot Authors
+Copyright (c) 2024-2025 Cot contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cot/Cargo.toml
+++ b/cot/Cargo.toml
@@ -43,6 +43,7 @@ thiserror.workspace = true
 time.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tower = { workspace = true, features = ["util"] }
+tower-livereload = { workspace = true, optional = true }
 tower-sessions = { workspace = true, features = ["memory-store"] }
 tracing.workspace = true
 
@@ -67,9 +68,11 @@ ignored = [
 
 [features]
 default = ["sqlite", "postgres", "mysql", "json"]
+full = ["default", "fake", "live-reload"]
 fake = ["dep:fake"]
 db = []
 sqlite = ["db", "sea-query/backend-sqlite", "sea-query-binder/sqlx-sqlite", "sqlx/sqlite"]
 postgres = ["db", "sea-query/backend-postgres", "sea-query-binder/sqlx-postgres", "sqlx/postgres"]
 mysql = ["db", "sea-query/backend-mysql", "sea-query-binder/sqlx-mysql", "sqlx/mysql"]
 json = ["serde_json"]
+live-reload = ["dep:tower-livereload"]

--- a/cot/src/admin.rs
+++ b/cot/src/admin.rs
@@ -18,7 +18,7 @@ use crate::forms::{
 use crate::request::{Request, RequestExt};
 use crate::response::{Response, ResponseExt};
 use crate::router::Router;
-use crate::{reverse, static_files, Body, CotApp, Render, StatusCode};
+use crate::{reverse_redirect, static_files, Body, CotApp, Render, StatusCode};
 
 #[derive(Debug, Form)]
 struct LoginForm {
@@ -60,7 +60,7 @@ async fn index(mut request: Request) -> cot::Result<Response> {
             Body::fixed(template.render()?),
         ))
     } else {
-        Ok(reverse!(request, "login"))
+        Ok(reverse_redirect!(request, "login"))
     }
 }
 
@@ -72,7 +72,7 @@ async fn login(mut request: Request) -> cot::Result<Response> {
         match login_form {
             FormResult::Ok(login_form) => {
                 if authenticate(&mut request, login_form).await? {
-                    return Ok(reverse!(request, "index"));
+                    return Ok(reverse_redirect!(request, "index"));
                 }
 
                 let mut context = LoginForm::build_context(&mut request).await?;
@@ -139,7 +139,7 @@ async fn view_model(mut request: Request) -> cot::Result<Response> {
             Body::fixed(template.render()?),
         ))
     } else {
-        Ok(reverse!(request, "login"))
+        Ok(reverse_redirect!(request, "login"))
     }
 }
 

--- a/cot/src/error_page.rs
+++ b/cot/src/error_page.rs
@@ -301,7 +301,7 @@ fn build_cot_failure_page() -> axum::response::Response {
     axum::response::Response::builder()
         .status(StatusCode::INTERNAL_SERVER_ERROR)
         .body(axum::body::Body::from(FAILURE_PAGE))
-        .expect("Building the Cot failure page should not fail")
+        .expect("Building the Cot failure page should never fail")
 }
 
 thread_local! {
@@ -310,7 +310,6 @@ thread_local! {
 }
 
 pub(super) fn error_page_panic_hook(info: &PanicHookInfo<'_>) {
-    // TODO print out the panic as well
     let location = info.location().map(|location| format!("{location}"));
     PANIC_LOCATION.replace(location);
 

--- a/cot/src/middleware.rs
+++ b/cot/src/middleware.rs
@@ -4,7 +4,135 @@
 //! are used to add functionality to the request/response cycle, such as
 //! session management, adding security headers, and more.
 
+use std::task::{Context, Poll};
+
+use bytes::Bytes;
+use futures_util::TryFutureExt;
+use http_body_util::combinators::BoxBody;
+use http_body_util::BodyExt;
+use tower::Service;
 use tower_sessions::{MemoryStore, SessionManagerLayer};
+
+use crate::error::ErrorRepr;
+use crate::request::Request;
+use crate::response::Response;
+use crate::{Body, Error};
+
+#[derive(Debug, Copy, Clone)]
+pub struct IntoCotResponseLayer;
+
+impl IntoCotResponseLayer {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for IntoCotResponseLayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S> tower::Layer<S> for IntoCotResponseLayer {
+    type Service = IntoCotResponse<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        IntoCotResponse { inner }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct IntoCotResponse<S> {
+    inner: S,
+}
+
+impl<S, B, E> Service<Request> for IntoCotResponse<S>
+where
+    S: Service<Request, Response = http::Response<B>>,
+    B: http_body::Body<Data = Bytes, Error = E> + Send + Sync + 'static,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    type Response = Response;
+    type Error = S::Error;
+    type Future = futures_util::future::MapOk<S::Future, fn(http::Response<B>) -> Response>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    #[inline]
+    fn call(&mut self, request: Request) -> Self::Future {
+        self.inner.call(request).map_ok(map_response)
+    }
+}
+
+fn map_response<B, E>(response: http::response::Response<B>) -> Response
+where
+    B: http_body::Body<Data = Bytes, Error = E> + Send + Sync + 'static,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    response.map(|body| Body::wrapper(BoxBody::new(body.map_err(map_err))))
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct IntoCotErrorLayer;
+
+impl IntoCotErrorLayer {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for IntoCotErrorLayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S> tower::Layer<S> for IntoCotErrorLayer {
+    type Service = IntoCotError<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        IntoCotError { inner }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct IntoCotError<S> {
+    inner: S,
+}
+
+impl<S> Service<Request> for IntoCotError<S>
+where
+    S: Service<Request>,
+    <S as Service<Request>>::Error: std::error::Error + Send + Sync + 'static,
+{
+    type Response = S::Response;
+    type Error = Error;
+    type Future = futures_util::future::MapErr<S::Future, fn(S::Error) -> Error>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(map_err)
+    }
+
+    #[inline]
+    fn call(&mut self, request: Request) -> Self::Future {
+        self.inner.call(request).map_err(map_err)
+    }
+}
+
+fn map_err<E>(error: E) -> Error
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    Error::new(ErrorRepr::MiddlewareWrapped {
+        source: Box::new(error),
+    })
+}
 
 #[derive(Debug, Copy, Clone)]
 pub struct SessionMiddleware;
@@ -29,6 +157,34 @@ impl<S> tower::Layer<S> for SessionMiddleware {
         let session_store = MemoryStore::default();
         let session_layer = SessionManagerLayer::new(session_store);
         session_layer.layer(inner)
+    }
+}
+
+#[cfg(feature = "live-reload")]
+#[derive(Debug, Clone)]
+pub struct LiveReloadMiddleware(tower_livereload::LiveReloadLayer);
+
+#[cfg(feature = "live-reload")]
+impl LiveReloadMiddleware {
+    #[must_use]
+    pub fn new() -> Self {
+        Self(tower_livereload::LiveReloadLayer::new())
+    }
+}
+
+#[cfg(feature = "live-reload")]
+impl Default for LiveReloadMiddleware {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(feature = "live-reload")]
+impl<S> tower::Layer<S> for LiveReloadMiddleware {
+    type Service = <tower_livereload::LiveReloadLayer as tower::Layer<S>>::Service;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        self.0.layer(inner)
     }
 }
 

--- a/cot/src/private.rs
+++ b/cot/src/private.rs
@@ -11,4 +11,5 @@ pub use bytes::Bytes;
 pub use tokio;
 
 // used in the CLI
+#[cfg(feature = "db")]
 pub use crate::utils::graph::apply_permutation;

--- a/cot/src/request.rs
+++ b/cot/src/request.rs
@@ -55,6 +55,9 @@ pub trait RequestExt: private::Sealed {
     fn router(&self) -> &Router;
 
     #[must_use]
+    fn route_name(&self) -> Option<&str>;
+
+    #[must_use]
     fn path_params(&self) -> &PathParams;
 
     #[must_use]
@@ -139,6 +142,12 @@ impl RequestExt for Request {
         self.context().router()
     }
 
+    fn route_name(&self) -> Option<&str> {
+        self.extensions()
+            .get::<RouteName>()
+            .map(|RouteName(name)| name.as_str())
+    }
+
     fn path_params(&self) -> &PathParams {
         self.extensions()
             .get::<PathParams>()
@@ -212,6 +221,10 @@ impl RequestExt for Request {
         }
     }
 }
+
+#[repr(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct RouteName(pub(crate) String);
 
 #[derive(Debug, Clone)]
 pub struct PathParams {

--- a/cot/src/router/path.rs
+++ b/cot/src/router/path.rs
@@ -178,10 +178,10 @@ impl ReverseParamMap {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! reverse_param_map {
-    ($($key:expr => $value:expr),*) => {{
+    ($($key:ident = $value:expr),*) => {{
         #[allow(unused_mut)]
         let mut map = $crate::router::path::ReverseParamMap::new();
-        $( map.insert($key, $value); )*
+        $( map.insert(stringify!($key), $value); )*
         map
     }};
 }

--- a/cot/src/utils.rs
+++ b/cot/src/utils.rs
@@ -1,1 +1,2 @@
+#[cfg(feature = "db")]
 pub(crate) mod graph;

--- a/cot/templates/admin/model_list.html
+++ b/cot/templates/admin/model_list.html
@@ -5,6 +5,6 @@
 {% block content %}
 {% let request = request %}
 {% for model in model_managers %}
-    <a href="{{ cot::reverse_str!(request, "view_model", "model_name" => model.url_name()) }}">{{ model.name() }}</a>
+    <a href="{{ cot::reverse!(request, "view_model", model_name = model.url_name()) }}">{{ model.name() }}</a>
 {% endfor %}
 {% endblock %}

--- a/examples/admin/Cargo.toml
+++ b/examples/admin/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 cot = { path = "../../cot" }
+rinja = "0.3.5"

--- a/examples/admin/src/main.rs
+++ b/examples/admin/src/main.rs
@@ -8,9 +8,19 @@ use cot::response::{Response, ResponseExt};
 use cot::router::{Route, Router};
 use cot::static_files::StaticFilesMiddleware;
 use cot::{AppContext, Body, CotApp, CotProject, StatusCode};
+use rinja::Template;
 
-async fn hello(_request: Request) -> cot::Result<Response> {
-    Ok(Response::new_html(StatusCode::OK, Body::fixed("xd")))
+#[derive(Debug, Template)]
+#[template(path = "index.html")]
+struct IndexTemplate<'a> {
+    request: &'a Request,
+}
+
+async fn index(request: Request) -> cot::Result<Response> {
+    let index_template = IndexTemplate { request: &request };
+    let rendered = index_template.render()?;
+
+    Ok(Response::new_html(StatusCode::OK, Body::fixed(rendered)))
 }
 
 struct HelloApp;
@@ -32,7 +42,7 @@ impl CotApp for HelloApp {
     }
 
     fn router(&self) -> Router {
-        Router::with_urls([Route::with_handler("/", hello)])
+        Router::with_urls([Route::with_handler("/", index)])
     }
 }
 

--- a/examples/admin/templates/index.html
+++ b/examples/admin/templates/index.html
@@ -5,10 +5,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sessions example</title>
+    <title>Admin Panel example</title>
 </head>
 <body>
 <h1>Hello!</h1>
-<p>Your name is: {{ name }}</p>
+<p>Go to the <a href="/admin/">admin panel</a>.</p>
 </body>
 </html>

--- a/examples/admin/templates/name.html
+++ b/examples/admin/templates/name.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 <h1>Hello!</h1>
-<form id="todo-form" action="{{ cot::reverse_str!(request, "name") }}" method="post">
+<form id="todo-form" action="{{ cot::reverse!(request, "name") }}" method="post">
     <input type="text" id="name" name="name" placeholder="Please enter your name" required>
     <button type="submit">Submit</button>
 </form>

--- a/examples/sessions/src/main.rs
+++ b/examples/sessions/src/main.rs
@@ -3,7 +3,7 @@ use cot::middleware::SessionMiddleware;
 use cot::request::{Request, RequestExt};
 use cot::response::{Response, ResponseExt};
 use cot::router::{Route, Router};
-use cot::{reverse, Body, CotApp, CotProject, StatusCode};
+use cot::{reverse_redirect, Body, CotApp, CotProject, StatusCode};
 use rinja::Template;
 
 #[derive(Debug, Template)]
@@ -33,7 +33,7 @@ async fn hello(request: Request) -> cot::Result<Response> {
         .expect("Invalid session value")
         .unwrap_or_default();
     if name.is_empty() {
-        return Ok(reverse!(request, "name"));
+        return Ok(reverse_redirect!(request, "name"));
     }
 
     let template = IndexTemplate {
@@ -56,7 +56,7 @@ async fn name(mut request: Request) -> cot::Result<Response> {
             .await
             .unwrap();
 
-        return Ok(reverse!(request, "index"));
+        return Ok(reverse_redirect!(request, "index"));
     }
 
     let template = NameTemplate { request: &request };

--- a/examples/sessions/templates/name.html
+++ b/examples/sessions/templates/name.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 <h1>Hello!</h1>
-<form id="todo-form" action="{{ cot::reverse_str!(request, "name") }}" method="post">
+<form id="todo-form" action="{{ cot::reverse!(request, "name") }}" method="post">
     <input type="text" id="name" name="name" placeholder="Please enter your name" required>
     <button type="submit">Submit</button>
 </form>

--- a/examples/todo-list/src/main.rs
+++ b/examples/todo-list/src/main.rs
@@ -7,7 +7,7 @@ use cot::forms::Form;
 use cot::request::{Request, RequestExt};
 use cot::response::{Response, ResponseExt};
 use cot::router::{Route, Router};
-use cot::{reverse, Body, CotApp, CotProject, StatusCode};
+use cot::{reverse_redirect, Body, CotApp, CotProject, StatusCode};
 use rinja::Template;
 
 #[derive(Debug, Clone)]
@@ -53,7 +53,7 @@ async fn add_todo(mut request: Request) -> cot::Result<Response> {
         .await?;
     }
 
-    Ok(reverse!(request, "index"))
+    Ok(reverse_redirect!(request, "index"))
 }
 
 async fn remove_todo(request: Request) -> cot::Result<Response> {
@@ -69,7 +69,7 @@ async fn remove_todo(request: Request) -> cot::Result<Response> {
             .await?;
     }
 
-    Ok(reverse!(request, "index"))
+    Ok(reverse_redirect!(request, "index"))
 }
 
 struct TodoApp;

--- a/examples/todo-list/templates/index.html
+++ b/examples/todo-list/templates/index.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 <h1>TODO List</h1>
-<form id="todo-form" action="{{ cot::reverse_str!(request, "add-todo") }}" method="post">
+<form id="todo-form" action="{{ cot::reverse!(request, "add-todo") }}" method="post">
     <input type="text" id="title" name="title" placeholder="Enter a new TODO" required>
     <button type="submit">Add TODO</button>
 </form>
@@ -17,7 +17,7 @@
     {% for todo in todo_items %}
     <li>
         {% let todo_id = todo.id %}
-        <form action="{{ cot::reverse_str!(request, "remove-todo", "todo_id" => todo_id) }}" method="post">
+        <form action="{{ cot::reverse!(request, "remove-todo", todo_id = todo_id) }}" method="post">
             <span>{{ todo.title }}</span>
             <button type="submit">Remove</button>
         </form>


### PR DESCRIPTION
This fixes a lot of stuff found when writing the documentation page:
* Add live reloading middleware
* Add support for response body-modifying middlewares
* Rename reverse_str!() to reverse!() and change param format a bit to be more intuitive
* Rename reverse!() to reverse_redirect!() since getting a URL as string is far more common than returning a redirect response
* Fixes around error handling, examples, documentation, etc.
* Updated year in LICENSE-MIT

After this initial batch of fixes, next PRs will be one feature per commit.