### PR TITLE
chore: release v0.1.0

### DIFF
--- a/cot-cli/CHANGELOG.md
+++ b/cot-cli/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/cot-rs/cot/releases/tag/cot-cli-v0.1.0) - 2025-02-11
+
+### Other
+
+- *(ci)* set up release-plz (#129)

--- a/cot-codegen/CHANGELOG.md
+++ b/cot-codegen/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/cot-rs/cot/releases/tag/cot_codegen-v0.1.0) - 2025-02-11
+
+### Other
+
+- *(ci)* set up release-plz (#129)

--- a/cot-macros/CHANGELOG.md
+++ b/cot-macros/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/cot-rs/cot/releases/tag/cot_macros-v0.1.0) - 2025-02-11
+
+### Other
+
+- *(ci)* set up release-plz (#129)


### PR DESCRIPTION



## 🤖 New release

* `cot_macros`: 0.1.0
* `cot_codegen`: 0.1.0
* `cot-cli`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `cot_macros`

<blockquote>

## [0.1.0](https://github.com/cot-rs/cot/releases/tag/cot_macros-v0.1.0) - 2025-02-11

### Other

- *(ci)* set up release-plz (#129)
</blockquote>

## `cot_codegen`

<blockquote>

## [0.1.0](https://github.com/cot-rs/cot/releases/tag/cot_codegen-v0.1.0) - 2025-02-11

### Other

- *(ci)* set up release-plz (#129)
</blockquote>

## `cot-cli`

<blockquote>

## [0.1.0](https://github.com/cot-rs/cot/releases/tag/cot-cli-v0.1.0) - 2025-02-11

### Other

- *(ci)* set up release-plz (#129)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).