### PR TITLE
test: use DROP ... WITH (FORCE) in tests

### DIFF
--- a/cot/src/test.rs
+++ b/cot/src/test.rs
@@ -336,7 +336,9 @@ impl TestDatabase {
             TestDatabaseKind::Postgres { db_url, db_name } => {
                 let database = Database::new(format!("{db_url}/postgres")).await?;
 
-                database.raw(&format!("DROP DATABASE {db_name}")).await?;
+                database
+                    .raw(&format!("DROP DATABASE {db_name} WITH (FORCE)"))
+                    .await?;
                 database.close().await?;
             }
             TestDatabaseKind::MySql { db_url, db_name } => {


### PR DESCRIPTION
Postgres tests very frequently fail because supposedly there's a session still running when dropping the test database (which doesn't make much sense, because closing the only session and THEN dropping the database should be done sequentially in a single future).

Single this is becoming increasingly annoying and I don't have any good idea how to fix this properly, and this is only affecting tests, I think it's fine to just do `WITH (FORCE)` and forget about the issue for now.

See also: https://github.com/orgs/cot-rs/projects/2?pane=issue&itemId=94050368