### PR TITLE
chore: add sponsor badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [![Documentation](https://docs.rs/cot/badge.svg)](https://docs.rs/cot)
 [![codecov](https://codecov.io/gh/cot-rs/cot/branch/master/graph/badge.svg)](https://codecov.io/gh/cot-rs/cot)
 [![Discord chat](https://img.shields.io/discord/1330137289287925781?logo=Discord&logoColor=white)](https://discord.cot.rs)
+[![GitHub Sponsors](https://img.shields.io/github/sponsors/cot-rs?label=GitHub%20sponsors)](https://github.com/sponsors/cot-rs)
+[![Open Collective backers](https://img.shields.io/opencollective/backers/cot?label=Open%20Collective%20backers)](https://opencollective.com/cot)
 </div>
 
 > [!WARNING]


### PR DESCRIPTION
Apart from the badges, I'm thinking of automatic listing of sponsors in README, I found two pre-made actions for that:
- https://github.com/antfu-collective/sponsorkit?tab=readme-ov-file#tiers-renderer
- https://github.com/marketplace/actions/add-github-sponsors-to-readme

What do you think of those @m4tx?