### PR TITLE
chore: deny all rustc/clippy warnings in the CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,7 +81,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run clippy
-        run: cargo clippy --no-deps --
+        run: cargo clippy --no-deps -- -D warnings
 
   external-deps:
     if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.head.repo.full_name != github.repository


### PR DESCRIPTION
This will prevent merging the code if it raises any compiler or clippy warnings, but still won't break the code immediately when a new lint is introduced, or won't prevent you from prototyping easily.