### PR TITLE
chore(deps): switch back to upstream tower-livereload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,8 +2777,9 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-livereload"
-version = "0.9.6-wip"
-source = "git+https://github.com/leotaku/tower-livereload.git?rev=106cc96f91b11a1eca6d3dfc86be4e766a90a415#106cc96f91b11a1eca6d3dfc86be4e766a90a415"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa6b29b17d4540f2bd9ec304ad39d280c4bdf291d0ea6c4123eeba10939af84"
 dependencies = [
  "bytes",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,8 +79,7 @@ thiserror = "2"
 time = { version = "0.3.35", default-features = false }
 tokio = { version = "1.41", default-features = false }
 tower = "0.5.2"
-# TODO switch back to the published version when https://github.com/leotaku/tower-livereload/pull/24 is released
-tower-livereload = { git = "https://github.com/leotaku/tower-livereload.git", rev = "106cc96f91b11a1eca6d3dfc86be4e766a90a415" }
+tower-livereload = "0.9.6"
 tower-sessions = { version = "0.13", default-features = false }
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = "0.3"


### PR DESCRIPTION
A new version has been released, so there's no longer any need to use our fork.