### PR TITLE
chore: modify how changelog is generated

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,6 @@
 [workspace]
 git_release_enable = false
-
+changelog_update = false
 git_release_body = """
 {{ changelog }}
 {% if remote.contributors %}
@@ -11,14 +11,31 @@ git_release_body = """
 {% endif %}
 """
 
-[[package]]
-name = "cot"  # name of the package to configure
-# include commits from internal crates in the changelog
-changelog_include = ["cot-codegen", "cot-macros"]
-# set the path of the changelog to the root of the repository
-changelog_path = "./CHANGELOG.md"
-git_release_enable = true  # create GitHub release
+[changelog]
+protect_breaking_commits = true
+commit_parsers = [
+    { message = "^.*\\(security\\)", group = "<!-- 0 -->Security", scope = "" },
+    { message = "^feat", group = "<!-- 1 -->New features" },
+    { message = "^fix", group = "<!-- 2 -->Fixes" },
+    { message = "^.*", group = "<!-- 3 -->Other" },
+]
+commit_preprocessors = [
+    # Replace multiple spaces with a single space.
+    { pattern = "  +", replace = " " },
+    # Replace the issue/PR number with the link. It will work for PRs as well as GitHub has a redirect.
+    { pattern = "\\(#([0-9]+)\\)", replace = "([#${1}](https://github.com/cot-rs/cot/pull/${1}))" },
+    # Hyperlink bare commit hashes like "abcd1234" in commit logs, with short commit hash as description.
+    { pattern = "([ \\n])(([a-f0-9]{7})[a-f0-9]*)", replace = "${1}commit [${3}](https://github.com/cot-rs/cot/commit/${2})" }
+]
 
 [[package]]
-name = "cot-cli"  # name of the package to configure
-git_release_enable = true  # create GitHub release
+name = "cot"
+changelog_update = true
+changelog_include = ["cot-codegen", "cot-macros"]
+changelog_path = "./CHANGELOG.md"
+git_release_enable = true
+
+[[package]]
+name = "cot-cli"
+changelog_update = true
+git_release_enable = true


### PR DESCRIPTION
Changes to the config:

- do not generate changelog for `cot-codegen` and `cot-macros`
- extract security changes to separate category
- preprocess commit messages to include links, so that the changelog is useful outside of GitHub
- removed pointless comments
- always output breaking commits

With those changes, the changelog for this version for `cot` will look like this:

## [0.2.0](https://github.com/cot-rs/cot/compare/cot-v0.1.4...cot-v0.2.0) - 2025-03-18

### <!-- 0 -->Security

- cycle session ID on login, flush session on logout ([#246](https://github.com/cot-rs/cot/pull/246))

### <!-- 1 -->New features

- add a user-friendly message for AddrInUse error ([#233](https://github.com/cot-rs/cot/pull/233))
- add support for remove field in automatic migration generator ([#232](https://github.com/cot-rs/cot/pull/232))
- add basic pagination support for admin panel ([#217](https://github.com/cot-rs/cot/pull/217))
- support "Remove Model" in Automatic Migration Generator ([#221](https://github.com/cot-rs/cot/pull/221))

### <!-- 2 -->Fixes

- panic backtrace/location not displayed on the error page ([#237](https://github.com/cot-rs/cot/pull/237))
- include APP_NAME in model ([#228](https://github.com/cot-rs/cot/pull/228))

### <!-- 3 -->Other

- [**breaking**] upgrade edition to 2024 ([#244](https://github.com/cot-rs/cot/pull/244))
- *(clippy)* add --all-targets to clippy CI and fix all warnings ([#240](https://github.com/cot-rs/cot/pull/240))
- add test for reverse!() reversing in the current app first ([#239](https://github.com/cot-rs/cot/pull/239))
- more docs (up to 100% doc coverage) ([#229](https://github.com/cot-rs/cot/pull/229))