### PR TITLE
chore(ci): use cargo-llvm-cov for code coverage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -130,30 +130,24 @@ jobs:
           toolchain: nightly
           components: llvm-tools-preview
 
+      - name: Reclaim disk space
+        run: >
+          sudo rm -rf /opt/hostedtoolcache/CodeQL /usr/local/.ghcup /usr/local/lib/android /usr/local/lib/dotnet /usr/local/lib/swift #magic___^_^___line
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2
 
       - name: Run the external dependencies
         run: docker compose up -d
 
-      - name: Test
-        run: cargo test --all-features --no-fail-fast -- --include-ignored
-        env:
-          RUSTFLAGS: "-Cinstrument-coverage"
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Install grcov
-        uses: baptiste0928/cargo-install@v3
-        with:
-          crate: grcov
-          # Remove --locked until this issue is fixed: https://github.com/mozilla/grcov/issues/1187
-          locked: false
-
-      - name: Run grcov
-        run: grcov . --binary-path target/debug/deps/ -s . -t lcov --branch --ignore-not-existing --ignore '../**' --ignore '/*' --ignore 'examples/**' -o coverage.lcov
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --branch --doctests --codecov --output-path codecov.json
 
       - uses: codecov/codecov-action@v5
         with:
-          files: ./coverage.lcov
+          files: coverage.json
           flags: rust
           fail_ci_if_error: true
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -132,7 +132,13 @@ jobs:
 
       - name: Reclaim disk space
         run: >
-          sudo rm -rf /opt/hostedtoolcache/CodeQL /usr/local/.ghcup /usr/local/lib/android /usr/local/lib/dotnet /usr/local/lib/swift #magic___^_^___line
+          sudo rm -rf \
+              /opt/hostedtoolcache/CodeQL \
+              /usr/local/.ghcup \
+              /usr/local/lib/android \
+              /usr/local/lib/dotnet \
+              /usr/local/lib/swift
+
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
A nice bonus is code coverage for doctests, too.