### PR TITLE
fix: use path dev-dependency for cot in cot-macros

### DIFF
--- a/cot-macros/Cargo.toml
+++ b/cot-macros/Cargo.toml
@@ -30,6 +30,6 @@ quote = { workspace = true, features = ["proc-macro"] }
 syn.workspace = true
 
 [dev-dependencies]
-cot.workspace = true
+cot = { path = "../cot" }
 trybuild.workspace = true
 rustversion.workspace = true


### PR DESCRIPTION
We won't be able to release without this.