### PR TITLE
fix: the build after `fake` semver-incompatible change in v3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,14 +882,14 @@ dependencies = [
 
 [[package]]
 name = "fake"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef603df4ba9adbca6a332db7da6f614f21eafefbaf8e087844e452fdec152d0"
+checksum = "6a3baff880c5dbe551ac6366b1d571f648e74437cec6605ec00cf9fb9eb94144"
 dependencies = [
  "chrono",
  "deunicode",
  "dummy",
- "rand 0.8.5",
+ "rand 0.9.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ cot_macros = { version = "0.1.0", path = "cot-macros" }
 darling = "0.20"
 derive_builder = "0.20"
 derive_more = "2"
-fake = "3.1"
+fake = "3.2"
 form_urlencoded = "1"
 futures = { version = "0.3", default-features = false }
 futures-core = { version = "0.3", default-features = false }

--- a/cot/src/db.rs
+++ b/cot/src/db.rs
@@ -1623,7 +1623,7 @@ impl<const LIMIT: u32> fake::Dummy<usize> for LimitedString<LIMIT> {
         );
 
         let str: String = rng
-            .sample_iter(&fake::rand::distributions::Alphanumeric)
+            .sample_iter(&fake::rand::distr::Alphanumeric)
             .take(*len)
             .map(char::from)
             .collect();


### PR DESCRIPTION
See: cksac/fake-rs#223