### PR TITLE
feat: switch to Rust-like syntax for URL params

### DIFF
--- a/cot-cli/src/new_project.rs
+++ b/cot-cli/src/new_project.rs
@@ -37,7 +37,7 @@ impl CotSource<'_> {
             CotSource::Path(path) => {
                 format!(
                     "path = \"{}\"",
-                    path.display().to_string().replace("\\", "\\\\")
+                    path.display().to_string().replace('\\', "\\\\")
                 )
             }
             CotSource::PublishedCrate => format!("version = \"{}\"", env!("CARGO_PKG_VERSION")),

--- a/cot/src/admin.rs
+++ b/cot/src/admin.rs
@@ -245,7 +245,7 @@ impl CotApp for AdminApp {
         Router::with_urls([
             crate::Route::with_handler_and_name("/", index, "index"),
             crate::Route::with_handler_and_name("/login", login, "login"),
-            crate::Route::with_handler_and_name("/:model_name", view_model, "view_model"),
+            crate::Route::with_handler_and_name("/{model_name}", view_model, "view_model"),
         ])
     }
 

--- a/cot/src/db.rs
+++ b/cot/src/db.rs
@@ -639,7 +639,7 @@ impl Database {
 
         let mut insert_statement = sea_query::Query::insert()
             .into_table(T::TABLE_NAME)
-            .columns(value_identifiers.iter().cloned())
+            .columns(value_identifiers.iter().copied())
             .values(
                 filtered_values
                     .into_iter()

--- a/cot/src/router.rs
+++ b/cot/src/router.rs
@@ -456,7 +456,7 @@ mod tests {
 
     #[test]
     fn router_reverse_with_param() {
-        let route = Route::with_handler_and_name("/test/:id", MockHandler, "test");
+        let route = Route::with_handler_and_name("/test/{id}", MockHandler, "test");
         let router = Router::with_urls(vec![route.clone()]);
         let mut params = ReverseParamMap::new();
         params.insert("id", "123");
@@ -494,8 +494,8 @@ mod tests {
 
     #[test]
     fn route_with_handler_and_params() {
-        let route = Route::with_handler("/test/:id", MockHandler);
-        assert_eq!(route.url.to_string(), "/test/:id");
+        let route = Route::with_handler("/test/{id}", MockHandler);
+        assert_eq!(route.url.to_string(), "/test/{id}");
     }
 
     #[test]

--- a/cot/src/router/path.rs
+++ b/cot/src/router/path.rs
@@ -23,9 +23,52 @@ impl PathMatcher {
         let mut parts = Vec::new();
         let mut state = State::Literal { start: 0 };
 
-        for (index, ch) in path_pattern.chars().map(Some).chain([None]).enumerate() {
+        let mut char_iter = path_pattern
+            .chars()
+            .map(Some)
+            .chain([None])
+            .enumerate()
+            .peekable();
+        loop {
+            let Some((index, ch)) = char_iter.next() else {
+                break;
+            };
+
             match (ch, state) {
-                (Some('/') | None, State::Param { start }) => {
+                (Some('{') | None, State::Literal { start }) => {
+                    let literal = &path_pattern[start..index];
+                    if literal.is_empty() {
+                        if index != 0 && ch != None {
+                            panic!("Consecutive parameters are not allowed");
+                        }
+                    } else {
+                        parts.push(PathPart::Literal(literal.to_string()));
+                    }
+                    state = State::Param { start: index + 1 };
+                }
+                (Some('{'), State::Param { start }) => {
+                    if start == index {
+                        // escaped `{`
+                        state = State::Literal { start: index };
+                    } else {
+                        panic!("Unclosed parameter: `{}`", &path_pattern[start..index]);
+                    }
+                }
+                (Some('}'), State::Literal { start }) => {
+                    let next_char = char_iter.peek().map(|(_, ch)| *ch).unwrap_or_default();
+
+                    if next_char == Some('}') {
+                        // escaped `}`
+                        let literal = &path_pattern[start..index + 1];
+                        parts.push(PathPart::Literal(literal.to_string()));
+
+                        char_iter.next();
+                        state = State::Literal { start: index + 2 };
+                    } else {
+                        panic!("Closing brace encountered without opening brace");
+                    }
+                }
+                (Some('}'), State::Param { start }) => {
                     let param_name = &path_pattern[start..index];
                     assert!(
                         Self::is_param_name_valid(param_name),
@@ -35,17 +78,10 @@ impl PathMatcher {
                     parts.push(PathPart::Param {
                         name: param_name.to_string(),
                     });
-                    state = State::Literal { start: index };
+                    state = State::Literal { start: index + 1 };
                 }
-                (Some(':') | None, State::Literal { start }) => {
-                    let literal = &path_pattern[start..index];
-                    if !literal.is_empty() {
-                        parts.push(PathPart::Literal(literal.to_string()));
-                    }
-                    state = State::Param { start: index + 1 };
-                }
-                (Some(':'), State::Param { .. }) => {
-                    panic!("Consecutive parameters are not allowed");
+                (Some('/') | None, State::Param { start }) => {
+                    panic!("Unclosed parameter: `{}`", &path_pattern[start..index]);
                 }
                 _ => {}
             }
@@ -222,8 +258,11 @@ enum PathPart {
 impl Display for PathPart {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            PathPart::Literal(s) => write!(f, "{s}"),
-            PathPart::Param { name } => write!(f, ":{name}"),
+            PathPart::Literal(s) => {
+                let s = s.replace("{", "{{").replace("}", "}}");
+                write!(f, "{s}")
+            }
+            PathPart::Param { name } => write!(f, "{{{name}}}"),
         }
     }
 }
@@ -265,8 +304,17 @@ mod tests {
     }
 
     #[test]
+    fn path_parser_escaped() {
+        let path_parser = PathMatcher::new("/users/{{{{{{escaped}}}}}}");
+        assert_eq!(
+            path_parser.capture("/users/{{{escaped}}}"),
+            Some(CaptureResult::new(vec![], ""))
+        );
+    }
+
+    #[test]
     fn path_parser_single_param() {
-        let path_parser = PathMatcher::new("/users/:id");
+        let path_parser = PathMatcher::new("/users/{id}");
         assert_eq!(
             path_parser.capture("/users/123"),
             Some(CaptureResult::new(vec![PathParam::new("id", "123")], ""))
@@ -287,7 +335,7 @@ mod tests {
 
     #[test]
     fn path_parser_multiple_params() {
-        let path_parser = PathMatcher::new("/users/:id/posts/:post_id");
+        let path_parser = PathMatcher::new("/users/{id}/posts/{post_id}");
         assert_eq!(
             path_parser.capture("/users/123/posts/456"),
             Some(CaptureResult::new(
@@ -313,30 +361,60 @@ mod tests {
     #[test]
     #[should_panic(expected = "Consecutive parameters are not allowed")]
     fn path_parser_consecutive_params() {
-        let _ = PathMatcher::new("/users/:id:post_id");
+        let _ = PathMatcher::new("/users/{id}{post_id}");
     }
 
     #[test]
     #[should_panic(expected = "Invalid parameter name: ``")]
     fn path_parser_invalid_name_empty() {
-        let _ = PathMatcher::new("/users/:");
+        let _ = PathMatcher::new("/users/{}");
     }
 
     #[test]
     #[should_panic(expected = "Invalid parameter name: `123`")]
     fn path_parser_invalid_name_numeric() {
-        let _ = PathMatcher::new("/users/:123");
+        let _ = PathMatcher::new("/users/{123}");
     }
 
     #[test]
     #[should_panic(expected = "Invalid parameter name: `abc#$%`")]
     fn path_parser_invalid_name_non_alphanumeric() {
-        let _ = PathMatcher::new("/users/:abc#$%");
+        let _ = PathMatcher::new("/users/{abc#$%}");
+    }
+
+    #[test]
+    #[should_panic(expected = "Unclosed parameter: `foo`")]
+    fn path_parser_unclosed() {
+        let _ = PathMatcher::new("/users/{foo");
+    }
+
+    #[test]
+    #[should_panic(expected = "Closing brace encountered without opening brace")]
+    fn path_parser_missing_opening_brace() {
+        let _ = PathMatcher::new("/users/foo}");
+    }
+
+    #[test]
+    #[should_panic(expected = "Unclosed parameter: `foo`")]
+    fn path_parser_unclosed_slash() {
+        let _ = PathMatcher::new("/users/{foo/bar");
+    }
+
+    #[test]
+    #[should_panic(expected = "Unclosed parameter: `foo`")]
+    fn path_parser_unclosed_double() {
+        let _ = PathMatcher::new("/users/{foo{bar");
+    }
+
+    #[test]
+    fn path_parser_display() {
+        let path_parser = PathMatcher::new("/users/{id}/posts/{{escaped}}");
+        assert_eq!(format!("{}", path_parser), "/users/{id}/posts/{{escaped}}");
     }
 
     #[test]
     fn reverse_with_valid_params() {
-        let path_parser = PathMatcher::new("/users/:id/posts/:post_id");
+        let path_parser = PathMatcher::new("/users/{id}/posts/{post_id}");
         let mut params = ReverseParamMap::new();
         params.insert("id", "123");
         params.insert("post_id", "456");
@@ -348,7 +426,7 @@ mod tests {
 
     #[test]
     fn reverse_with_missing_param() {
-        let path_parser = PathMatcher::new("/users/:id/posts/:post_id");
+        let path_parser = PathMatcher::new("/users/{id}/posts/{post_id}");
         let mut params = ReverseParamMap::new();
         params.insert("id", "123");
         let result = path_parser.reverse(&params);
@@ -361,7 +439,7 @@ mod tests {
 
     #[test]
     fn reverse_with_extra_param() {
-        let path_parser = PathMatcher::new("/users/:id/posts/:post_id");
+        let path_parser = PathMatcher::new("/users/{id}/posts/{post_id}");
         let mut params = ReverseParamMap::new();
         params.insert("id", "123");
         params.insert("post_id", "456");

--- a/cot/src/router/path.rs
+++ b/cot/src/router/path.rs
@@ -69,7 +69,7 @@ impl PathMatcher {
                     }
                 }
                 (Some('}'), State::Param { start }) => {
-                    let param_name = &path_pattern[start..index];
+                    let param_name = &path_pattern[start..index].trim();
                     assert!(
                         Self::is_param_name_valid(param_name),
                         "Invalid parameter name: `{param_name}`"
@@ -331,6 +331,16 @@ mod tests {
             ))
         );
         assert_eq!(path_parser.capture("/users/"), None);
+    }
+
+    #[test]
+    fn path_parser_param_whitespace() {
+        let path_parser = PathMatcher::new("/users/{ id }");
+
+        assert_eq!(
+            path_parser.capture("/users/123"),
+            Some(CaptureResult::new(vec![PathParam::new("id", "123")], ""))
+        );
     }
 
     #[test]

--- a/cot/tests/router.rs
+++ b/cot/tests/router.rs
@@ -55,7 +55,7 @@ async fn project() -> CotProject {
         fn router(&self) -> Router {
             Router::with_urls([
                 Route::with_handler_and_name("/", index, "index"),
-                Route::with_handler_and_name("/get/:name", parameterized, "parameterized"),
+                Route::with_handler_and_name("/get/{name}", parameterized, "parameterized"),
             ])
         }
     }

--- a/examples/todo-list/src/main.rs
+++ b/examples/todo-list/src/main.rs
@@ -93,7 +93,7 @@ impl CotApp for TodoApp {
         Router::with_urls([
             Route::with_handler_and_name("/", index, "index"),
             Route::with_handler_and_name("/todos/add", add_todo, "add-todo"),
-            Route::with_handler_and_name("/todos/:todo_id/remove", remove_todo, "remove-todo"),
+            Route::with_handler_and_name("/todos/{todo_id}/remove", remove_todo, "remove-todo"),
         ])
     }
 }


### PR DESCRIPTION
This follows a similar change in axum 0.8 (although we have an in-house solution to parse URL params). This has numerous advantages:
* It is more similar to what Rust users expect, given it's the same format as used in `println!()`, `format!()`, etc.
* It is also the same format as used in OpenAPI specs
* The old format didn't support putting an actual colon in the URL; the new one supports escaping with double braces