### PR TITLE
ci: set codecov coverage threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.5%
 github_checks:
   annotations: false


### PR DESCRIPTION
Codecov marks all PRs that do not hit the coverage target as failing, which isn't very useful. This sets the threshold to 0.5% meaning that anything that doesn't drop the overall coverage by 0.5% or more will suceed.