### PR TITLE
refactor: rename `app_context` to just `context`

### DIFF
--- a/cot-cli/src/project_template/src/main.rs
+++ b/cot-cli/src/project_template/src/main.rs
@@ -60,8 +60,8 @@ impl Project for {{ project_struct_name }} {
         context: &ProjectContext<WithApps>,
     ) -> BoxedHandler {
         handler
-            .middleware(StaticFilesMiddleware::from_app_context(context))
-            .middleware(LiveReloadMiddleware::from_app_context(context))
+            .middleware(StaticFilesMiddleware::from_context(context))
+            .middleware(LiveReloadMiddleware::from_context(context))
             .build()
     }
 }

--- a/cot/src/handler.rs
+++ b/cot/src/handler.rs
@@ -69,7 +69,7 @@ where
 ///         context: &ProjectContext<WithApps>,
 ///     ) -> BoxedHandler {
 ///         handler
-///             .middleware(StaticFilesMiddleware::from_app_context(context))
+///             .middleware(StaticFilesMiddleware::from_context(context))
 ///             .build()
 ///     }
 /// }

--- a/cot/src/middleware.rs
+++ b/cot/src/middleware.rs
@@ -43,7 +43,7 @@ use crate::{Body, Error};
 ///     ) -> BoxedHandler {
 ///         handler
 ///             // IntoCotResponseLayer used internally in middleware()
-///             .middleware(LiveReloadMiddleware::from_app_context(context))
+///             .middleware(LiveReloadMiddleware::from_context(context))
 ///             .build()
 ///     }
 /// }
@@ -157,7 +157,7 @@ where
 ///     ) -> BoxedHandler {
 ///         handler
 ///             // IntoCotErrorLayer used internally in middleware()
-///             .middleware(LiveReloadMiddleware::from_app_context(context))
+///             .middleware(LiveReloadMiddleware::from_context(context))
 ///             .build()
 ///     }
 /// }
@@ -296,7 +296,7 @@ impl LiveReloadMiddleware {
     }
 
     #[must_use]
-    pub fn from_app_context(context: &crate::ProjectContext<crate::project::WithApps>) -> Self {
+    pub fn from_context(context: &crate::ProjectContext<crate::project::WithApps>) -> Self {
         Self::with_enabled(context.config().middlewares.live_reload.enabled)
     }
 

--- a/cot/src/project.rs
+++ b/cot/src/project.rs
@@ -359,7 +359,7 @@ pub trait Project {
     ///         context: &ProjectContext<WithApps>,
     ///     ) -> BoxedHandler {
     ///         handler
-    ///             .middleware(LiveReloadMiddleware::from_app_context(context))
+    ///             .middleware(LiveReloadMiddleware::from_context(context))
     ///             .build()
     ///     }
     /// }
@@ -483,7 +483,7 @@ pub trait Project {
 ///         context: &ProjectContext<WithApps>,
 ///     ) -> BoxedHandler {
 ///         handler
-///             .middleware(LiveReloadMiddleware::from_app_context(context))
+///             .middleware(LiveReloadMiddleware::from_context(context))
 ///             .build()
 ///     }
 /// }
@@ -518,7 +518,7 @@ where
     ///         context: &ProjectContext<WithApps>,
     ///     ) -> BoxedHandler {
     ///         handler
-    ///             .middleware(LiveReloadMiddleware::from_app_context(context))
+    ///             .middleware(LiveReloadMiddleware::from_context(context))
     ///             .build()
     ///     }
     /// }
@@ -559,7 +559,7 @@ where
     ///         context: &ProjectContext<WithApps>,
     ///     ) -> BoxedHandler {
     ///         handler
-    ///             .middleware(LiveReloadMiddleware::from_app_context(context))
+    ///             .middleware(LiveReloadMiddleware::from_context(context))
     ///             .build()
     ///     }
     /// }
@@ -854,29 +854,6 @@ impl<S: BootstrapPhase> Bootstrapper<S> {
         self.project.as_ref()
     }
 
-    /// Returns the app context for the bootstrapper.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use cot::project::{Bootstrapper, WithConfig};
-    /// use cot::{App, Project};
-    ///
-    /// struct MyProject;
-    /// impl Project for MyProject {}
-    ///
-    /// # #[tokio::main]
-    /// # async fn main() -> cot::Result<()> {
-    /// let bootstrapper = Bootstrapper::new(MyProject);
-    /// let context = bootstrapper.app_context();
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[must_use]
-    pub fn app_context(&self) -> &ProjectContext<S> {
-        &self.context
-    }
-
     /// Returns the context for the bootstrapper.
     ///
     /// # Examples
@@ -1087,11 +1064,11 @@ impl Bootstrapper<WithConfig> {
 
         let router = Arc::new(Router::with_urls(module_builder.urls));
 
-        let app_context = self.context.with_apps(module_builder.apps, router);
+        let context = self.context.with_apps(module_builder.apps, router);
 
         Bootstrapper {
             project: self.project,
-            context: app_context,
+            context,
             handler: self.handler,
         }
     }
@@ -1144,7 +1121,7 @@ impl Bootstrapper<WithApps> {
         let auth_backend = self.project.auth_backend(&self.context);
         #[cfg(feature = "db")]
         let database = Self::init_database(&self.context.config.database).await?;
-        let app_context = self.context.with_auth_and_db(
+        let context = self.context.with_auth_and_db(
             auth_backend,
             #[cfg(feature = "db")]
             database,
@@ -1152,7 +1129,7 @@ impl Bootstrapper<WithApps> {
 
         Ok(Bootstrapper {
             project: self.project,
-            context: app_context,
+            context,
             handler,
         })
     }
@@ -1974,10 +1951,10 @@ mod tests {
                 context: &ProjectContext<WithApps>,
             ) -> BoxedHandler {
                 handler
-                    .middleware(
-                        crate::static_files::StaticFilesMiddleware::from_app_context(context),
-                    )
-                    .middleware(crate::middleware::LiveReloadMiddleware::from_app_context(
+                    .middleware(crate::static_files::StaticFilesMiddleware::from_context(
+                        context,
+                    ))
+                    .middleware(crate::middleware::LiveReloadMiddleware::from_context(
                         context,
                     ))
                     .build()

--- a/cot/src/static_files.rs
+++ b/cot/src/static_files.rs
@@ -170,7 +170,7 @@ impl StaticFilesMiddleware {
     /// Creates a new `StaticFilesMiddleware` instance from the application
     /// context.
     #[must_use]
-    pub fn from_app_context(context: &ProjectContext<WithApps>) -> Self {
+    pub fn from_context(context: &ProjectContext<WithApps>) -> Self {
         Self {
             static_files: Arc::new(StaticFiles::from(context)),
         }
@@ -373,7 +373,7 @@ mod tests {
 
     #[cot::test]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `sqlite3_open_v2`
-    async fn static_files_middleware_from_app_context() {
+    async fn static_files_middleware_from_context() {
         struct App1;
         impl App for App1 {
             fn name(&self) -> &'static str {
@@ -407,7 +407,7 @@ mod tests {
         let bootstrapper = Bootstrapper::new(TestProject)
             .with_config(ProjectConfig::default())
             .with_apps();
-        let middleware = StaticFilesMiddleware::from_app_context(bootstrapper.context());
+        let middleware = StaticFilesMiddleware::from_context(bootstrapper.context());
         let static_files = middleware.static_files;
 
         let file = static_files.get_file("admin/admin.css").unwrap();

--- a/cot/src/test.rs
+++ b/cot/src/test.rs
@@ -558,7 +558,7 @@ impl TestRequestBuilder {
             None => Box::new(NoAuthBackend),
         };
 
-        let app_context = ProjectContext::initialized(
+        let context = ProjectContext::initialized(
             self.config.clone().unwrap_or_default(),
             Vec::new(),
             Arc::new(self.router.clone().unwrap_or_else(Router::empty)),
@@ -566,7 +566,7 @@ impl TestRequestBuilder {
             #[cfg(feature = "db")]
             self.database.clone(),
         );
-        prepare_request(&mut request, Arc::new(app_context));
+        prepare_request(&mut request, Arc::new(context));
 
         if let Some(session) = &self.session {
             request.extensions_mut().insert(session.clone());

--- a/examples/admin/src/main.rs
+++ b/examples/admin/src/main.rs
@@ -78,7 +78,7 @@ impl Project for AdminProject {
         context: &ProjectContext<WithApps>,
     ) -> BoxedHandler {
         handler
-            .middleware(StaticFilesMiddleware::from_app_context(context))
+            .middleware(StaticFilesMiddleware::from_context(context))
             .middleware(SessionMiddleware::new())
             .middleware(LiveReloadMiddleware::new())
             .build()

--- a/examples/todo-list/src/main.rs
+++ b/examples/todo-list/src/main.rs
@@ -121,7 +121,7 @@ impl Project for TodoProject {
         context: &ProjectContext<WithApps>,
     ) -> BoxedHandler {
         handler
-            .middleware(StaticFilesMiddleware::from_app_context(context))
+            .middleware(StaticFilesMiddleware::from_context(context))
             .middleware(SessionMiddleware::new())
             .build()
     }


### PR DESCRIPTION
It was inconsistent with the actual structure name and confusing, hence the last-minute change.