### PR TITLE
feat(error): enhance error logging with tracing integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,7 @@ dependencies = [
  "tower-livereload",
  "tower-sessions",
  "tracing",
+ "tracing-test",
  "url",
 ]
 
@@ -2871,6 +2872,27 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/cot/Cargo.toml
+++ b/cot/Cargo.toml
@@ -58,6 +58,7 @@ tracing.workspace = true
 url = { workspace = true, features = ["serde"], optional = true }
 
 [dev-dependencies]
+tracing-test = "0.2.5"
 async-stream.workspace = true
 fake.workspace = true
 futures.workspace = true


### PR DESCRIPTION

This PR enhances error logging in Cot by implementing structured logging with the tracing crate. The goal is to improve observability and enable better integration with OpenTelemetry for monitoring errors in production services.

Changes:
- Implement structured error logging with tracing spans
- Add request context and metadata to error logs
- Include backtrace information in error spans
- Add comprehensive test coverage for logging functionality
- Maintain backwards compatibility with existing error pages


Added new tests that verify:
- Error logging with request context
- Error logging without request context
- Panic logging
- Not found logging
- Integration with error page handlers


related Issues
Implements better error monitoring as discussed in issue #160 


- [x] Tests added for new functionality (some might be redundant)
- [x] Code follows project style guidelines
- [x] All tests passing
- [x] No new  warnings