### PR TITLE
fix: use cot's version instead of cli's when creating a new project

### DIFF
--- a/cot-cli/src/new_project.rs
+++ b/cot-cli/src/new_project.rs
@@ -45,7 +45,7 @@ impl CotSource<'_> {
                     path.display().to_string().replace('\\', "\\\\")
                 )
             }
-            CotSource::PublishedCrate => format!("version = \"{}\"", env!("CARGO_PKG_VERSION")),
+            CotSource::PublishedCrate => format!("version = \"{}\"", cot::__private::COT_VERSION),
         }
     }
 }

--- a/cot/src/private.rs
+++ b/cot/src/private.rs
@@ -17,3 +17,9 @@ pub use tokio;
 // used in the CLI
 #[cfg(feature = "db")]
 pub use crate::utils::graph::apply_permutation;
+
+/// The version of the crate.
+///
+/// This is used in the CLI to specify the version of the crate to use in the
+/// `Cargo.toml` file when creating a new Cot project.
+pub const COT_VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
cot and cot-cli crates' version do not necessarily have to be in sync (strictly speaking, cot-cli's version can be higher than cot's) so we need to make sure we put the latest cot crate version in user's Cargo.toml. Otherwise, build failures might happen because of invalid dependencies.