### PR TITLE
feat: add #[track_caller] to `unwrap`s for better panic messages

### DIFF
--- a/cot/src/db.rs
+++ b/cot/src/db.rs
@@ -526,6 +526,7 @@ impl DbFieldValue {
     /// assert_eq!(value_field.unwrap_value(), DbValue::Int(Some(42)));
     /// ```
     #[must_use]
+    #[track_caller]
     pub fn unwrap_value(self) -> DbValue {
         self.expect_value("called DbValue::unwrap_value() on a wrong DbValue variant")
     }
@@ -550,6 +551,7 @@ impl DbFieldValue {
     /// );
     /// ```
     #[must_use]
+    #[track_caller]
     pub fn expect_value(self, message: &str) -> DbValue {
         match self {
             Self::Value(value) => value,
@@ -1466,6 +1468,7 @@ impl<T> Auto<T> {
     /// assert_eq!(auto.unwrap(), 42);
     /// ```
     #[must_use]
+    #[track_caller]
     pub fn unwrap(self) -> T {
         self.expect("called `Auto::unwrap()` on a `Auto::Auto` value")
     }

--- a/cot/src/db/relations.rs
+++ b/cot/src/db/relations.rs
@@ -72,6 +72,7 @@ impl<T: Model> ForeignKey<T> {
     /// # Panics
     ///
     /// Panics if the model has not been stored in this [`ForeignKey`] instance.
+    #[track_caller]
     pub fn unwrap(self) -> T {
         match self {
             Self::Model(model) => *model,

--- a/cot/src/form.rs
+++ b/cot/src/form.rs
@@ -94,6 +94,7 @@ impl<T: Form> FormResult<T> {
     /// # Panics
     ///
     /// Panics if the form validation failed.
+    #[track_caller]
     pub fn unwrap(self) -> T {
         match self {
             Self::Ok(form) => form,


### PR DESCRIPTION
This attribute causes the panic message to point to the location of the caller, rather than to the location where the panic is. This makes more useful panic messages, as they will point to users' codes rather than the internal Cot code.