### PR TITLE
refactor: remove Render trait

### DIFF
--- a/cot-macros/src/lib.rs
+++ b/cot-macros/src/lib.rs
@@ -17,14 +17,6 @@ use crate::main_fn::fn_to_cot_main;
 use crate::model::impl_model_for_struct;
 use crate::query::{query_to_tokens, Query};
 
-/// Derive the [`Form`] trait for a struct.
-///
-/// This macro will generate an implementation of the [`Form`] trait for the
-/// given named struct. Note that all the fields of the struct **must**
-/// implement the [`AsFormField`] trait.
-///
-/// [`Form`]: trait.Form.html
-/// [`AsFormField`]: trait.AsFormField.html
 #[proc_macro_derive(Form, attributes(form))]
 pub fn derive_form(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as syn::DeriveInput);

--- a/cot/src/admin.rs
+++ b/cot/src/admin.rs
@@ -18,7 +18,7 @@ use crate::form::{
 use crate::request::{Request, RequestExt};
 use crate::response::{Response, ResponseExt};
 use crate::router::Router;
-use crate::{reverse_redirect, static_files, Body, CotApp, Render, StatusCode};
+use crate::{reverse_redirect, static_files, Body, CotApp, StatusCode};
 
 #[derive(Debug, Form)]
 struct LoginForm {

--- a/cot/src/html.rs
+++ b/cot/src/html.rs
@@ -1,0 +1,295 @@
+//! HTML rendering utilities.
+//!
+//! This module provides structures and methods for creating and rendering HTML
+//! content.
+//!
+//! # Examples
+//!
+//! ## Creating and rendering an HTML Tag
+//!
+//! ```
+//! use cot::html::HtmlTag;
+//!
+//! let tag = HtmlTag::new("br");
+//! let html = tag.render();
+//! assert_eq!(html.as_str(), "<br />");
+//! ```
+//!
+//! ## Adding Attributes to an HTML Tag
+//!
+//! ```
+//! use cot::html::HtmlTag;
+//!
+//! let mut tag = HtmlTag::new("input");
+//! tag.attr("type", "text").attr("placeholder", "Enter text");
+//! tag.bool_attr("disabled");
+//! assert_eq!(
+//!     tag.render().as_str(),
+//!     "<input type=\"text\" placeholder=\"Enter text\" disabled />"
+//! );
+//! ```
+
+use std::fmt::Write;
+
+use derive_more::{Deref, Display, From};
+use rinja::filters::Escaper;
+
+/// A type that represents HTML content as a string.
+///
+/// Note that this is just a newtype wrapper around `String` and does not
+/// provide any HTML escaping functionality. It is **not** guaranteed to be safe
+/// from XSS attacks.
+///
+/// For HTML escaping, it is recommended to use the [`HtmlTag`] struct.
+///
+/// # Examples
+///
+/// ```
+/// use cot::html::Html;
+///
+/// let html = Html::new("<div>Hello</div>");
+/// assert_eq!(html.as_str(), "<div>Hello</div>");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Deref, From, Display)]
+pub struct Html(String);
+
+impl Html {
+    /// Creates a new `Html` instance from a string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cot::html::Html;
+    ///
+    /// let html = Html::new("<div>Hello</div>");
+    /// assert_eq!(html.as_str(), "<div>Hello</div>");
+    /// ```
+    #[must_use]
+    pub fn new<T: Into<String>>(html: T) -> Self {
+        Self(html.into())
+    }
+
+    /// Returns the inner string as a `&str`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cot::html::Html;
+    ///
+    /// let html = Html::new("<div>Hello</div>");
+    /// assert_eq!(html.as_str(), "<div>Hello</div>");
+    /// ```
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A helper struct for rendering HTML tags.
+///
+/// This struct is used to build HTML tags with attributes and boolean
+/// attributes. It automatically escapes all attribute values.
+///
+/// # Examples
+///
+/// ```
+/// use cot::html::HtmlTag;
+///
+/// let mut tag = HtmlTag::new("input");
+/// tag.attr("type", "text").attr("placeholder", "Enter text");
+/// tag.bool_attr("disabled");
+/// assert_eq!(
+///     tag.render().as_str(),
+///     "<input type=\"text\" placeholder=\"Enter text\" disabled />"
+/// );
+/// ```
+#[derive(Debug)]
+pub struct HtmlTag {
+    tag: String,
+    attributes: Vec<(String, String)>,
+    boolean_attributes: Vec<String>,
+}
+
+impl HtmlTag {
+    /// Creates a new `HtmlTag` instance.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cot::html::HtmlTag;
+    ///
+    /// let tag = HtmlTag::new("div");
+    /// assert_eq!(tag.render().as_str(), "<div />");
+    /// ```
+    #[must_use]
+    pub fn new(tag: &str) -> Self {
+        Self {
+            tag: tag.to_string(),
+            attributes: Vec::new(),
+            boolean_attributes: Vec::new(),
+        }
+    }
+
+    /// Creates a new `HtmlTag` instance for an input element.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cot::html::HtmlTag;
+    ///
+    /// let input = HtmlTag::input("text");
+    /// assert_eq!(input.render().as_str(), "<input type=\"text\" />");
+    /// ```
+    #[must_use]
+    pub fn input(input_type: &str) -> Self {
+        let mut input = Self::new("input");
+        input.attr("type", input_type);
+        input
+    }
+
+    /// Adds an attribute to the HTML tag.
+    ///
+    /// # Safety
+    ///
+    /// This function will escape the attribute value. Note that it does not
+    /// escape the attribute name.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the attribute already exists.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cot::html::HtmlTag;
+    ///
+    /// let mut tag = HtmlTag::new("input");
+    /// tag.attr("type", "text").attr("placeholder", "Enter text");
+    /// assert_eq!(
+    ///     tag.render().as_str(),
+    ///     "<input type=\"text\" placeholder=\"Enter text\" />"
+    /// );
+    /// ```
+    pub fn attr(&mut self, key: &str, value: &str) -> &mut Self {
+        assert!(
+            !self.attributes.iter().any(|(k, _)| k == key),
+            "Attribute already exists: {key}"
+        );
+        self.attributes.push((key.to_string(), value.to_string()));
+        self
+    }
+
+    /// Adds a boolean attribute to the HTML tag.
+    ///
+    /// # Safety
+    ///
+    /// This function will not escape the attribute name.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the boolean attribute already exists.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cot::html::HtmlTag;
+    ///
+    /// let mut tag = HtmlTag::new("input");
+    /// tag.bool_attr("disabled");
+    /// assert_eq!(tag.render().as_str(), "<input disabled />");
+    /// ```
+    pub fn bool_attr(&mut self, key: &str) -> &mut Self {
+        assert!(
+            !self.boolean_attributes.contains(&key.to_string()),
+            "Boolean attribute already exists: {key}"
+        );
+        self.boolean_attributes.push(key.to_string());
+        self
+    }
+
+    /// Renders the HTML tag.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cot::html::HtmlTag;
+    ///
+    /// let tag = HtmlTag::new("div");
+    /// assert_eq!(tag.render().as_str(), "<div />");
+    /// ```
+    #[must_use]
+    pub fn render(&self) -> Html {
+        const FAIL_MSG: &str = "Failed to write HTML tag";
+
+        let mut result = String::new();
+        write!(&mut result, "<{}", self.tag).expect(FAIL_MSG);
+
+        for (key, value) in &self.attributes {
+            write!(&mut result, " {}=\"", key).expect(FAIL_MSG);
+            rinja::filters::Html
+                .write_escaped_str(&mut result, value)
+                .expect(FAIL_MSG);
+            write!(&mut result, "\"").expect(FAIL_MSG);
+        }
+        for key in &self.boolean_attributes {
+            write!(&mut result, " {}", key).expect(FAIL_MSG);
+        }
+
+        write!(&mut result, " />").expect(FAIL_MSG);
+        result.into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_html_new() {
+        let html = Html::new("<div>Hello</div>");
+        assert_eq!(html.as_str(), "<div>Hello</div>");
+    }
+
+    #[test]
+    fn test_html_tag_new() {
+        let tag = HtmlTag::new("div");
+        assert_eq!(tag.render().as_str(), "<div />");
+    }
+
+    #[test]
+    fn test_html_tag_with_attributes() {
+        let mut tag = HtmlTag::new("input");
+        tag.attr("type", "text").attr("placeholder", "Enter text");
+        assert_eq!(
+            tag.render().as_str(),
+            "<input type=\"text\" placeholder=\"Enter text\" />"
+        );
+    }
+
+    #[test]
+    fn test_html_tag_escaping() {
+        let mut tag = HtmlTag::new("input");
+        tag.attr("type", "text").attr("placeholder", "<>&\"'");
+        assert_eq!(
+            tag.render().as_str(),
+            "<input type=\"text\" placeholder=\"&#60;&#62;&#38;&#34;&#39;\" />"
+        );
+    }
+
+    #[test]
+    fn test_html_tag_with_boolean_attributes() {
+        let mut tag = HtmlTag::new("input");
+        tag.bool_attr("disabled");
+        assert_eq!(tag.render().as_str(), "<input disabled />");
+    }
+
+    #[test]
+    fn test_html_tag_input() {
+        let mut input = HtmlTag::input("text");
+        input.attr("name", "username");
+        assert_eq!(
+            input.render().as_str(),
+            "<input type=\"text\" name=\"username\" />"
+        );
+    }
+}

--- a/cot/src/lib.rs
+++ b/cot/src/lib.rs
@@ -65,6 +65,7 @@ pub mod cli;
 pub mod config;
 mod error_page;
 mod handler;
+pub mod html;
 pub mod middleware;
 pub(crate) mod project;
 pub mod request;
@@ -90,37 +91,3 @@ pub type StatusCode = http::StatusCode;
 
 /// A type alias for an HTTP method.
 pub type Method = http::Method;
-
-/// A trait for types that can be used to render them as HTML.
-pub trait Render {
-    /// Renders the object as an HTML string.
-    fn render(&self) -> Html;
-}
-
-/// A type that represents HTML content as a string.
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Default,
-    derive_more::Deref,
-    derive_more::From,
-    derive_more::Display,
-)]
-pub struct Html(String);
-
-impl Html {
-    #[must_use]
-    pub fn new<T: Into<String>>(html: T) -> Self {
-        Self(html.into())
-    }
-
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}

--- a/cot/src/private.rs
+++ b/cot/src/private.rs
@@ -8,6 +8,10 @@
 
 pub use async_trait::async_trait;
 pub use bytes::Bytes;
+/// Rinja's macros don't work when Rinja is re-exported, so there's no point in
+/// re-exporting it publicly. However, we need to re-export it here so that our
+/// macros can implement traits from Rinja.
+pub use rinja;
 pub use tokio;
 
 // used in the CLI

--- a/cot/templates/admin/login.html
+++ b/cot/templates/admin/login.html
@@ -17,7 +17,7 @@
 
         <div class="form-row">
             <label for="{{ form.username.id() }}">Username:</label>
-            {{ form.username.render()|safe }}
+            {{ form.username }}
             {% for error in form.errors_for(FormErrorTarget::Field("username")) %}
             {{ error }}
             {% endfor %}
@@ -25,7 +25,7 @@
 
         <div class="form-row">
             <label for="{{ form.password.id() }}">Password:</label>
-            {{ form.password.render()|safe }}
+            {{ form.password }}
             {% for error in form.errors_for(FormErrorTarget::Field("password")) %}
             {{ error }}
             {% endfor %}

--- a/cot/tests/form.rs
+++ b/cot/tests/form.rs
@@ -19,6 +19,15 @@ async fn context_from_empty_request() {
 }
 
 #[tokio::test]
+async fn context_display_non_empty() {
+    let mut request = TestRequestBuilder::get("/").build();
+
+    let context = MyForm::build_context(&mut request).await.unwrap();
+    let form_rendered = context.to_string();
+    assert!(!form_rendered.is_empty());
+}
+
+#[tokio::test]
 async fn form_from_request() {
     let mut request = TestRequestBuilder::post("/")
         .form_data(&[("name", "Alice"), ("age", "30")])


### PR DESCRIPTION
There's really no point of having a separate trait that just returns Strings (even if they're wrapped in Html newtype).

One of the advantages of rinja over askama is that we can mark types as HTML-safe, so they don't get escaped. So now, after removing Render and using plain old Display, instead of writing `{{ form_field.render()|safe }}` we can do just `{{ form_field }}`.