### PR TITLE
ci: remove clippy-action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,12 +79,7 @@ jobs:
           save-if: false
 
       - name: Run clippy
-        uses: giraffate/clippy-action@v1
-        with:
-          reporter: github-pr-check
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          clippy_flags: '--no-deps --all-targets -- -D warnings'
-          fail_on_error: true
+        run: cargo clippy --no-deps --all-targets -- -D warnings
 
   external-deps:
     if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.head.repo.full_name != github.repository


### PR DESCRIPTION
Clippy doesn't actually seem to be properly run, so reverting to just running `cargo clippy` directly.