### PR TITLE
chore: rename cot-cli executable to just `cot`

### DIFF
--- a/cot-cli/Cargo.toml
+++ b/cot-cli/Cargo.toml
@@ -5,6 +5,10 @@ edition.workspace = true
 license.workspace = true
 description = "Modern web framework focused on speed and ease of use - CLI tool."
 
+[[bin]]
+name = "cot"
+path = "src/main.rs"
+
 [lints]
 workspace = true
 


### PR DESCRIPTION
This will be more convenient for the users, and won't produce conflicts anyway (since the `cot` crate is a library).