### PR TITLE
fix: unit test after 25785c27

### DIFF
--- a/cot-cli/src/new_project.rs
+++ b/cot-cli/src/new_project.rs
@@ -148,7 +148,7 @@ mod tests {
         let source = CotSource::PublishedCrate;
         assert_eq!(
             source.as_cargo_toml_source(),
-            format!("version = \"{}\"", env!("CARGO_PKG_VERSION"))
+            format!("version = \"{}\"", cot::__private::COT_VERSION)
         );
     }
 }


### PR DESCRIPTION
PR #213 has properly decoupled cot's and cot-cli's versions but haven't updated the unit test that tests the Cargo.toml generated by `cot new` (which now fails in #215).