### PR TITLE
feat: take values by reference in the reverse_param_map macro

### DIFF
--- a/cot/src/router/path.rs
+++ b/cot/src/router/path.rs
@@ -258,7 +258,7 @@ macro_rules! reverse_param_map {
     ($($key:ident = $value:expr),*) => {{
         #[allow(unused_mut)]
         let mut map = $crate::router::path::ReverseParamMap::new();
-        $( map.insert(stringify!($key), $value); )*
+        $( map.insert(stringify!($key), &$value); )*
         map
     }};
 }


### PR DESCRIPTION
This simple change makes the framework users' code a bit easier to write, especially when writing templates where you don't see compiler errors easily.