### PR TITLE
feat!: use extractor pattern for request handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,9 @@ dependencies = [
  "sea-query",
  "sea-query-binder",
  "serde",
+ "serde_html_form",
  "serde_json",
+ "serde_path_to_error",
  "sha2",
  "sqlx",
  "subtle",
@@ -2151,6 +2153,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_html_form"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d2de91cf02bbc07cde38891769ccd5d4f073d22a40683aa4bc7a95781aaa2c4"
+dependencies = [
+ "form_urlencoded",
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2159,6 +2174,16 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,9 @@ rustversion = "1"
 sea-query = { version = "0.32", default-features = false }
 sea-query-binder = { version = "0.7", default-features = false }
 serde = "1"
+serde_html_form = "0.2"
 serde_json = "1"
+serde_path_to_error = "0.1.17"
 sha2 = "0.10"
 sqlx = { version = "0.8", default-features = false }
 subtle = { version = "2", default-features = false }

--- a/cot-cli/src/project_template/config/dev.toml
+++ b/cot-cli/src/project_template/config/dev.toml
@@ -3,6 +3,9 @@ secret_key = "{{ dev_secret_key }}"
 [database]
 url = "sqlite://db.sqlite3?mode=rwc"
 
+[auth_backend]
+type = "database"
+
 [middlewares]
 live_reload.enabled = true
 

--- a/cot-cli/src/project_template/config/prod.toml.example
+++ b/cot-cli/src/project_template/config/prod.toml.example
@@ -5,3 +5,6 @@ url = "sqlite://db.sqlite3?mode=rwc"
 # Or:
 # url = "postgres://user:password@localhost:5432/database"
 # url = "mysql://user:password@localhost:3306/database"
+
+[auth_backend]
+type = "database"

--- a/cot-macros/src/lib.rs
+++ b/cot-macros/src/lib.rs
@@ -138,8 +138,8 @@ pub fn dbtest(_args: TokenStream, input: TokenStream) -> TokenStream {
 /// # Examples
 ///
 /// ```no_run
-/// use cot::project::WithConfig;
-/// use cot::{App, AppBuilder, Project, ProjectContext};
+/// use cot::project::RegisterAppsContext;
+/// use cot::{App, AppBuilder, Project};
 ///
 /// struct HelloApp;
 ///
@@ -151,7 +151,7 @@ pub fn dbtest(_args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// struct HelloProject;
 /// impl Project for HelloProject {
-///     fn register_apps(&self, apps: &mut AppBuilder, _context: &ProjectContext<WithConfig>) {
+///     fn register_apps(&self, apps: &mut AppBuilder, _context: &RegisterAppsContext) {
 ///         apps.register_with_views(HelloApp, "");
 ///     }
 /// }

--- a/cot/Cargo.toml
+++ b/cot/Cargo.toml
@@ -42,7 +42,9 @@ rinja.workspace = true
 sea-query = { workspace = true }
 sea-query-binder = { workspace = true, features = ["with-chrono", "runtime-tokio"] }
 serde = { workspace = true, features = ["derive"] }
+serde_html_form = { workspace = true }
 serde_json = { workspace = true, optional = true }
+serde_path_to_error = { workspace = true }
 sha2.workspace = true
 sqlx = { workspace = true, features = ["runtime-tokio", "chrono"] }
 subtle = { workspace = true, features = ["std"] }

--- a/cot/src/admin.rs
+++ b/cot/src/admin.rs
@@ -4,12 +4,10 @@
 //! registered in the application, straight from the web interface.
 
 use std::any::Any;
-use std::collections::HashMap;
 use std::marker::PhantomData;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use cot::Error;
 /// Implements the [`AdminModel`] trait for a struct.
 ///
 /// This is a simple method for adding a database model to the admin panel.
@@ -19,30 +17,33 @@ use cot::Error;
 /// `#[derive(Form)]` attributes.
 pub use cot_macros::AdminModel;
 use derive_more::Debug;
+use http::request::Parts;
 use rinja::Template;
+use serde::Deserialize;
 
-use crate::auth::{AuthRequestExt, Password};
+use crate::auth::{Auth, Password};
 use crate::form::{
     Form, FormContext, FormErrorTarget, FormField, FormFieldValidationError, FormResult,
 };
-use crate::request::{Request, RequestExt, query_pairs};
+use crate::request::extractors::{FromRequestParts, Path, UrlQuery};
+use crate::request::{Request, RequestExt};
 use crate::response::{Response, ResponseExt};
-use crate::router::Router;
-use crate::{App, Body, Method, RequestHandler, StatusCode, reverse_redirect, static_files};
+use crate::router::{Router, Urls};
+use crate::{App, Body, Error, Method, RequestHandler, StatusCode, reverse_redirect, static_files};
 
-struct AdminAuthenticated<T: Send + Sync>(T);
+struct AdminAuthenticated<T, H: Send + Sync>(H, PhantomData<fn() -> T>);
 
-impl<T: RequestHandler + Send + Sync> AdminAuthenticated<T> {
+impl<T, H: RequestHandler<T> + Send + Sync> AdminAuthenticated<T, H> {
     #[must_use]
-    fn new(handler: T) -> Self {
-        Self(handler)
+    fn new(handler: H) -> Self {
+        Self(handler, PhantomData)
     }
 }
 
-#[async_trait]
-impl<T: RequestHandler + Send + Sync> RequestHandler for AdminAuthenticated<T> {
+impl<T, H: RequestHandler<T> + Send + Sync> RequestHandler<T> for AdminAuthenticated<T, H> {
     async fn handle(&self, mut request: Request) -> crate::Result<Response> {
-        if !request.user().await?.is_authenticated() {
+        let auth: Auth = request.extract_parts().await?;
+        if !auth.user().is_authenticated() {
             return Ok(reverse_redirect!(request, "login")?);
         }
 
@@ -50,18 +51,21 @@ impl<T: RequestHandler + Send + Sync> RequestHandler for AdminAuthenticated<T> {
     }
 }
 
-async fn index(request: Request) -> crate::Result<Response> {
+async fn index(
+    urls: Urls,
+    AdminModelManagers(managers): AdminModelManagers,
+) -> crate::Result<Response> {
     #[derive(Debug, Template)]
     #[template(path = "admin/model_list.html")]
     struct ModelListTemplate<'a> {
-        request: &'a Request,
+        urls: &'a Urls,
         #[debug("..")]
         model_managers: Vec<Box<dyn AdminModelManager>>,
     }
 
     let template = ModelListTemplate {
-        request: &request,
-        model_managers: admin_model_managers(&request),
+        urls: &urls,
+        model_managers: managers,
     };
     Ok(Response::new_html(
         StatusCode::OK,
@@ -75,11 +79,11 @@ struct LoginForm {
     password: Password,
 }
 
-async fn login(mut request: Request) -> cot::Result<Response> {
+async fn login(urls: Urls, auth: Auth, mut request: Request) -> crate::Result<Response> {
     #[derive(Debug, Template)]
     #[template(path = "admin/login.html")]
     struct LoginTemplate<'a> {
-        request: &'a Request,
+        urls: &'a Urls,
         form: <LoginForm as Form>::Context,
     }
 
@@ -89,8 +93,8 @@ async fn login(mut request: Request) -> cot::Result<Response> {
         let login_form = LoginForm::from_request(&mut request).await?;
         match login_form {
             FormResult::Ok(login_form) => {
-                if authenticate(&mut request, login_form).await? {
-                    return Ok(reverse_redirect!(request, "index")?);
+                if authenticate(&auth, login_form).await? {
+                    return Ok(reverse_redirect!(urls, "index")?);
                 }
 
                 let mut context = LoginForm::build_context(&mut request).await?;
@@ -107,7 +111,7 @@ async fn login(mut request: Request) -> cot::Result<Response> {
     };
 
     let template = LoginTemplate {
-        request: &request,
+        urls: &urls,
         form: login_form_context,
     };
     Ok(Response::new_html(
@@ -116,9 +120,9 @@ async fn login(mut request: Request) -> cot::Result<Response> {
     ))
 }
 
-async fn authenticate(request: &mut Request, login_form: LoginForm) -> cot::Result<bool> {
+async fn authenticate(auth: &Auth, login_form: LoginForm) -> cot::Result<bool> {
     #[cfg(feature = "db")]
-    let user = request
+    let user = auth
         .authenticate(&crate::auth::db::DatabaseUserCredentials::new(
             login_form.username,
             Password::new(login_form.password.into_string()),
@@ -129,7 +133,7 @@ async fn authenticate(request: &mut Request, login_form: LoginForm) -> cot::Resu
     let user: Option<Box<dyn crate::auth::User + Send + Sync>> = None;
 
     if let Some(user) = user {
-        request.login(user).await?;
+        auth.login(user).await?;
         Ok(true)
     } else {
         Ok(false)
@@ -166,11 +170,23 @@ impl Pagination {
     }
 }
 
-async fn view_model(request: Request) -> cot::Result<Response> {
+#[derive(Debug, Deserialize)]
+struct PaginationParams {
+    page: Option<u64>,
+    page_size: Option<u64>,
+}
+
+async fn view_model(
+    urls: Urls,
+    managers: AdminModelManagers,
+    Path(model_name): Path<String>,
+    UrlQuery(pagination_params): UrlQuery<PaginationParams>,
+    request: Request,
+) -> cot::Result<Response> {
     #[derive(Debug, Template)]
     #[template(path = "admin/model.html")]
     struct ModelTemplate<'a> {
-        request: &'a Request,
+        urls: &'a Urls,
         #[debug("..")]
         model: &'a dyn AdminModelManager,
         #[debug("..")]
@@ -181,44 +197,28 @@ async fn view_model(request: Request) -> cot::Result<Response> {
         total_pages: u64,
     }
 
-    let model_name: String = request.path_params().parse()?;
-    let manager = get_manager(&request, &model_name)?;
+    let manager = get_manager(managers, &model_name)?;
 
-    let query_params: HashMap<String, String> = request
-        .uri()
-        .query()
-        .map(|q| {
-            query_pairs(&Bytes::copy_from_slice(q.as_bytes()))
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-                .collect()
-        })
-        .unwrap_or_default();
-
-    let page: u64 = query_params
-        .get("page")
-        .map_or(1, |p| p.parse().unwrap_or(1));
-
-    let limit = query_params
-        .get("page_size")
-        .map_or(10, |p| p.parse().unwrap_or(10));
+    let page = pagination_params.page.unwrap_or(1);
+    let page_size = pagination_params.page_size.unwrap_or(10);
 
     let total_object_counts = manager.get_total_object_counts(&request).await?;
-    let total_pages = total_object_counts.div_ceil(limit);
+    let total_pages = total_object_counts.div_ceil(page_size);
 
     if page == 0 || page > total_pages {
         return Err(Error::not_found_message(format!("page {page} not found")));
     }
 
-    let pagination = Pagination::new(limit, page);
+    let pagination = Pagination::new(page_size, page);
 
     let objects = manager.get_objects(&request, pagination).await?;
 
     let template = ModelTemplate {
-        request: &request,
+        urls: &urls,
         model: &*manager,
         objects,
         page,
-        page_size: &limit,
+        page_size: &page_size,
         total_object_counts,
         total_pages,
     };
@@ -229,19 +229,27 @@ async fn view_model(request: Request) -> cot::Result<Response> {
     ))
 }
 
-async fn create_model_instance(request: Request) -> cot::Result<Response> {
-    let model_name: String = request.path_params().parse()?;
-
-    edit_model_instance_impl(request, &model_name, None).await
+async fn create_model_instance(
+    urls: Urls,
+    managers: AdminModelManagers,
+    Path(model_name): Path<String>,
+    request: Request,
+) -> cot::Result<Response> {
+    edit_model_instance_impl(urls, managers, request, &model_name, None).await
 }
 
-async fn edit_model_instance(request: Request) -> cot::Result<Response> {
-    let (model_name, object_id): (String, String) = request.path_params().parse()?;
-
-    edit_model_instance_impl(request, &model_name, Some(&object_id)).await
+async fn edit_model_instance(
+    urls: Urls,
+    managers: AdminModelManagers,
+    Path((model_name, object_id)): Path<(String, String)>,
+    request: Request,
+) -> cot::Result<Response> {
+    edit_model_instance_impl(urls, managers, request, &model_name, Some(&object_id)).await
 }
 
 async fn edit_model_instance_impl(
+    urls: Urls,
+    managers: AdminModelManagers,
     mut request: Request,
     model_name: &str,
     object_id: Option<&str>,
@@ -249,14 +257,14 @@ async fn edit_model_instance_impl(
     #[derive(Debug, Template)]
     #[template(path = "admin/model_edit.html")]
     struct ModelEditTemplate<'a> {
-        request: &'a Request,
+        urls: &'a Urls,
         #[debug("..")]
         model: &'a dyn AdminModelManager,
         form_context: Box<dyn FormContext>,
         is_edit: bool,
     }
 
-    let manager = get_manager(&request, model_name)?;
+    let manager = get_manager(managers, model_name)?;
 
     let form_context = if request.method() == Method::POST {
         let form_context = manager.save_from_request(&mut request, object_id).await?;
@@ -265,7 +273,7 @@ async fn edit_model_instance_impl(
             form_context
         } else {
             return Ok(reverse_redirect!(
-                request,
+                urls,
                 "view_model",
                 model_name = manager.url_name()
             )?);
@@ -279,7 +287,7 @@ async fn edit_model_instance_impl(
     };
 
     let template = ModelEditTemplate {
-        request: &request,
+        urls: &urls,
         model: &*manager,
         form_context,
         is_edit: object_id.is_some(),
@@ -291,33 +299,36 @@ async fn edit_model_instance_impl(
     ))
 }
 
-async fn remove_model_instance(mut request: Request) -> cot::Result<Response> {
+async fn remove_model_instance(
+    urls: Urls,
+    managers: AdminModelManagers,
+    Path((model_name, object_id)): Path<(String, String)>,
+    mut request: Request,
+) -> cot::Result<Response> {
     #[derive(Debug, Template)]
     #[template(path = "admin/model_remove.html")]
     struct ModelRemoveTemplate<'a> {
-        request: &'a Request,
+        urls: &'a Urls,
         #[debug("..")]
         model: &'a dyn AdminModelManager,
         #[debug("..")]
         object: &'a dyn AdminModel,
     }
 
-    let (model_name, object_id): (String, String) = request.path_params().parse()?;
-
-    let manager = get_manager(&request, &model_name)?;
+    let manager = get_manager(managers, &model_name)?;
     let object = get_object(&mut request, &*manager, &object_id).await?;
 
     if request.method() == Method::POST {
         manager.remove_by_id(&mut request, &object_id).await?;
 
         Ok(reverse_redirect!(
-            request,
+            urls,
             "view_model",
             model_name = manager.url_name()
         )?)
     } else {
         let template = ModelRemoveTemplate {
-            request: &request,
+            urls: &urls,
             model: &*manager,
             object: &*object,
         };
@@ -346,23 +357,29 @@ async fn get_object(
         })
 }
 
-fn get_manager(request: &Request, model_name: &str) -> cot::Result<Box<dyn AdminModelManager>> {
-    let model_managers = admin_model_managers(request);
-
+fn get_manager(
+    AdminModelManagers(model_managers): AdminModelManagers,
+    model_name: &str,
+) -> cot::Result<Box<dyn AdminModelManager>> {
     model_managers
         .into_iter()
         .find(|manager| manager.url_name() == model_name)
         .ok_or_else(|| Error::not_found_message(format!("Model `{model_name}` not found")))
 }
 
-#[must_use]
-fn admin_model_managers(request: &Request) -> Vec<Box<dyn AdminModelManager>> {
-    request
-        .context()
-        .apps()
-        .iter()
-        .flat_map(|app| app.admin_model_managers())
-        .collect()
+#[repr(transparent)]
+struct AdminModelManagers(Vec<Box<dyn AdminModelManager>>);
+
+impl FromRequestParts for AdminModelManagers {
+    async fn from_request_parts(parts: &mut Parts) -> cot::Result<Self> {
+        let managers = parts
+            .context()
+            .apps()
+            .iter()
+            .flat_map(|app| app.admin_model_managers())
+            .collect();
+        Ok(Self(managers))
+    }
 }
 
 /// A trait for adding admin models to the app.

--- a/cot/src/admin.rs
+++ b/cot/src/admin.rs
@@ -197,10 +197,12 @@ async fn view_model(
         total_pages: u64,
     }
 
+    const DEFAULT_PAGE_SIZE: u64 = 10;
+
     let manager = get_manager(managers, &model_name)?;
 
     let page = pagination_params.page.unwrap_or(1);
-    let page_size = pagination_params.page_size.unwrap_or(10);
+    let page_size = pagination_params.page_size.unwrap_or(DEFAULT_PAGE_SIZE);
 
     let total_object_counts = manager.get_total_object_counts(&request).await?;
     let total_pages = total_object_counts.div_ceil(page_size);

--- a/cot/src/admin.rs
+++ b/cot/src/admin.rs
@@ -643,12 +643,12 @@ impl AdminApp {
     ///
     /// ```
     /// use cot::admin::AdminApp;
-    /// use cot::project::WithConfig;
-    /// use cot::{AppBuilder, Project, ProjectContext};
+    /// use cot::project::RegisterAppsContext;
+    /// use cot::{AppBuilder, Project};
     ///
     /// struct MyProject;
     /// impl Project for MyProject {
-    ///     fn register_apps(&self, apps: &mut AppBuilder, _context: &ProjectContext<WithConfig>) {
+    ///     fn register_apps(&self, apps: &mut AppBuilder, _context: &RegisterAppsContext) {
     ///         apps.register_with_views(AdminApp::new(), "/admin");
     ///     }
     /// }

--- a/cot/src/auth/db.rs
+++ b/cot/src/auth/db.rs
@@ -571,8 +571,8 @@ impl DatabaseUserApp {
     /// ```no_run
     /// use cot::auth::db::DatabaseUserApp;
     /// use cot::config::{DatabaseConfig, ProjectConfig};
-    /// use cot::project::WithConfig;
-    /// use cot::{App, AppBuilder, Project, ProjectContext};
+    /// use cot::project::RegisterAppsContext;
+    /// use cot::{App, AppBuilder, Project};
     ///
     /// struct HelloProject;
     /// impl Project for HelloProject {
@@ -582,8 +582,8 @@ impl DatabaseUserApp {
     ///             .build())
     ///     }
     ///
-    ///     fn register_apps(&self, apps: &mut AppBuilder, _context: &ProjectContext<WithConfig>) {
-    ///         use cot::project::WithConfig;
+    ///     fn register_apps(&self, apps: &mut AppBuilder, _context: &RegisterAppsContext) {
+    ///         use cot::project::{RegisterAppsContext, WithConfig};
     ///         apps.register_with_views(DatabaseUserApp::new(), "");
     ///     }
     /// }

--- a/cot/src/auth/db.rs
+++ b/cot/src/auth/db.rs
@@ -6,6 +6,7 @@
 use std::any::Any;
 use std::borrow::Cow;
 use std::fmt::{Display, Formatter};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 // Importing `Auto` from `cot` instead of `crate` so that the migration generator
@@ -24,9 +25,8 @@ use crate::auth::{
 };
 use crate::config::SecretKey;
 use crate::db::migrations::SyncDynMigration;
-use crate::db::{DatabaseBackend, LimitedString, Model, model, query};
+use crate::db::{Database, DatabaseBackend, LimitedString, Model, model, query};
 use crate::form::Form;
-use crate::request::{Request, RequestExt};
 
 pub mod migrations;
 
@@ -102,6 +102,7 @@ impl DatabaseUser {
     /// #     test_database.with_auth().run_migrations().await;
     /// #     let request = TestRequestBuilder::get("/")
     /// #         .with_db_auth(test_database.database())
+    /// #         .await
     /// #         .build();
     /// #     view(&request).await?;
     /// #     test_database.cleanup().await?;
@@ -168,6 +169,7 @@ impl DatabaseUser {
     /// #     test_database.with_auth().run_migrations().await;
     /// #     let request = TestRequestBuilder::get("/")
     /// #         .with_db_auth(test_database.database())
+    /// #         .await
     /// #         .build();
     /// #     view(&request).await?;
     /// #     test_database.cleanup().await?;
@@ -222,6 +224,7 @@ impl DatabaseUser {
     /// #     test_database.with_auth().run_migrations().await;
     /// #     let request = TestRequestBuilder::get("/")
     /// #         .with_db_auth(test_database.database())
+    /// #         .await
     /// #         .build();
     /// #     view(&request).await?;
     /// #     test_database.cleanup().await?;
@@ -321,6 +324,7 @@ impl DatabaseUser {
     /// #     test_database.with_auth().run_migrations().await;
     /// #     let request = TestRequestBuilder::get("/")
     /// #         .with_db_auth(test_database.database())
+    /// #         .await
     /// #         .build();
     /// #     view(&request).await?;
     /// #     test_database.cleanup().await?;
@@ -367,6 +371,7 @@ impl DatabaseUser {
     /// #     test_database.with_auth().run_migrations().await;
     /// #     let request = TestRequestBuilder::get("/")
     /// #         .with_db_auth(test_database.database())
+    /// #         .await
     /// #         .build();
     /// #     view(&request).await?;
     /// #     test_database.cleanup().await?;
@@ -487,13 +492,9 @@ impl DatabaseUserCredentials {
 ///
 /// This backend supports authenticating users using the
 /// [`DatabaseUserCredentials`] struct and ignores all other credential types.
-#[derive(Debug, Copy, Clone)]
-pub struct DatabaseUserBackend;
-
-impl Default for DatabaseUserBackend {
-    fn default() -> Self {
-        Self::new()
-    }
+#[derive(Debug, Clone)]
+pub struct DatabaseUserBackend {
+    database: Arc<Database>,
 }
 
 impl DatabaseUserBackend {
@@ -502,23 +503,25 @@ impl DatabaseUserBackend {
     /// # Example
     ///
     /// ```
+    /// use std::sync::Arc;
+    ///
     /// use cot::auth::AuthBackend;
     /// use cot::auth::db::DatabaseUserBackend;
     /// use cot::config::ProjectConfig;
-    /// use cot::project::WithApps;
+    /// use cot::project::{AuthBackendContext, WithApps};
     /// use cot::{Project, ProjectContext};
     ///
     /// struct HelloProject;
     /// impl Project for HelloProject {
-    ///     fn auth_backend(&self, context: &ProjectContext<WithApps>) -> Box<dyn AuthBackend> {
-    ///         Box::new(DatabaseUserBackend::new())
+    ///     fn auth_backend(&self, context: &AuthBackendContext) -> Arc<dyn AuthBackend> {
+    ///         Arc::new(DatabaseUserBackend::new(context.database().clone()))
     ///         // note that it's usually better to just set the auth backend in the config
     ///     }
     /// }
     /// ```
     #[must_use]
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(database: Arc<Database>) -> Self {
+        Self { database }
     }
 }
 
@@ -526,12 +529,11 @@ impl DatabaseUserBackend {
 impl AuthBackend for DatabaseUserBackend {
     async fn authenticate(
         &self,
-        request: &Request,
         credentials: &(dyn Any + Send + Sync),
     ) -> Result<Option<Box<dyn User + Send + Sync>>> {
         if let Some(credentials) = credentials.downcast_ref::<DatabaseUserCredentials>() {
             #[allow(trivial_casts)] // Upcast to the correct Box type
-            Ok(DatabaseUser::authenticate(request.db(), credentials)
+            Ok(DatabaseUser::authenticate(&self.database, credentials)
                 .await
                 .map(|user| user.map(|user| Box::new(user) as Box<dyn User + Send + Sync>))?)
         } else {
@@ -539,17 +541,13 @@ impl AuthBackend for DatabaseUserBackend {
         }
     }
 
-    async fn get_by_id(
-        &self,
-        request: &Request,
-        id: UserId,
-    ) -> Result<Option<Box<dyn User + Send + Sync>>> {
+    async fn get_by_id(&self, id: UserId) -> Result<Option<Box<dyn User + Send + Sync>>> {
         let UserId::Int(id) = id else {
             return Err(AuthError::UserIdTypeNotSupported);
         };
 
         #[allow(trivial_casts)] // Upcast to the correct Box type
-        Ok(DatabaseUser::get_by_id(request.db(), id)
+        Ok(DatabaseUser::get_by_id(&self.database, id)
             .await?
             .map(|user| Box::new(user) as Box<dyn User + Send + Sync>))
     }

--- a/cot/src/cli.rs
+++ b/cot/src/cli.rs
@@ -357,7 +357,7 @@ impl CliTask for CollectStatic {
             .expect("required argument");
         println!("Collecting static files into {:?}", dir);
 
-        let bootstrapper = bootstrapper.with_apps();
+        let bootstrapper = bootstrapper.with_apps().with_database().await?;
         StaticFiles::from(bootstrapper.context())
             .collect_into(dir)
             .map_err(|e| Error::new(ErrorRepr::CollectStatic { source: e }))?;

--- a/cot/src/cli.rs
+++ b/cot/src/cli.rs
@@ -414,7 +414,8 @@ mod tests {
 
     use super::*;
     use crate::config::ProjectConfig;
-    use crate::{App, AppBuilder, ProjectContext};
+    use crate::project::RegisterAppsContext;
+    use crate::{App, AppBuilder};
 
     #[test]
     fn cli_new() {
@@ -498,7 +499,7 @@ mod tests {
 
         struct TestProject;
         impl cot::Project for TestProject {
-            fn register_apps(&self, apps: &mut AppBuilder, _context: &ProjectContext<WithConfig>) {
+            fn register_apps(&self, apps: &mut AppBuilder, _context: &RegisterAppsContext) {
                 apps.register(TestApp);
             }
         }

--- a/cot/src/config.rs
+++ b/cot/src/config.rs
@@ -227,10 +227,11 @@ impl ProjectConfig {
     /// ```
     #[must_use]
     pub fn dev_default() -> ProjectConfig {
-        ProjectConfig::builder()
-            .debug(true)
-            .register_panic_hook(true)
-            .build()
+        let mut builder = ProjectConfig::builder();
+        builder.debug(true).register_panic_hook(true);
+        #[cfg(feature = "db")]
+        builder.database(DatabaseConfig::builder().url("sqlite::memory:").build());
+        builder.build()
     }
 
     /// Create a new [`ProjectConfig`] from a TOML string.
@@ -292,7 +293,7 @@ impl ProjectConfigBuilder {
 ///
 /// let config = AuthBackendConfig::Database;
 /// ```
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AuthBackendConfig {
     /// No authentication backend.
@@ -300,6 +301,7 @@ pub enum AuthBackendConfig {
     /// This enables [`NoAuthBackend`](cot::auth::NoAuthBackend) to be used as
     /// the authentication backend, which effectively disables
     /// authentication.
+    #[default]
     None,
     /// Database authentication backend.
     ///
@@ -307,20 +309,6 @@ pub enum AuthBackendConfig {
     /// to be used as the authentication backend.
     #[cfg(feature = "db")]
     Database,
-}
-
-impl Default for AuthBackendConfig {
-    fn default() -> Self {
-        #[cfg(feature = "db")]
-        {
-            Self::Database
-        }
-
-        #[cfg(not(feature = "db"))]
-        {
-            Self::None
-        }
-    }
 }
 
 /// The configuration for the database.

--- a/cot/src/db.rs
+++ b/cot/src/db.rs
@@ -1339,6 +1339,37 @@ impl DatabaseBackend for Database {
     }
 }
 
+#[async_trait]
+impl DatabaseBackend for std::sync::Arc<Database> {
+    async fn insert_or_update<T: Model>(&self, data: &mut T) -> Result<()> {
+        Database::insert_or_update(self, data).await
+    }
+
+    async fn insert<T: Model>(&self, data: &mut T) -> Result<()> {
+        Database::insert(self, data).await
+    }
+
+    async fn update<T: Model>(&self, data: &mut T) -> Result<()> {
+        Database::update(self, data).await
+    }
+
+    async fn query<T: Model>(&self, query: &Query<T>) -> Result<Vec<T>> {
+        Database::query(self, query).await
+    }
+
+    async fn get<T: Model>(&self, query: &Query<T>) -> Result<Option<T>> {
+        Database::get(self, query).await
+    }
+
+    async fn exists<T: Model>(&self, query: &Query<T>) -> Result<bool> {
+        Database::exists(self, query).await
+    }
+
+    async fn delete<T: Model>(&self, query: &Query<T>) -> Result<StatementResult> {
+        Database::delete(self, query).await
+    }
+}
+
 /// Result of a statement execution.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StatementResult {

--- a/cot/src/error.rs
+++ b/cot/src/error.rs
@@ -150,8 +150,6 @@ impl_error_from_repr!(crate::db::DatabaseError);
 impl_error_from_repr!(tower_sessions::session::Error);
 impl_error_from_repr!(crate::form::FormError);
 impl_error_from_repr!(crate::auth::AuthError);
-#[cfg(feature = "json")]
-impl_error_from_repr!(serde_json::Error);
 impl_error_from_repr!(crate::request::PathParamsDeserializerError);
 
 #[derive(Debug, Error)]
@@ -225,7 +223,7 @@ pub(crate) enum ErrorRepr {
     /// An error occurred while trying to serialize or deserialize JSON.
     #[error("JSON error: {0}")]
     #[cfg(feature = "json")]
-    Json(#[from] serde_json::Error),
+    Json(serde_path_to_error::Error<serde_json::Error>),
     /// An error occurred inside a middleware-wrapped view.
     #[error(transparent)]
     MiddlewareWrapped {
@@ -234,6 +232,9 @@ pub(crate) enum ErrorRepr {
     /// An error occurred while trying to parse path parameters.
     #[error("Could not parse path parameters: {0}")]
     PathParametersParse(#[from] crate::request::PathParamsDeserializerError),
+    /// An error occurred while trying to parse query parameters.
+    #[error("Could not parse query parameters: {0}")]
+    QueryParametersParse(serde_path_to_error::Error<serde::de::value::Error>),
     /// An error occured in an [`AdminModel`](crate::admin::AdminModel).
     #[error("Admin error: {0}")]
     AdminError(#[source] Box<dyn std::error::Error + Send + Sync>),

--- a/cot/src/form.rs
+++ b/cot/src/form.rs
@@ -452,6 +452,30 @@ mod tests {
     use crate::headers::FORM_CONTENT_TYPE;
 
     #[cot::test]
+    async fn form_data_extract_get_empty() {
+        let mut request = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("https://example.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let bytes = form_data(&mut request).await.unwrap();
+        assert_eq!(bytes, Bytes::from_static(b""));
+    }
+
+    #[cot::test]
+    async fn form_data_extract_get() {
+        let mut request = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("https://example.com/?hello=world")
+            .body(Body::empty())
+            .unwrap();
+
+        let bytes = form_data(&mut request).await.unwrap();
+        assert_eq!(bytes, Bytes::from_static(b"hello=world"));
+    }
+
+    #[cot::test]
     async fn form_data_extract() {
         let mut request = http::Request::builder()
             .method(http::Method::POST)

--- a/cot/src/form.rs
+++ b/cot/src/form.rs
@@ -27,6 +27,7 @@ use std::borrow::Cow;
 use std::fmt::{Debug, Display};
 
 use async_trait::async_trait;
+use bytes::Bytes;
 /// Derive the [`Form`] trait for a struct and create a [`FormContext`] for it.
 ///
 /// This macro will generate an implementation of the [`Form`] trait for the
@@ -54,6 +55,7 @@ use async_trait::async_trait;
 pub use cot_macros::Form;
 use thiserror::Error;
 
+use crate::headers::FORM_CONTENT_TYPE;
 use crate::request;
 use crate::request::{Request, RequestExt};
 
@@ -216,8 +218,7 @@ pub trait Form: Sized {
     /// This method should return an error if the form data could not be read
     /// from the request.
     async fn build_context(request: &mut Request) -> Result<Self::Context, FormError> {
-        let form_data = request
-            .form_data()
+        let form_data = form_data(request)
             .await
             .map_err(|error| FormError::RequestError {
                 error: Box::new(error),
@@ -234,6 +235,33 @@ pub trait Form: Sized {
         }
 
         Ok(context)
+    }
+}
+
+/// Get the request body as bytes. If the request method is GET or HEAD, the
+/// query string is returned. Otherwise, if the request content type is
+/// `application/x-www-form-urlencoded`, then the body is read and returned.
+/// Otherwise, an error is thrown.
+///
+/// # Errors
+///
+/// Throws an error if the request method is not GET or HEAD and the content
+/// type is not `application/x-www-form-urlencoded`.
+/// Throws an error if the request body could not be read.
+pub async fn form_data(request: &mut Request) -> crate::Result<Bytes> {
+    if request.method() == http::Method::GET || request.method() == http::Method::HEAD {
+        if let Some(query) = request.uri().query() {
+            return Ok(Bytes::copy_from_slice(query.as_bytes()));
+        }
+
+        Ok(Bytes::new())
+    } else {
+        request.expect_content_type(FORM_CONTENT_TYPE)?;
+
+        let body = std::mem::take(request.body_mut());
+        let bytes = body.into_bytes().await?;
+
+        Ok(bytes)
     }
 }
 
@@ -413,4 +441,25 @@ pub trait AsFormField {
 
     /// Returns `self` as a value that can be set with [`FormField::set_value`].
     fn to_field_value(&self) -> String;
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use crate::Body;
+    use crate::form::form_data;
+    use crate::headers::FORM_CONTENT_TYPE;
+
+    #[cot::test]
+    async fn form_data_extract() {
+        let mut request = http::Request::builder()
+            .method(http::Method::POST)
+            .header(http::header::CONTENT_TYPE, FORM_CONTENT_TYPE)
+            .body(Body::fixed("hello=world"))
+            .unwrap();
+
+        let bytes = form_data(&mut request).await.unwrap();
+        assert_eq!(bytes, Bytes::from_static(b"hello=world"));
+    }
 }

--- a/cot/src/handler.rs
+++ b/cot/src/handler.rs
@@ -1,10 +1,12 @@
 use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
 
-use async_trait::async_trait;
 use tower::util::BoxCloneSyncService;
 
 use crate::error::ErrorRepr;
 use crate::request::Request;
+use crate::request::extractors::{FromRequest, FromRequestParts};
 use crate::response::{Response, not_found_response};
 use crate::{Error, Result};
 
@@ -14,34 +16,171 @@ use crate::{Error, Result};
 /// usually need to implement this directly, as it is already
 /// implemented for closures and functions that take a [`Request`]
 /// and return a [`Result<Response>`].
-#[async_trait]
-pub trait RequestHandler {
+pub trait RequestHandler<T = ()> {
     /// Handle the request and returns a response.
     ///
     /// # Errors
     ///
     /// This method can return an error if the request handler fails to handle
     /// the request.
-    async fn handle(&self, request: Request) -> Result<Response>;
+    fn handle(&self, request: Request) -> impl Future<Output = Result<Response>> + Send;
 }
 
-#[async_trait]
-impl<T, R> RequestHandler for T
-where
-    T: Fn(Request) -> R + Clone + Send + Sync + 'static,
-    R: for<'a> Future<Output = Result<Response>> + Send,
-{
-    async fn handle(&self, request: Request) -> Result<Response> {
-        let response = self(request).await;
-        match response {
-            Ok(response) => Ok(response),
-            Err(error) => match error.inner {
-                ErrorRepr::NotFound { message } => Ok(not_found_response(message)),
-                _ => Err(error),
-            },
+pub(crate) trait BoxRequestHandler {
+    fn handle(
+        &self,
+        request: Request,
+    ) -> Pin<Box<dyn Future<Output = Result<Response>> + Send + '_>>;
+}
+
+pub(crate) fn into_box_request_handler<T, H: RequestHandler<T> + Send + Sync>(
+    handler: H,
+) -> impl BoxRequestHandler {
+    struct Inner<T, H>(H, PhantomData<fn() -> T>);
+
+    impl<T, H: RequestHandler<T> + Send + Sync> BoxRequestHandler for Inner<T, H> {
+        fn handle(
+            &self,
+            request: Request,
+        ) -> Pin<Box<dyn Future<Output = Result<Response>> + Send + '_>> {
+            Box::pin(async move {
+                let response = self.0.handle(request).await;
+
+                match response {
+                    Ok(response) => Ok(response),
+                    Err(error) => match error.inner {
+                        ErrorRepr::NotFound { message } => Ok(not_found_response(message)),
+                        _ => Err(error),
+                    },
+                }
+            })
         }
     }
+
+    Inner(handler, PhantomData)
 }
+
+macro_rules! impl_request_handler {
+    ($($ty:ident),*) => {
+        impl<T, $($ty,)* R> RequestHandler<($($ty,)*)> for T
+        where
+            T: Fn($($ty,)*) -> R + Clone + Send + Sync + 'static,
+            $($ty: FromRequestParts + Send,)*
+            R: for<'a> Future<Output = Result<Response>> + Send,
+        {
+            #[allow(non_snake_case)]
+            async fn handle(&self, request: Request) -> Result<Response> {
+                #[allow(unused_variables, unused_mut)] // for the case where there are no params
+                let (mut parts, _body) = request.into_parts();
+
+                $(
+                    let $ty = $ty::from_request_parts(&mut parts).await?;
+                )*
+
+                self($($ty,)*).await
+            }
+        }
+    };
+}
+
+macro_rules! impl_request_handler_from_request {
+    ($($ty_lhs:ident,)* ($ty_from_request:ident) $(,$ty_rhs:ident)*) => {
+        impl<T, $($ty_lhs,)* $ty_from_request, $($ty_rhs,)* R> RequestHandler<($($ty_lhs,)* $ty_from_request, (), $($ty_rhs,)*)> for T
+        where
+            T: Fn($($ty_lhs,)* $ty_from_request, $($ty_rhs),*) -> R + Clone + Send + Sync + 'static,
+            $($ty_lhs: FromRequestParts + Send,)*
+            $ty_from_request: FromRequest + Send,
+            $($ty_rhs: FromRequestParts + Send,)*
+            R: for<'a> Future<Output = Result<Response>> + Send,
+        {
+            #[allow(non_snake_case)]
+            async fn handle(&self, request: Request) -> Result<Response> {
+                #[allow(unused_mut)] // for the case where there are no FromRequestParts params
+                let (mut parts, body) = request.into_parts();
+
+                $(
+                    let $ty_lhs = $ty_lhs::from_request_parts(&mut parts).await?;
+                )*
+                $(
+                    let $ty_rhs = $ty_rhs::from_request_parts(&mut parts).await?;
+                )*
+
+                let request = Request::from_parts(parts, body);
+                let $ty_from_request = $ty_from_request::from_request(request).await?;
+
+                self($($ty_lhs,)* $ty_from_request, $($ty_rhs),*).await
+            }
+        }
+    };
+}
+
+impl_request_handler!();
+impl_request_handler!(P1);
+impl_request_handler!(P1, P2);
+impl_request_handler!(P1, P2, P3);
+impl_request_handler!(P1, P2, P3, P4);
+impl_request_handler!(P1, P2, P3, P4, P5);
+impl_request_handler!(P1, P2, P3, P4, P5, P6);
+impl_request_handler!(P1, P2, P3, P4, P5, P6, P7);
+impl_request_handler!(P1, P2, P3, P4, P5, P6, P7, P8);
+impl_request_handler!(P1, P2, P3, P4, P5, P6, P7, P8, P9);
+impl_request_handler!(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10);
+
+impl_request_handler_from_request!((P1));
+impl_request_handler_from_request!((P1), P2);
+impl_request_handler_from_request!(P1, (P2));
+impl_request_handler_from_request!((P1), P2, P3);
+impl_request_handler_from_request!(P1, (P2), P3);
+impl_request_handler_from_request!(P1, P2, (P3));
+impl_request_handler_from_request!((P1), P2, P3, P4);
+impl_request_handler_from_request!(P1, (P2), P3, P4);
+impl_request_handler_from_request!(P1, P2, (P3), P4);
+impl_request_handler_from_request!(P1, P2, P3, (P4));
+impl_request_handler_from_request!((P1), P2, P3, P4, P5);
+impl_request_handler_from_request!(P1, (P2), P3, P4, P5);
+impl_request_handler_from_request!(P1, P2, (P3), P4, P5);
+impl_request_handler_from_request!(P1, P2, P3, (P4), P5);
+impl_request_handler_from_request!(P1, P2, P3, P4, (P5));
+impl_request_handler_from_request!((P1), P2, P3, P4, P5, P6);
+impl_request_handler_from_request!(P1, (P2), P3, P4, P5, P6);
+impl_request_handler_from_request!(P1, P2, (P3), P4, P5, P6);
+impl_request_handler_from_request!(P1, P2, P3, (P4), P5, P6);
+impl_request_handler_from_request!(P1, P2, P3, P4, (P5), P6);
+impl_request_handler_from_request!(P1, P2, P3, P4, P5, (P6));
+impl_request_handler_from_request!((P1), P2, P3, P4, P5, P6, P7);
+impl_request_handler_from_request!(P1, (P2), P3, P4, P5, P6, P7);
+impl_request_handler_from_request!(P1, P2, (P3), P4, P5, P6, P7);
+impl_request_handler_from_request!(P1, P2, P3, (P4), P5, P6, P7);
+impl_request_handler_from_request!(P1, P2, P3, P4, (P5), P6, P7);
+impl_request_handler_from_request!(P1, P2, P3, P4, P5, (P6), P7);
+impl_request_handler_from_request!(P1, P2, P3, P4, P5, P6, (P7));
+impl_request_handler_from_request!((P1), P2, P3, P4, P5, P6, P7, P8);
+impl_request_handler_from_request!(P1, (P2), P3, P4, P5, P6, P7, P8);
+impl_request_handler_from_request!(P1, P2, (P3), P4, P5, P6, P7, P8);
+impl_request_handler_from_request!(P1, P2, P3, (P4), P5, P6, P7, P8);
+impl_request_handler_from_request!(P1, P2, P3, P4, (P5), P6, P7, P8);
+impl_request_handler_from_request!(P1, P2, P3, P4, P5, (P6), P7, P8);
+impl_request_handler_from_request!(P1, P2, P3, P4, P5, P6, (P7), P8);
+impl_request_handler_from_request!(P1, P2, P3, P4, P5, P6, P7, (P8));
+impl_request_handler_from_request!((P1), P2, P3, P4, P5, P6, P7, P8, P9);
+impl_request_handler_from_request!(P1, (P2), P3, P4, P5, P6, P7, P8, P9);
+impl_request_handler_from_request!(P1, P2, (P3), P4, P5, P6, P7, P8, P9);
+impl_request_handler_from_request!(P1, P2, P3, (P4), P5, P6, P7, P8, P9);
+impl_request_handler_from_request!(P1, P2, P3, P4, (P5), P6, P7, P8, P9);
+impl_request_handler_from_request!(P1, P2, P3, P4, P5, (P6), P7, P8, P9);
+impl_request_handler_from_request!(P1, P2, P3, P4, P5, P6, (P7), P8, P9);
+impl_request_handler_from_request!(P1, P2, P3, P4, P5, P6, P7, (P8), P9);
+impl_request_handler_from_request!(P1, P2, P3, P4, P5, P6, P7, P8, (P9));
+impl_request_handler_from_request!((P1), P2, P3, P4, P5, P6, P7, P8, P9, P10);
+impl_request_handler_from_request!(P1, (P2), P3, P4, P5, P6, P7, P8, P9, P10);
+impl_request_handler_from_request!(P1, P2, (P3), P4, P5, P6, P7, P8, P9, P10);
+impl_request_handler_from_request!(P1, P2, P3, (P4), P5, P6, P7, P8, P9, P10);
+impl_request_handler_from_request!(P1, P2, P3, P4, (P5), P6, P7, P8, P9, P10);
+impl_request_handler_from_request!(P1, P2, P3, P4, P5, (P6), P7, P8, P9, P10);
+impl_request_handler_from_request!(P1, P2, P3, P4, P5, P6, (P7), P8, P9, P10);
+impl_request_handler_from_request!(P1, P2, P3, P4, P5, P6, P7, (P8), P9, P10);
+impl_request_handler_from_request!(P1, P2, P3, P4, P5, P6, P7, P8, (P9), P10);
+impl_request_handler_from_request!(P1, P2, P3, P4, P5, P6, P7, P8, P9, (P10));
 
 /// A wrapper around a handler that's used in
 /// [`Bootstrapper`](cot::Bootstrapper).
@@ -57,7 +196,7 @@ where
 ///
 /// ```
 /// use cot::config::ProjectConfig;
-/// use cot::project::{RootHandlerBuilder, WithApps};
+/// use cot::project::{MiddlewareContext, RootHandlerBuilder};
 /// use cot::static_files::StaticFilesMiddleware;
 /// use cot::{Bootstrapper, BoxedHandler, Project, ProjectContext};
 ///
@@ -66,7 +205,7 @@ where
 ///     fn middlewares(
 ///         &self,
 ///         handler: RootHandlerBuilder,
-///         context: &ProjectContext<WithApps>,
+///         context: &MiddlewareContext,
 ///     ) -> BoxedHandler {
 ///         handler
 ///             .middleware(StaticFilesMiddleware::from_context(context))

--- a/cot/src/lib.rs
+++ b/cot/src/lib.rs
@@ -75,6 +75,7 @@ pub mod project;
 pub mod request;
 pub mod response;
 pub mod router;
+pub mod session;
 pub mod static_files;
 pub mod test;
 pub(crate) mod utils;

--- a/cot/src/middleware.rs
+++ b/cot/src/middleware.rs
@@ -7,6 +7,7 @@
 use std::task::{Context, Poll};
 
 use bytes::Bytes;
+use futures_core::future::BoxFuture;
 use futures_util::TryFutureExt;
 use http_body_util::BodyExt;
 use http_body_util::combinators::BoxBody;
@@ -14,6 +15,7 @@ use tower::Service;
 use tower_sessions::{MemoryStore, SessionManagerLayer};
 
 use crate::error::ErrorRepr;
+use crate::project::MiddlewareContext;
 use crate::request::Request;
 use crate::response::Response;
 use crate::{Body, Error};
@@ -31,7 +33,7 @@ use crate::{Body, Error};
 ///
 /// ```
 /// use cot::middleware::LiveReloadMiddleware;
-/// use cot::project::{RootHandlerBuilder, WithApps};
+/// use cot::project::{MiddlewareContext, RootHandlerBuilder};
 /// use cot::{BoxedHandler, Project, ProjectContext};
 ///
 /// struct MyProject;
@@ -39,7 +41,7 @@ use crate::{Body, Error};
 ///     fn middlewares(
 ///         &self,
 ///         handler: RootHandlerBuilder,
-///         context: &ProjectContext<WithApps>,
+///         context: &MiddlewareContext,
 ///     ) -> BoxedHandler {
 ///         handler
 ///             // IntoCotResponseLayer used internally in middleware()
@@ -103,15 +105,15 @@ pub struct IntoCotResponse<S> {
     inner: S,
 }
 
-impl<S, B, E> Service<Request> for IntoCotResponse<S>
+impl<S, ResBody, E> Service<Request> for IntoCotResponse<S>
 where
-    S: Service<Request, Response = http::Response<B>>,
-    B: http_body::Body<Data = Bytes, Error = E> + Send + Sync + 'static,
+    S: Service<Request, Response = http::Response<ResBody>>,
+    ResBody: http_body::Body<Data = Bytes, Error = E> + Send + Sync + 'static,
     E: std::error::Error + Send + Sync + 'static,
 {
     type Response = Response;
     type Error = S::Error;
-    type Future = futures_util::future::MapOk<S::Future, fn(http::Response<B>) -> Response>;
+    type Future = futures_util::future::MapOk<S::Future, fn(http::Response<ResBody>) -> Response>;
 
     #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -124,9 +126,9 @@ where
     }
 }
 
-fn map_response<B, E>(response: http::response::Response<B>) -> Response
+fn map_response<ResBody, E>(response: http::response::Response<ResBody>) -> Response
 where
-    B: http_body::Body<Data = Bytes, Error = E> + Send + Sync + 'static,
+    ResBody: http_body::Body<Data = Bytes, Error = E> + Send + Sync + 'static,
     E: std::error::Error + Send + Sync + 'static,
 {
     response.map(|body| Body::wrapper(BoxBody::new(body.map_err(map_err))))
@@ -145,7 +147,7 @@ where
 ///
 /// ```
 /// use cot::middleware::LiveReloadMiddleware;
-/// use cot::project::{RootHandlerBuilder, WithApps};
+/// use cot::project::{MiddlewareContext, RootHandlerBuilder};
 /// use cot::{BoxedHandler, Project, ProjectContext};
 ///
 /// struct MyProject;
@@ -153,7 +155,7 @@ where
 ///     fn middlewares(
 ///         &self,
 ///         handler: RootHandlerBuilder,
-///         context: &ProjectContext<WithApps>,
+///         context: &MiddlewareContext,
 ///     ) -> BoxedHandler {
 ///         handler
 ///             // IntoCotErrorLayer used internally in middleware()
@@ -268,7 +270,7 @@ impl SessionMiddleware {
     ///
     /// ```
     /// use cot::middleware::SessionMiddleware;
-    /// use cot::project::{RootHandlerBuilder, WithApps};
+    /// use cot::project::{MiddlewareContext, RootHandlerBuilder};
     /// use cot::{BoxedHandler, Project, ProjectContext};
     ///
     /// struct MyProject;
@@ -276,7 +278,7 @@ impl SessionMiddleware {
     ///     fn middlewares(
     ///         &self,
     ///         handler: RootHandlerBuilder,
-    ///         context: &ProjectContext<WithApps>,
+    ///         context: &MiddlewareContext,
     ///     ) -> BoxedHandler {
     ///         handler
     ///             .middleware(SessionMiddleware::from_context(context))
@@ -285,9 +287,10 @@ impl SessionMiddleware {
     /// }
     /// ```
     #[must_use]
-    pub fn from_context(context: &crate::ProjectContext<crate::project::WithApps>) -> Self {
+    pub fn from_context(context: &MiddlewareContext) -> Self {
         Self::new().secure(context.config().middlewares.session.secure)
     }
+
     /// Sets the secure flag for the session middleware.
     ///
     /// # Examples
@@ -312,10 +315,194 @@ impl Default for SessionMiddleware {
 }
 
 impl<S> tower::Layer<S> for SessionMiddleware {
-    type Service = <SessionManagerLayer<MemoryStore> as tower::Layer<S>>::Service;
+    type Service = <SessionManagerLayer<MemoryStore> as tower::Layer<
+        <SessionWrapperLayer as tower::Layer<S>>::Service,
+    >>::Service;
 
     fn layer(&self, inner: S) -> Self::Service {
-        self.inner.layer(inner)
+        let session_store = MemoryStore::default();
+        let session_layer = SessionManagerLayer::new(session_store);
+        let session_wrapper_layer = SessionWrapperLayer::new();
+        let layers = (session_layer, session_wrapper_layer);
+
+        layers.layer(inner)
+    }
+}
+
+/// A middleware layer that wraps the session object in a
+/// [`crate::session::Session`].
+///
+/// This is only useful inside [`SessionMiddleware`] to expose session object as
+/// [`crate::session::Session`] to the request handlers. This shouldn't be
+/// useful on its own.
+#[derive(Debug, Copy, Clone)]
+pub struct SessionWrapperLayer;
+
+impl SessionWrapperLayer {
+    /// Create a new [`SessionWrapperLayer`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cot::middleware::SessionWrapperLayer;
+    ///
+    /// let middleware = SessionWrapperLayer::new();
+    /// ```
+    #[must_use]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for SessionWrapperLayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S> tower::Layer<S> for SessionWrapperLayer {
+    type Service = SessionWrapper<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        SessionWrapper { inner }
+    }
+}
+
+/// Service struct that wraps the session object in a
+/// [`crate::session::Session`].
+///
+/// Used by [`SessionWrapperLayer`].
+#[derive(Debug, Clone)]
+pub struct SessionWrapper<S> {
+    inner: S,
+}
+
+impl<ReqBody, ResBody, S> Service<http::Request<ReqBody>> for SessionWrapper<S>
+where
+    S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send,
+    ReqBody: Send + 'static,
+    ResBody: Default + Send,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: http::Request<ReqBody>) -> Self::Future {
+        let session = req
+            .extensions_mut()
+            .remove::<tower_sessions::Session>()
+            .expect("session extension must be present");
+        let session_wrapped = crate::session::Session::new(session);
+        req.extensions_mut().insert(session_wrapped);
+
+        self.inner.call(req)
+    }
+}
+
+/// A middleware that provides authentication functionality.
+///
+/// This middleware is used to authenticate requests and add the authenticated
+/// user to the request extensions. This adds the [`crate::auth::Auth`] object
+/// to the request which can be accessed by the request handlers.
+///
+/// # Examples
+///
+/// ```
+/// use cot::middleware::AuthMiddleware;
+/// use cot::project::{MiddlewareContext, RootHandlerBuilder};
+/// use cot::{BoxedHandler, Project, ProjectContext};
+///
+/// struct MyProject;
+/// impl Project for MyProject {
+///     fn middlewares(
+///         &self,
+///         handler: RootHandlerBuilder,
+///         context: &MiddlewareContext,
+///     ) -> BoxedHandler {
+///         handler.middleware(AuthMiddleware::new()).build()
+///     }
+/// }
+/// ```
+#[derive(Debug, Copy, Clone)]
+pub struct AuthMiddleware;
+
+impl AuthMiddleware {
+    /// Create a new [`AuthMiddleware`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cot::middleware::AuthMiddleware;
+    ///
+    /// let middleware = AuthMiddleware::new();
+    /// ```
+    #[must_use]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for AuthMiddleware {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S> tower::Layer<S> for AuthMiddleware {
+    type Service = AuthService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AuthService::new(inner)
+    }
+}
+
+/// Service that adds [`crate::auth::Auth`] to the request.
+///
+/// Used by [`AuthMiddleware`].
+#[derive(Debug, Clone)]
+pub struct AuthService<S> {
+    inner: S,
+}
+
+impl<S> AuthService<S> {
+    fn new(inner: S) -> Self {
+        Self { inner }
+    }
+}
+
+impl<S> Service<Request> for AuthService<S>
+where
+    S: Service<Request, Response = Response, Error = Error> + Clone + Send + 'static,
+    S::Future: Send,
+{
+    type Response = S::Response;
+    type Error = Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request) -> Self::Future {
+        // The inner service may panic until ready, so it's important to clone
+        // it here and used the version that is ready. This is a common pattern when
+        // using `tower::Service`.
+        //
+        // https://docs.rs/tower/latest/tower/trait.Service.html#be-careful-when-cloning-inner-services
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        Box::pin(async move {
+            let auth = crate::auth::Auth::from_request(&mut req).await?;
+            req.extensions_mut().insert(auth);
+
+            inner.call(req).await
+        })
     }
 }
 #[cfg(feature = "live-reload")]
@@ -356,7 +543,7 @@ type LiveReloadLayerType = tower::util::Either<
 ///
 /// ```
 /// use cot::middleware::LiveReloadMiddleware;
-/// use cot::project::{RootHandlerBuilder, WithApps};
+/// use cot::project::{MiddlewareContext, RootHandlerBuilder};
 /// use cot::{BoxedHandler, Project, ProjectContext};
 ///
 /// struct MyProject;
@@ -364,7 +551,7 @@ type LiveReloadLayerType = tower::util::Either<
 ///     fn middlewares(
 ///         &self,
 ///         handler: RootHandlerBuilder,
-///         context: &ProjectContext<WithApps>,
+///         context: &MiddlewareContext,
 ///     ) -> BoxedHandler {
 ///         handler
 ///             .middleware(LiveReloadMiddleware::from_context(context))
@@ -385,7 +572,7 @@ impl LiveReloadMiddleware {
     ///
     /// ```
     /// use cot::middleware::LiveReloadMiddleware;
-    /// use cot::project::{RootHandlerBuilder, WithApps};
+    /// use cot::project::{MiddlewareContext, RootHandlerBuilder};
     /// use cot::{BoxedHandler, Project, ProjectContext};
     ///
     /// struct MyProject;
@@ -393,7 +580,7 @@ impl LiveReloadMiddleware {
     ///     fn middlewares(
     ///         &self,
     ///         handler: RootHandlerBuilder,
-    ///         context: &ProjectContext<WithApps>,
+    ///         context: &MiddlewareContext,
     ///     ) -> BoxedHandler {
     ///         // only enable live reloading when compiled in debug mode
     ///         #[cfg(debug_assertions)]
@@ -414,7 +601,7 @@ impl LiveReloadMiddleware {
     ///
     /// ```
     /// use cot::middleware::LiveReloadMiddleware;
-    /// use cot::project::{RootHandlerBuilder, WithApps};
+    /// use cot::project::{MiddlewareContext, RootHandlerBuilder};
     /// use cot::{BoxedHandler, Project, ProjectContext};
     ///
     /// struct MyProject;
@@ -422,7 +609,7 @@ impl LiveReloadMiddleware {
     ///     fn middlewares(
     ///         &self,
     ///         handler: RootHandlerBuilder,
-    ///         context: &ProjectContext<WithApps>,
+    ///         context: &MiddlewareContext,
     ///     ) -> BoxedHandler {
     ///         handler
     ///             .middleware(LiveReloadMiddleware::from_context(context))
@@ -439,7 +626,7 @@ impl LiveReloadMiddleware {
     /// live_reload.enabled = true
     /// ```
     #[must_use]
-    pub fn from_context(context: &crate::ProjectContext<crate::project::WithApps>) -> Self {
+    pub fn from_context(context: &crate::ProjectContext<crate::project::WithDatabase>) -> Self {
         Self::with_enabled(context.config().middlewares.live_reload.enabled)
     }
 

--- a/cot/src/middleware.rs
+++ b/cot/src/middleware.rs
@@ -626,7 +626,7 @@ impl LiveReloadMiddleware {
     /// live_reload.enabled = true
     /// ```
     #[must_use]
-    pub fn from_context(context: &crate::ProjectContext<crate::project::WithDatabase>) -> Self {
+    pub fn from_context(context: &MiddlewareContext) -> Self {
         Self::with_enabled(context.config().middlewares.live_reload.enabled)
     }
 

--- a/cot/src/project.rs
+++ b/cot/src/project.rs
@@ -319,23 +319,34 @@ pub trait Project {
     /// # Examples
     ///
     /// ```
+    /// use std::sync::Arc;
+    ///
     /// use cot::auth::{AuthBackend, NoAuthBackend};
-    /// use cot::project::WithApps;
-    /// use cot::{App, Project, ProjectContext};
+    /// use cot::project::AuthBackendContext;
+    /// use cot::{App, Project};
     ///
     /// struct HelloProject;
     /// impl Project for HelloProject {
-    ///     fn auth_backend(&self, context: &ProjectContext<WithApps>) -> Box<dyn AuthBackend> {
-    ///         Box::new(NoAuthBackend)
+    ///     fn auth_backend(&self, context: &AuthBackendContext) -> Arc<dyn AuthBackend> {
+    ///         Arc::new(NoAuthBackend)
     ///     }
     /// }
     /// ```
-    fn auth_backend(&self, context: &ProjectContext<WithApps>) -> Box<dyn AuthBackend> {
-        #[allow(trivial_casts)] // cast to Box<dyn AuthBackend>
+    fn auth_backend(&self, context: &ProjectContext<WithDatabase>) -> Arc<dyn AuthBackend> {
+        #[allow(trivial_casts)] // cast to Arc<dyn AuthBackend>
         match &context.config().auth_backend {
-            AuthBackendConfig::None => Box::new(NoAuthBackend) as Box<dyn AuthBackend>,
+            AuthBackendConfig::None => Arc::new(NoAuthBackend) as Arc<dyn AuthBackend>,
             #[cfg(feature = "db")]
-            AuthBackendConfig::Database => Box::new(DatabaseUserBackend) as Box<dyn AuthBackend>,
+            AuthBackendConfig::Database => Arc::new(DatabaseUserBackend::new(
+                context
+                    .try_database()
+                    .expect(
+                        "Database missing when constructing database auth backend. \
+                        Make sure the database config is set up correctly or disable \
+                        authentication in the config.",
+                    )
+                    .clone(),
+            )) as Arc<dyn AuthBackend>,
         }
     }
 
@@ -348,7 +359,7 @@ pub trait Project {
     ///
     /// ```
     /// use cot::middleware::LiveReloadMiddleware;
-    /// use cot::project::{RootHandlerBuilder, WithApps};
+    /// use cot::project::{MiddlewareContext, RootHandlerBuilder};
     /// use cot::{BoxedHandler, Project, ProjectContext};
     ///
     /// struct MyProject;
@@ -356,7 +367,7 @@ pub trait Project {
     ///     fn middlewares(
     ///         &self,
     ///         handler: RootHandlerBuilder,
-    ///         context: &ProjectContext<WithApps>,
+    ///         context: &MiddlewareContext,
     ///     ) -> BoxedHandler {
     ///         handler
     ///             .middleware(LiveReloadMiddleware::from_context(context))
@@ -368,7 +379,7 @@ pub trait Project {
     fn middlewares(
         &self,
         handler: RootHandlerBuilder,
-        context: &ProjectContext<WithApps>,
+        context: &MiddlewareContext,
     ) -> BoxedHandler {
         handler.build()
     }
@@ -464,6 +475,18 @@ pub trait Project {
     }
 }
 
+/// An alias for `ProjectContext` in appropriate phase for use with the
+/// [`Project::register_apps`] method.
+pub type RegisterAppsContext = ProjectContext<WithConfig>;
+
+/// An alias for `ProjectContext` in appropriate phase for use with the
+/// [`Project::auth_backend`] method.
+pub type AuthBackendContext = ProjectContext<WithDatabase>;
+
+/// An alias for `ProjectContext` in appropriate phase for use with the
+/// [`Project::middlewares`] method.
+pub type MiddlewareContext = ProjectContext<WithDatabase>;
+
 /// A helper struct to build the root handler for the project.
 ///
 /// This is mainly useful for attaching middlewares to the project.
@@ -472,7 +495,7 @@ pub trait Project {
 ///
 /// ```
 /// use cot::middleware::LiveReloadMiddleware;
-/// use cot::project::{RootHandlerBuilder, WithApps};
+/// use cot::project::{MiddlewareContext, RootHandlerBuilder};
 /// use cot::{BoxedHandler, Project, ProjectContext};
 ///
 /// struct MyProject;
@@ -480,7 +503,7 @@ pub trait Project {
 ///     fn middlewares(
 ///         &self,
 ///         handler: RootHandlerBuilder,
-///         context: &ProjectContext<WithApps>,
+///         context: &MiddlewareContext,
 ///     ) -> BoxedHandler {
 ///         handler
 ///             .middleware(LiveReloadMiddleware::from_context(context))
@@ -507,7 +530,7 @@ where
     ///
     /// ```
     /// use cot::middleware::LiveReloadMiddleware;
-    /// use cot::project::{RootHandlerBuilder, WithApps};
+    /// use cot::project::{MiddlewareContext, RootHandlerBuilder};
     /// use cot::{BoxedHandler, Project, ProjectContext};
     ///
     /// struct MyProject;
@@ -515,7 +538,7 @@ where
     ///     fn middlewares(
     ///         &self,
     ///         handler: RootHandlerBuilder,
-    ///         context: &ProjectContext<WithApps>,
+    ///         context: &MiddlewareContext,
     ///     ) -> BoxedHandler {
     ///         handler
     ///             .middleware(LiveReloadMiddleware::from_context(context))
@@ -548,7 +571,7 @@ where
     ///
     /// ```
     /// use cot::middleware::LiveReloadMiddleware;
-    /// use cot::project::{RootHandlerBuilder, WithApps};
+    /// use cot::project::{MiddlewareContext, RootHandlerBuilder};
     /// use cot::{BoxedHandler, Project, ProjectContext};
     ///
     /// struct MyProject;
@@ -556,7 +579,7 @@ where
     ///     fn middlewares(
     ///         &self,
     ///         handler: RootHandlerBuilder,
-    ///         context: &ProjectContext<WithApps>,
+    ///         context: &MiddlewareContext,
     ///     ) -> BoxedHandler {
     ///         handler
     ///             .middleware(LiveReloadMiddleware::from_context(context))
@@ -1103,6 +1126,7 @@ impl Bootstrapper<WithApps> {
     /// # async fn main() -> cot::Result<()> {
     /// let bootstrapper = Bootstrapper::new(MyProject)
     ///     .with_config(ProjectConfig::default())
+    ///     .with_apps()
     ///     .boot()
     ///     .await?;
     /// let (context, handler) = bootstrapper.into_context_and_handler();
@@ -1112,17 +1136,47 @@ impl Bootstrapper<WithApps> {
     // Send not needed; Bootstrapper is run async in a single thread
     #[allow(clippy::future_not_send)]
     pub async fn boot(self) -> cot::Result<Bootstrapper<Initialized>> {
-        let router_service = RouterService::new(Arc::clone(&self.context.router));
-        let handler = RootHandlerBuilder {
-            handler: router_service,
-        };
-        let handler = self.project.middlewares(handler, &self.context);
+        self.with_database().await?.boot().await
+    }
 
-        let auth_backend = self.project.auth_backend(&self.context);
+    /// Moves forward to the next phase of bootstrapping, the with-database
+    /// phase.
+    ///
+    /// See the [`BootstrapPhase`] and [`WithDatabase`] documentation for more
+    /// details.
+    ///
+    /// # Errors
+    ///
+    /// This method may return an error if it cannot initialize the database.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cot::config::ProjectConfig;
+    /// use cot::project::{Bootstrapper, WithApps};
+    /// use cot::{AppBuilder, Project};
+    ///
+    /// struct MyProject;
+    /// impl Project for MyProject {}
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> cot::Result<()> {
+    /// let bootstrapper = Bootstrapper::new(MyProject)
+    ///     .with_config(ProjectConfig::default())
+    ///     .with_apps()
+    ///     .with_database()
+    ///     .await?
+    ///     .boot()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    // Send not needed; Bootstrapper is run async in a single thread
+    #[allow(clippy::future_not_send)]
+    pub async fn with_database(self) -> cot::Result<Bootstrapper<WithDatabase>> {
         #[cfg(feature = "db")]
         let database = Self::init_database(&self.context.config.database).await?;
-        let context = self.context.with_auth_and_db(
-            auth_backend,
+        let context = self.context.with_database(
             #[cfg(feature = "db")]
             database,
         );
@@ -1130,7 +1184,7 @@ impl Bootstrapper<WithApps> {
         Ok(Bootstrapper {
             project: self.project,
             context,
-            handler,
+            handler: self.handler,
         })
     }
 
@@ -1143,6 +1197,62 @@ impl Bootstrapper<WithApps> {
             }
             None => Ok(None),
         }
+    }
+}
+
+impl Bootstrapper<WithDatabase> {
+    /// Builds the Cot project instance.
+    ///
+    /// This is the final step in the bootstrapping process. It initializes the
+    /// project with the given configuration and returns a [`Bootstrapper`]
+    /// instance that contains the project's context and handler.
+    ///
+    /// You shouldn't have to use this method directly most of the time. It's
+    /// mainly useful for controlling the bootstrapping process in custom
+    /// [`CliTask`](cli::CliTask)s.
+    ///
+    /// # Errors
+    ///
+    /// This method may return an error if it cannot initialize any of the
+    /// project's components, such as the database.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cot::config::ProjectConfig;
+    /// use cot::{Bootstrapper, Project};
+    ///
+    /// struct MyProject;
+    /// impl Project for MyProject {}
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> cot::Result<()> {
+    /// let bootstrapper = Bootstrapper::new(MyProject)
+    ///     .with_config(ProjectConfig::default())
+    ///     .boot()
+    ///     .await?;
+    /// let (context, handler) = bootstrapper.into_context_and_handler();
+    /// # Ok(())
+    /// # }
+    /// ```
+    // Function marked `async` to be consistent with the other `boot` methods
+    // Send not needed; Bootstrapper is run async in a single thread
+    #[allow(clippy::unused_async, clippy::future_not_send)]
+    pub async fn boot(self) -> cot::Result<Bootstrapper<Initialized>> {
+        let router_service = RouterService::new(Arc::clone(&self.context.router));
+        let handler = RootHandlerBuilder {
+            handler: router_service,
+        };
+        let handler = self.project.middlewares(handler, &self.context);
+
+        let auth_backend = self.project.auth_backend(&self.context);
+        let context = self.context.with_auth(auth_backend);
+
+        Ok(Bootstrapper {
+            project: self.project,
+            context,
+            handler,
+        })
     }
 }
 
@@ -1185,6 +1295,14 @@ mod sealed {
 /// bootstrapper. It's used to ensure that you can't access nonexistent
 /// data until the bootstrapper has reached the corresponding phase.
 ///
+/// # Order of phases
+///
+/// 1. [`Uninitialized`]
+/// 2. [`WithConfig`]
+/// 3. [`WithApps`]
+/// 4. [`WithDatabase`]
+/// 5. [`Initialized`]
+///
 /// # Sealed
 ///
 /// This trait is sealed and can't be implemented outside the `cot`
@@ -1193,22 +1311,21 @@ mod sealed {
 /// # Examples
 ///
 /// ```
-/// ///
-/// use cot::project::{RootHandlerBuilder, WithApps, WithConfig};
+/// use cot::project::{MiddlewareContext, RegisterAppsContext, RootHandlerBuilder};
 /// use cot::{AppBuilder, BoxedHandler, Project, ProjectContext};
 ///
 /// struct MyProject;
 /// impl Project for MyProject {
 ///     // `WithConfig` phase here
-///     fn register_apps(&self, apps: &mut AppBuilder, context: &ProjectContext<WithConfig>) {
+///     fn register_apps(&self, apps: &mut AppBuilder, context: &RegisterAppsContext) {
 ///         todo!();
 ///     }
 ///
-///     // `WithApps` phase here (which comes after `WithConfig`)
+///     // `WithDatabase` phase here (which comes after `WithConfig`)
 ///     fn middlewares(
 ///         &self,
 ///         handler: RootHandlerBuilder,
-///         context: &ProjectContext<WithApps>,
+///         context: &MiddlewareContext,
 ///     ) -> BoxedHandler {
 ///         todo!()
 ///     }
@@ -1226,11 +1343,11 @@ pub trait BootstrapPhase: sealed::Sealed {
     type Apps;
     /// The type of the router.
     type Router: Debug;
-    /// The type of the auth backend.
-    type AuthBackend;
     /// The type of the database.
     #[cfg(feature = "db")]
     type Database: Debug;
+    /// The type of the auth backend.
+    type AuthBackend;
 }
 
 /// First phase of bootstrapping a Cot project, the uninitialized phase.
@@ -1240,7 +1357,7 @@ pub trait BootstrapPhase: sealed::Sealed {
 /// See the details about the different bootstrap phases in the
 /// [`BootstrapPhase`] trait documentation.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct Uninitialized;
+pub enum Uninitialized {}
 
 impl sealed::Sealed for Uninitialized {}
 impl BootstrapPhase for Uninitialized {
@@ -1248,9 +1365,9 @@ impl BootstrapPhase for Uninitialized {
     type Config = ();
     type Apps = ();
     type Router = ();
-    type AuthBackend = ();
     #[cfg(feature = "db")]
     type Database = ();
+    type AuthBackend = ();
 }
 
 /// Second phase of bootstrapping a Cot project, the with-config phase.
@@ -1260,7 +1377,7 @@ impl BootstrapPhase for Uninitialized {
 /// See the details about the different bootstrap phases in the
 /// [`BootstrapPhase`] trait documentation.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct WithConfig;
+pub enum WithConfig {}
 
 impl sealed::Sealed for WithConfig {}
 impl BootstrapPhase for WithConfig {
@@ -1268,9 +1385,9 @@ impl BootstrapPhase for WithConfig {
     type Config = Arc<ProjectConfig>;
     type Apps = ();
     type Router = ();
-    type AuthBackend = ();
     #[cfg(feature = "db")]
     type Database = ();
+    type AuthBackend = ();
 }
 
 /// Third phase of bootstrapping a Cot project, the with-apps phase.
@@ -1280,7 +1397,7 @@ impl BootstrapPhase for WithConfig {
 /// See the details about the different bootstrap phases in the
 /// [`BootstrapPhase`] trait documentation.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct WithApps;
+pub enum WithApps {}
 
 impl sealed::Sealed for WithApps {}
 impl BootstrapPhase for WithApps {
@@ -1288,9 +1405,29 @@ impl BootstrapPhase for WithApps {
     type Config = <WithConfig as BootstrapPhase>::Config;
     type Apps = Vec<Box<dyn App>>;
     type Router = Arc<Router>;
-    type AuthBackend = ();
     #[cfg(feature = "db")]
     type Database = ();
+    type AuthBackend = ();
+}
+
+/// Fourth phase of bootstrapping a Cot project, the with-database phase.
+///
+/// # See also
+///
+/// See the details about the different bootstrap phases in the
+/// [`BootstrapPhase`] trait documentation.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum WithDatabase {}
+
+impl sealed::Sealed for WithDatabase {}
+impl BootstrapPhase for WithDatabase {
+    type RequestHandler = ();
+    type Config = <WithApps as BootstrapPhase>::Config;
+    type Apps = <WithApps as BootstrapPhase>::Apps;
+    type Router = <WithApps as BootstrapPhase>::Router;
+    #[cfg(feature = "db")]
+    type Database = Option<Arc<Database>>;
+    type AuthBackend = <WithApps as BootstrapPhase>::AuthBackend;
 }
 
 /// The final phase of bootstrapping a Cot project, the initialized phase.
@@ -1300,17 +1437,17 @@ impl BootstrapPhase for WithApps {
 /// See the details about the different bootstrap phases in the
 /// [`BootstrapPhase`] trait documentation.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct Initialized;
+pub enum Initialized {}
 
 impl sealed::Sealed for Initialized {}
 impl BootstrapPhase for Initialized {
     type RequestHandler = BoxedHandler;
-    type Config = <WithApps as BootstrapPhase>::Config;
-    type Apps = <WithApps as BootstrapPhase>::Apps;
-    type Router = <WithApps as BootstrapPhase>::Router;
-    type AuthBackend = Box<dyn AuthBackend>;
+    type Config = <WithDatabase as BootstrapPhase>::Config;
+    type Apps = <WithDatabase as BootstrapPhase>::Apps;
+    type Router = <WithDatabase as BootstrapPhase>::Router;
     #[cfg(feature = "db")]
-    type Database = Option<Arc<Database>>;
+    type Database = <WithDatabase as BootstrapPhase>::Database;
+    type AuthBackend = Arc<dyn AuthBackend>;
 }
 
 /// Shared context and configs for all apps. Used in conjunction with the
@@ -1321,10 +1458,10 @@ pub struct ProjectContext<S: BootstrapPhase = Initialized> {
     #[debug("..")]
     apps: S::Apps,
     router: S::Router,
-    #[debug("..")]
-    auth_backend: S::AuthBackend,
     #[cfg(feature = "db")]
     database: S::Database,
+    #[debug("..")]
+    auth_backend: S::AuthBackend,
 }
 
 impl ProjectContext<Uninitialized> {
@@ -1334,9 +1471,9 @@ impl ProjectContext<Uninitialized> {
             config: (),
             apps: (),
             router: (),
-            auth_backend: (),
             #[cfg(feature = "db")]
             database: (),
+            auth_backend: (),
         }
     }
 
@@ -1345,14 +1482,14 @@ impl ProjectContext<Uninitialized> {
             config: Arc::new(config),
             apps: self.apps,
             router: self.router,
-            auth_backend: self.auth_backend,
             #[cfg(feature = "db")]
             database: self.database,
+            auth_backend: self.auth_backend,
         }
     }
 }
 
-impl ProjectContext<WithConfig> {
+impl<S: BootstrapPhase<Config = Arc<ProjectConfig>>> ProjectContext<S> {
     /// Returns the configuration for the project.
     ///
     /// # Examples
@@ -1376,45 +1513,23 @@ impl ProjectContext<WithConfig> {
     pub fn config(&self) -> &ProjectConfig {
         &self.config
     }
+}
 
+impl ProjectContext<WithConfig> {
     #[must_use]
     fn with_apps(self, apps: Vec<Box<dyn App>>, router: Arc<Router>) -> ProjectContext<WithApps> {
         ProjectContext {
             config: self.config,
             apps,
             router,
-            auth_backend: self.auth_backend,
             #[cfg(feature = "db")]
             database: self.database,
+            auth_backend: self.auth_backend,
         }
     }
 }
 
-impl ProjectContext<WithApps> {
-    /// Returns the configuration for the project.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use cot::request::{Request, RequestExt};
-    /// use cot::response::Response;
-    ///
-    /// async fn index(request: Request) -> cot::Result<Response> {
-    ///     let config = request.context().config();
-    ///     // can also be accessed via:
-    ///     let config = request.project_config();
-    ///
-    ///     let db_url = &config.database.url;
-    ///
-    ///     // ...
-    /// #    todo!()
-    /// }
-    /// ```
-    #[must_use]
-    pub fn config(&self) -> &ProjectConfig {
-        &self.config
-    }
-
+impl<S: BootstrapPhase<Apps = Vec<Box<dyn App>>>> ProjectContext<S> {
     /// Returns the apps for the project.
     ///
     /// # Examples
@@ -1434,20 +1549,35 @@ impl ProjectContext<WithApps> {
     pub fn apps(&self) -> &[Box<dyn App>] {
         &self.apps
     }
+}
 
+impl ProjectContext<WithApps> {
     #[must_use]
-    fn with_auth_and_db(
+    fn with_database(
         self,
-        auth_backend: Box<dyn AuthBackend>,
         #[cfg(feature = "db")] database: Option<Arc<Database>>,
-    ) -> ProjectContext<Initialized> {
+    ) -> ProjectContext<WithDatabase> {
+        ProjectContext {
+            config: self.config,
+            apps: self.apps,
+            router: self.router,
+            #[cfg(feature = "db")]
+            database,
+            auth_backend: self.auth_backend,
+        }
+    }
+}
+
+impl ProjectContext<WithDatabase> {
+    #[must_use]
+    fn with_auth(self, auth_backend: Arc<dyn AuthBackend>) -> ProjectContext<Initialized> {
         ProjectContext {
             config: self.config,
             apps: self.apps,
             router: self.router,
             auth_backend,
             #[cfg(feature = "db")]
-            database,
+            database: self.database,
         }
     }
 }
@@ -1464,56 +1594,14 @@ impl ProjectContext<Initialized> {
             config,
             apps,
             router,
-            auth_backend,
             #[cfg(feature = "db")]
             database,
+            auth_backend,
         }
     }
+}
 
-    /// Returns the configuration for the project.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use cot::request::{Request, RequestExt};
-    /// use cot::response::Response;
-    ///
-    /// async fn index(request: Request) -> cot::Result<Response> {
-    ///     let config = request.context().config();
-    ///     // can also be accessed via:
-    ///     let config = request.project_config();
-    ///
-    ///     let db_url = &config.database.url;
-    ///
-    ///     // ...
-    /// #    todo!()
-    /// }
-    /// ```
-    #[must_use]
-    pub fn config(&self) -> &ProjectConfig {
-        &self.config
-    }
-
-    /// Returns the apps for the project.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use cot::request::{Request, RequestExt};
-    /// use cot::response::Response;
-    ///
-    /// async fn index(request: Request) -> cot::Result<Response> {
-    ///     let apps = request.context().apps();
-    ///
-    ///     // ...
-    /// #    todo!()
-    /// }
-    /// ```
-    #[must_use]
-    pub fn apps(&self) -> &[Box<dyn App>] {
-        &self.apps
-    }
-
+impl<S: BootstrapPhase<Router = Arc<Router>>> ProjectContext<S> {
     /// Returns the router for the project.
     ///
     /// # Examples
@@ -1534,10 +1622,11 @@ impl ProjectContext<Initialized> {
     /// }
     /// ```
     #[must_use]
-    pub fn router(&self) -> &Router {
+    pub fn router(&self) -> &Arc<Router> {
         &self.router
     }
-
+}
+impl<S: BootstrapPhase<AuthBackend = Arc<dyn AuthBackend>>> ProjectContext<S> {
     /// Returns the authentication backend for the project.
     ///
     /// # Examples
@@ -1553,10 +1642,13 @@ impl ProjectContext<Initialized> {
     /// }
     /// ```
     #[must_use]
-    pub fn auth_backend(&self) -> &dyn AuthBackend {
-        self.auth_backend.as_ref()
+    pub fn auth_backend(&self) -> &Arc<dyn AuthBackend> {
+        &self.auth_backend
     }
+}
 
+#[cfg(feature = "db")]
+impl<S: BootstrapPhase<Database = Option<Arc<Database>>>> ProjectContext<S> {
     /// Returns the database for the project, if it is enabled.
     ///
     /// # Examples
@@ -1602,9 +1694,10 @@ impl ProjectContext<Initialized> {
     /// #    todo!()
     /// }
     /// ```
-    #[must_use]
     #[cfg(feature = "db")]
-    pub fn database(&self) -> &Database {
+    #[must_use]
+    #[track_caller]
+    pub fn database(&self) -> &Arc<Database> {
         self.try_database().expect(
             "Database missing. Did you forget to add the database when configuring CotProject?",
         )
@@ -1905,7 +1998,6 @@ mod tests {
     use super::*;
     use crate::auth::UserId;
     use crate::config::SecretKey;
-    use crate::test::TestRequestBuilder;
 
     struct TestApp;
 
@@ -1948,7 +2040,7 @@ mod tests {
             fn middlewares(
                 &self,
                 handler: RootHandlerBuilder,
-                context: &ProjectContext<WithApps>,
+                context: &MiddlewareContext,
             ) -> BoxedHandler {
                 handler
                     .middleware(crate::static_files::StaticFilesMiddleware::from_context(
@@ -2011,12 +2103,13 @@ mod tests {
                     .auth_backend(AuthBackendConfig::None)
                     .build(),
             )
-            .with_apps(vec![], Arc::new(Router::empty()));
+            .with_apps(vec![], Arc::new(Router::empty()))
+            .with_database(None);
 
         let auth_backend = TestProject.auth_backend(&context);
         assert!(
             auth_backend
-                .get_by_id(&TestRequestBuilder::get("/").build(), UserId::Int(0))
+                .get_by_id(UserId::Int(0))
                 .await
                 .unwrap()
                 .is_none()

--- a/cot/src/project.rs
+++ b/cot/src/project.rs
@@ -290,8 +290,8 @@ pub trait Project {
     /// # Examples
     ///
     /// ```
-    /// use cot::project::{AppBuilder, WithConfig};
-    /// use cot::{App, Project, ProjectContext};
+    /// use cot::project::{AppBuilder, RegisterAppsContext};
+    /// use cot::{App, Project};
     ///
     /// struct MyApp;
     /// impl App for MyApp {
@@ -302,13 +302,13 @@ pub trait Project {
     ///
     /// struct MyProject;
     /// impl Project for MyProject {
-    ///     fn register_apps(&self, apps: &mut AppBuilder, context: &ProjectContext<WithConfig>) {
+    ///     fn register_apps(&self, apps: &mut AppBuilder, context: &RegisterAppsContext) {
     ///         apps.register(MyApp);
     ///     }
     /// }
     /// ```
     #[allow(unused_variables)]
-    fn register_apps(&self, apps: &mut AppBuilder, context: &ProjectContext<WithConfig>) {}
+    fn register_apps(&self, apps: &mut AppBuilder, context: &RegisterAppsContext) {}
 
     /// Sets the authentication backend to use.
     ///
@@ -332,7 +332,7 @@ pub trait Project {
     ///     }
     /// }
     /// ```
-    fn auth_backend(&self, context: &ProjectContext<WithDatabase>) -> Arc<dyn AuthBackend> {
+    fn auth_backend(&self, context: &AuthBackendContext) -> Arc<dyn AuthBackend> {
         #[allow(trivial_casts)] // cast to Arc<dyn AuthBackend>
         match &context.config().auth_backend {
             AuthBackendConfig::None => Arc::new(NoAuthBackend) as Arc<dyn AuthBackend>,
@@ -597,8 +597,8 @@ where
 /// # Examples
 ///
 /// ```
-/// use cot::project::{AppBuilder, WithConfig};
-/// use cot::{App, Project, ProjectContext};
+/// use cot::project::{AppBuilder, RegisterAppsContext};
+/// use cot::{App, Project};
 ///
 /// struct MyApp;
 /// impl App for MyApp {
@@ -609,7 +609,7 @@ where
 ///
 /// struct MyProject;
 /// impl Project for MyProject {
-///     fn register_apps(&self, apps: &mut AppBuilder, context: &ProjectContext<WithConfig>) {
+///     fn register_apps(&self, apps: &mut AppBuilder, context: &RegisterAppsContext) {
 ///         apps.register(MyApp);
 ///     }
 /// }
@@ -637,7 +637,7 @@ impl AppBuilder {
     /// # Examples
     ///
     /// ```
-    /// use cot::project::WithConfig;
+    /// use cot::project::RegisterAppsContext;
     /// use cot::{App, Project};
     ///
     /// struct HelloApp;
@@ -650,11 +650,7 @@ impl AppBuilder {
     ///
     /// struct HelloProject;
     /// impl Project for HelloProject {
-    ///     fn register_apps(
-    ///         &self,
-    ///         apps: &mut cot::AppBuilder,
-    ///         _context: &cot::ProjectContext<WithConfig>,
-    ///     ) {
+    ///     fn register_apps(&self, apps: &mut cot::AppBuilder, _context: &RegisterAppsContext) {
     ///         apps.register(HelloApp);
     ///     }
     /// }
@@ -671,7 +667,7 @@ impl AppBuilder {
     /// # Examples
     ///
     /// ```
-    /// use cot::project::WithConfig;
+    /// use cot::project::RegisterAppsContext;
     /// use cot::{App, Project};
     ///
     /// struct HelloApp;
@@ -684,11 +680,7 @@ impl AppBuilder {
     ///
     /// struct HelloProject;
     /// impl Project for HelloProject {
-    ///     fn register_apps(
-    ///         &self,
-    ///         apps: &mut cot::AppBuilder,
-    ///         _context: &cot::ProjectContext<WithConfig>,
-    ///     ) {
+    ///     fn register_apps(&self, apps: &mut cot::AppBuilder, _context: &RegisterAppsContext) {
     ///         apps.register_with_views(HelloApp, "/hello");
     ///     }
     /// }
@@ -2121,7 +2113,7 @@ mod tests {
     async fn bootstrapper() {
         struct TestProject;
         impl Project for TestProject {
-            fn register_apps(&self, apps: &mut AppBuilder, _context: &ProjectContext<WithConfig>) {
+            fn register_apps(&self, apps: &mut AppBuilder, _context: &RegisterAppsContext) {
                 apps.register_with_views(TestApp {}, "/app");
             }
         }

--- a/cot/src/request.rs
+++ b/cot/src/request.rs
@@ -737,7 +737,6 @@ mod tests {
     fn request_ext_path_params() {
         let mut request = TestRequestBuilder::get("/").build();
 
-        // Insert path params manually
         let mut params = PathParams::new();
         params.insert("id".to_string(), "42".to_string());
         request.extensions_mut().insert(params);
@@ -749,7 +748,6 @@ mod tests {
     fn request_ext_path_params_mut() {
         let mut request = TestRequestBuilder::get("/").build();
 
-        // Add a param using path_params_mut
         request
             .path_params_mut()
             .insert("id".to_string(), "42".to_string());
@@ -795,7 +793,6 @@ mod tests {
     #[tokio::test]
     async fn request_ext_extract_parts() {
         async fn handler(mut request: Request) -> Result<Response> {
-            // Test extract_parts with Path extractor
             let Path(id): Path<String> = request.extract_parts().await?;
             assert_eq!(id, "42");
 
@@ -808,41 +805,53 @@ mod tests {
             .router(router.clone())
             .build();
 
-        // Test extract_parts with Path extractor
         router.handle(request).await.unwrap();
     }
 
     #[test]
-    fn parts_ext_implementations() {
+    fn parts_ext_path_params() {
         let (mut parts, _) = Request::new(Body::empty()).into_parts();
-
-        // Add path params
         let mut params = PathParams::new();
         params.insert("id".to_string(), "42".to_string());
         parts.extensions.insert(params);
 
-        // Test access to path params
         assert_eq!(parts.path_params().get("id"), Some("42"));
+    }
 
-        // Test mutating path params
+    #[test]
+    fn parts_ext_mutating_path_params() {
+        let (mut parts, _) = Request::new(Body::empty()).into_parts();
         parts
             .path_params_mut()
             .insert("page".to_string(), "1".to_string());
+
         assert_eq!(parts.path_params().get("page"), Some("1"));
+    }
 
-        // Test app name
+    #[test]
+    fn parts_ext_app_name() {
+        let (mut parts, _) = Request::new(Body::empty()).into_parts();
         parts.extensions.insert(AppName("test_app".to_string()));
+
         assert_eq!(parts.app_name(), Some("test_app"));
+    }
 
-        // Test route name
+    #[test]
+    fn parts_ext_route_name() {
+        let (mut parts, _) = Request::new(Body::empty()).into_parts();
         parts.extensions.insert(RouteName("test_route".to_string()));
-        assert_eq!(parts.route_name(), Some("test_route"));
 
-        // Test content type
+        assert_eq!(parts.route_name(), Some("test_route"));
+    }
+
+    #[test]
+    fn parts_ext_content_type() {
+        let (mut parts, _) = Request::new(Body::empty()).into_parts();
         parts.headers.insert(
             http::header::CONTENT_TYPE,
             http::HeaderValue::from_static("text/plain"),
         );
+
         assert_eq!(
             parts.content_type(),
             Some(&http::HeaderValue::from_static("text/plain"))
@@ -853,12 +862,10 @@ mod tests {
     async fn parts_extract_parts() {
         let (mut parts, _) = Request::new(Body::empty()).into_parts();
 
-        // Add path params
         let mut params = PathParams::new();
         params.insert("id".to_string(), "42".to_string());
         parts.extensions.insert(params);
 
-        // Test extract_parts with Path extractor
         let Path(id): Path<String> = parts.extract_parts().await.unwrap();
         assert_eq!(id, "42");
     }

--- a/cot/src/request.rs
+++ b/cot/src/request.rs
@@ -13,23 +13,22 @@
 //! ```
 
 use std::borrow::Cow;
+use std::future::Future;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use bytes::Bytes;
+use http::Extensions;
+use http::request::Parts;
 use indexmap::IndexMap;
-pub use path_params_deserializer::PathParamsDeserializerError;
-use tower_sessions::Session;
 
 #[cfg(feature = "db")]
 use crate::db::Database;
 use crate::error::ErrorRepr;
-use crate::headers::FORM_CONTENT_TYPE;
-#[cfg(feature = "json")]
-use crate::headers::JSON_CONTENT_TYPE;
+use crate::request::extractors::FromRequestParts;
 use crate::router::Router;
 use crate::{Body, Result};
 
+pub mod extractors;
 mod path_params_deserializer;
 
 /// HTTP request type.
@@ -46,8 +45,26 @@ mod private {
 ///
 /// This trait is sealed since it doesn't make sense to be implemented for types
 /// outside the context of Cot.
-#[async_trait]
 pub trait RequestExt: private::Sealed {
+    /// Runs an extractor implementing [`FromRequestParts`] on the request.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cot::request::extractors::Path;
+    /// use cot::request::{Request, RequestExt};
+    /// use cot::response::Response;
+    ///
+    /// async fn my_handler(mut request: Request) -> cot::Result<Response> {
+    ///     let path_params = request.extract_parts::<Path<String>>().await?;
+    ///     // ...
+    ///     # unimplemented!()
+    /// }
+    /// ```
+    fn extract_parts<E>(&mut self) -> impl Future<Output = Result<E>> + Send
+    where
+        E: FromRequestParts + 'static;
+
     /// Get the application context.
     ///
     /// # Examples
@@ -59,7 +76,7 @@ pub trait RequestExt: private::Sealed {
     /// async fn my_handler(mut request: Request) -> cot::Result<Response> {
     ///     let context = request.context();
     ///     // ... do something with the context
-    ///     # todo!()
+    ///     # unimplemented!()
     /// }
     /// ```
     #[must_use]
@@ -76,7 +93,7 @@ pub trait RequestExt: private::Sealed {
     /// async fn my_handler(mut request: Request) -> cot::Result<Response> {
     ///     let config = request.project_config();
     ///     // ... do something with the config
-    ///     # todo!()
+    ///     # unimplemented!()
     /// }
     /// ```
     #[must_use]
@@ -93,13 +110,13 @@ pub trait RequestExt: private::Sealed {
     /// async fn my_handler(mut request: Request) -> cot::Result<Response> {
     ///     let router = request.router();
     ///     // ... do something with the router
-    ///     # todo!()
+    ///     # unimplemented!()
     /// }
     /// ```
     #[must_use]
-    fn router(&self) -> &Router;
+    fn router(&self) -> &Arc<Router>;
 
-    /// Get the app name teh current route belogns to, or [`None`] if the
+    /// Get the app name the current route belongs to, or [`None`] if the
     /// request is not routed.
     ///
     /// This is mainly useful for providing context to reverse redirects, where
@@ -114,7 +131,7 @@ pub trait RequestExt: private::Sealed {
     /// async fn my_handler(mut request: Request) -> cot::Result<Response> {
     ///     let app_name = request.app_name();
     ///     // ... do something with the app name
-    ///     # todo!()
+    ///     # unimplemented!()
     /// }
     /// ```
     fn app_name(&self) -> Option<&str>;
@@ -134,7 +151,7 @@ pub trait RequestExt: private::Sealed {
     /// async fn my_handler(mut request: Request) -> cot::Result<Response> {
     ///     let route_name = request.route_name();
     ///     // ... do something with the route name
-    ///     # todo!()
+    ///     # unimplemented!()
     /// }
     /// ```
     #[must_use]
@@ -151,7 +168,7 @@ pub trait RequestExt: private::Sealed {
     /// async fn my_handler(mut request: Request) -> cot::Result<Response> {
     ///     let path_params = request.path_params();
     ///     // ... do something with the path params
-    ///     # todo!()
+    ///     # unimplemented!()
     /// }
     /// ```
     #[must_use]
@@ -168,7 +185,7 @@ pub trait RequestExt: private::Sealed {
     /// async fn my_handler(mut request: Request) -> cot::Result<Response> {
     ///     let path_params = request.path_params_mut();
     ///     // ... do something with the path params
-    ///     # todo!()
+    ///     # unimplemented!()
     /// }
     /// ```
     #[must_use]
@@ -185,127 +202,12 @@ pub trait RequestExt: private::Sealed {
     /// async fn my_handler(mut request: Request) -> cot::Result<Response> {
     ///     let db = request.db();
     ///     // ... do something with the database
-    ///     # todo!()
+    ///     # unimplemented!()
     /// }
     /// ```
     #[cfg(feature = "db")]
     #[must_use]
-    fn db(&self) -> &Database;
-
-    /// Get the session object.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use cot::request::{Request, RequestExt};
-    /// use cot::response::Response;
-    ///
-    /// async fn hello(request: Request) -> cot::Result<Response> {
-    ///     let name: String = request
-    ///         .session()
-    ///         .get("user_name")
-    ///         .await
-    ///         .expect("Invalid session value")
-    ///         .unwrap_or_default();
-    ///     println!("Hello, {}!", name);
-    ///
-    ///     // ...
-    ///     # todo!()
-    /// }
-    ///
-    /// async fn set_name(mut request: Request) -> cot::Result<Response> {
-    ///     request
-    ///         .session_mut()
-    ///         .insert("user_name", "test_user")
-    ///         .await
-    ///         .unwrap();
-    ///
-    ///     // ...
-    ///     # todo!()
-    /// }
-    /// ```
-    #[must_use]
-    fn session(&self) -> &Session;
-
-    /// Get the session object mutably.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use cot::request::{Request, RequestExt};
-    /// use cot::response::Response;
-    ///
-    /// async fn hello(request: Request) -> cot::Result<Response> {
-    ///     let name: String = request
-    ///         .session()
-    ///         .get("user_name")
-    ///         .await
-    ///         .expect("Invalid session value")
-    ///         .unwrap_or_default();
-    ///     println!("Hello, {}!", name);
-    ///
-    ///     // ...
-    ///     # todo!()
-    /// }
-    ///
-    /// async fn set_name(mut request: Request) -> cot::Result<Response> {
-    ///     request
-    ///         .session_mut()
-    ///         .insert("user_name", "test_user")
-    ///         .await
-    ///         .unwrap();
-    ///
-    ///     // ...
-    ///     # todo!()
-    /// }
-    /// ```
-    #[must_use]
-    fn session_mut(&mut self) -> &mut Session;
-
-    /// Get the request body as bytes. If the request method is GET or HEAD, the
-    /// query string is returned. Otherwise, if the request content type is
-    /// `application/x-www-form-urlencoded`, then the body is read and returned.
-    /// Otherwise, an error is thrown.
-    ///
-    /// # Errors
-    ///
-    /// Throws an error if the request method is not GET or HEAD and the content
-    /// type is not `application/x-www-form-urlencoded`.
-    /// Throws an error if the request body could not be read.
-    async fn form_data(&mut self) -> Result<Bytes>;
-
-    /// Get the request body as JSON and deserialize it into a type `T`
-    /// implementing `serde::de::DeserializeOwned`.
-    ///
-    /// The content type of the request must be `application/json`.
-    ///
-    /// # Errors
-    ///
-    /// Throws an error if the content type is not `application/json`.
-    /// Throws an error if the request body could not be read.
-    /// Throws an error if the request body could not be deserialized - either
-    /// because the JSON is invalid or because the deserialization to the target
-    /// structure failed.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use cot::request::{Request, RequestExt};
-    /// use cot::response::{Response, ResponseExt};
-    /// use serde::{Deserialize, Serialize};
-    ///
-    /// #[derive(Serialize, Deserialize)]
-    /// struct MyData {
-    ///     hello: String,
-    /// }
-    ///
-    /// async fn my_handler(mut request: Request) -> cot::Result<Response> {
-    ///     let data: MyData = request.json().await?;
-    ///     Ok(Response::new_json(cot::StatusCode::OK, &data)?)
-    /// }
-    /// ```
-    #[cfg(feature = "json")]
-    async fn json<T: serde::de::DeserializeOwned>(&mut self) -> Result<T>;
+    fn db(&self) -> &Arc<Database>;
 
     /// Get the content type of the request.
     ///
@@ -318,7 +220,7 @@ pub trait RequestExt: private::Sealed {
     /// async fn my_handler(mut request: Request) -> cot::Result<Response> {
     ///     let content_type = request.content_type();
     ///     // ... do something with the content type
-    ///     # todo!()
+    ///     # unimplemented!()
     /// }
     /// ```
     #[must_use]
@@ -339,16 +241,45 @@ pub trait RequestExt: private::Sealed {
     /// async fn my_handler(mut request: Request) -> cot::Result<Response> {
     ///     request.expect_content_type("application/json")?;
     ///     // ...
-    ///     # todo!()
+    ///     # unimplemented!()
     /// }
     /// ```
-    fn expect_content_type(&mut self, expected: &'static str) -> Result<()>;
+    fn expect_content_type(&mut self, expected: &'static str) -> Result<()> {
+        let content_type = self
+            .content_type()
+            .map_or("".into(), |value| String::from_utf8_lossy(value.as_bytes()));
+        if content_type == expected {
+            Ok(())
+        } else {
+            Err(ErrorRepr::InvalidContentType {
+                expected,
+                actual: content_type.into_owned(),
+            }
+            .into())
+        }
+    }
+
+    #[doc(hidden)]
+    fn extensions(&self) -> &Extensions;
 }
 
 impl private::Sealed for Request {}
 
-#[async_trait]
 impl RequestExt for Request {
+    async fn extract_parts<E>(&mut self) -> Result<E>
+    where
+        E: FromRequestParts + 'static,
+    {
+        let request = std::mem::take(self);
+
+        let (mut parts, body) = request.into_parts();
+        let result = E::from_request_parts(&mut parts).await;
+
+        *self = Request::from_parts(parts, body);
+        result
+    }
+
+    #[track_caller]
     fn context(&self) -> &crate::ProjectContext {
         self.extensions()
             .get::<Arc<crate::ProjectContext>>()
@@ -359,7 +290,7 @@ impl RequestExt for Request {
         self.context().config()
     }
 
-    fn router(&self) -> &Router {
+    fn router(&self) -> &Arc<Router> {
         self.context().router()
     }
 
@@ -375,6 +306,7 @@ impl RequestExt for Request {
             .map(|RouteName(name)| name.as_str())
     }
 
+    #[track_caller]
     fn path_params(&self) -> &PathParams {
         self.extensions()
             .get::<PathParams>()
@@ -386,66 +318,76 @@ impl RequestExt for Request {
     }
 
     #[cfg(feature = "db")]
-    fn db(&self) -> &Database {
+    fn db(&self) -> &Arc<Database> {
         self.context().database()
-    }
-
-    fn session(&self) -> &Session {
-        self.extensions()
-            .get::<Session>()
-            .expect("Session extension missing. Did you forget to add the SessionMiddleware?")
-    }
-
-    fn session_mut(&mut self) -> &mut Session {
-        self.extensions_mut()
-            .get_mut::<Session>()
-            .expect("Session extension missing. Did you forget to add the SessionMiddleware?")
-    }
-
-    async fn form_data(&mut self) -> Result<Bytes> {
-        if self.method() == http::Method::GET || self.method() == http::Method::HEAD {
-            if let Some(query) = self.uri().query() {
-                return Ok(Bytes::copy_from_slice(query.as_bytes()));
-            }
-
-            Ok(Bytes::new())
-        } else {
-            self.expect_content_type(FORM_CONTENT_TYPE)?;
-
-            let body = std::mem::take(self.body_mut());
-            let bytes = body.into_bytes().await?;
-
-            Ok(bytes)
-        }
-    }
-
-    #[cfg(feature = "json")]
-    async fn json<T: serde::de::DeserializeOwned>(&mut self) -> Result<T> {
-        self.expect_content_type(JSON_CONTENT_TYPE)?;
-
-        let body = std::mem::take(self.body_mut());
-        let bytes = body.into_bytes().await?;
-
-        Ok(serde_json::from_slice(&bytes)?)
     }
 
     fn content_type(&self) -> Option<&http::HeaderValue> {
         self.headers().get(http::header::CONTENT_TYPE)
     }
 
-    fn expect_content_type(&mut self, expected: &'static str) -> Result<()> {
-        let content_type = self
-            .content_type()
-            .map_or("".into(), |value| String::from_utf8_lossy(value.as_bytes()));
-        if content_type == expected {
-            Ok(())
-        } else {
-            Err(ErrorRepr::InvalidContentType {
-                expected,
-                actual: content_type.into_owned(),
-            }
-            .into())
-        }
+    fn extensions(&self) -> &Extensions {
+        self.extensions()
+    }
+}
+
+impl private::Sealed for Parts {}
+
+impl RequestExt for Parts {
+    async fn extract_parts<E>(&mut self) -> Result<E>
+    where
+        E: FromRequestParts + 'static,
+    {
+        E::from_request_parts(self).await
+    }
+
+    fn context(&self) -> &crate::ProjectContext {
+        self.extensions
+            .get::<Arc<crate::ProjectContext>>()
+            .expect("AppContext extension missing")
+    }
+
+    fn project_config(&self) -> &crate::config::ProjectConfig {
+        self.context().config()
+    }
+
+    fn router(&self) -> &Arc<Router> {
+        self.context().router()
+    }
+
+    fn app_name(&self) -> Option<&str> {
+        self.extensions
+            .get::<AppName>()
+            .map(|AppName(name)| name.as_str())
+    }
+
+    fn route_name(&self) -> Option<&str> {
+        self.extensions
+            .get::<RouteName>()
+            .map(|RouteName(name)| name.as_str())
+    }
+
+    fn path_params(&self) -> &PathParams {
+        self.extensions
+            .get::<PathParams>()
+            .expect("PathParams extension missing")
+    }
+
+    fn path_params_mut(&mut self) -> &mut PathParams {
+        self.extensions.get_or_insert_default::<PathParams>()
+    }
+
+    #[cfg(feature = "db")]
+    fn db(&self) -> &Arc<Database> {
+        self.context().database()
+    }
+
+    fn content_type(&self) -> Option<&http::HeaderValue> {
+        self.headers.get(http::header::CONTENT_TYPE)
+    }
+
+    fn extensions(&self) -> &Extensions {
+        &self.extensions
     }
 }
 
@@ -470,7 +412,6 @@ pub(crate) struct RouteName(pub(crate) String);
 /// ```
 /// use cot::request::{PathParams, Request, RequestExt};
 /// use cot::response::Response;
-/// ///
 /// use cot::test::TestRequestBuilder;
 ///
 /// async fn my_handler(mut request: Request) -> cot::Result<Response> {
@@ -690,9 +631,19 @@ impl PathParams {
     pub fn parse<'de, T: serde::Deserialize<'de>>(
         &'de self,
     ) -> std::result::Result<T, PathParamsDeserializerError> {
-        T::deserialize(path_params_deserializer::PathParamsDeserializer::new(self))
+        let deserializer = path_params_deserializer::PathParamsDeserializer::new(self);
+        serde_path_to_error::deserialize(deserializer).map_err(PathParamsDeserializerError)
     }
 }
+
+/// An error that occurs when deserializing path parameters.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{0}")]
+pub struct PathParamsDeserializerError(
+    // A wrapper over the original deserializer error. The exact error reason
+    // shouldn't be useful to the user, hence we're not exposing it.
+    #[source] serde_path_to_error::Error<path_params_deserializer::PathParamsDeserializerError>,
+);
 
 pub(crate) fn query_pairs(bytes: &Bytes) -> impl Iterator<Item = (Cow<'_, str>, Cow<'_, str>)> {
     form_urlencoded::parse(bytes.as_ref())
@@ -701,31 +652,10 @@ pub(crate) fn query_pairs(bytes: &Bytes) -> impl Iterator<Item = (Cow<'_, str>, 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[cot::test]
-    async fn form_data() {
-        let mut request = http::Request::builder()
-            .method(http::Method::POST)
-            .header(http::header::CONTENT_TYPE, FORM_CONTENT_TYPE)
-            .body(Body::fixed("hello=world"))
-            .unwrap();
-
-        let bytes = request.form_data().await.unwrap();
-        assert_eq!(bytes, Bytes::from_static(b"hello=world"));
-    }
-
-    #[cfg(feature = "json")]
-    #[cot::test]
-    async fn json() {
-        let mut request = http::Request::builder()
-            .method(http::Method::POST)
-            .header(http::header::CONTENT_TYPE, JSON_CONTENT_TYPE)
-            .body(Body::fixed(r#"{"hello":"world"}"#))
-            .unwrap();
-
-        let data: serde_json::Value = request.json().await.unwrap();
-        assert_eq!(data, serde_json::json!({"hello": "world"}));
-    }
+    use crate::request::extractors::Path;
+    use crate::response::Response;
+    use crate::router::{Route, Router};
+    use crate::test::TestRequestBuilder;
 
     #[test]
     fn path_params() {
@@ -769,5 +699,167 @@ mod tests {
                 (Cow::from("foo"), Cow::from("bar"))
             ]
         );
+    }
+
+    #[test]
+    fn request_ext_app_name() {
+        let mut request = TestRequestBuilder::get("/").build();
+        assert_eq!(request.app_name(), None);
+
+        request
+            .extensions_mut()
+            .insert(AppName("test_app".to_string()));
+        assert_eq!(request.app_name(), Some("test_app"));
+    }
+
+    #[test]
+    fn request_ext_route_name() {
+        let mut request = TestRequestBuilder::get("/").build();
+        assert_eq!(request.route_name(), None);
+
+        request
+            .extensions_mut()
+            .insert(RouteName("test_route".to_string()));
+        assert_eq!(request.route_name(), Some("test_route"));
+    }
+
+    #[test]
+    fn request_ext_parts_route_name() {
+        let request = TestRequestBuilder::get("/").build();
+        let (mut parts, _body) = request.into_parts();
+        assert_eq!(parts.route_name(), None);
+
+        parts.extensions.insert(RouteName("test_route".to_string()));
+        assert_eq!(parts.route_name(), Some("test_route"));
+    }
+
+    #[test]
+    fn request_ext_path_params() {
+        let mut request = TestRequestBuilder::get("/").build();
+
+        // Insert path params manually
+        let mut params = PathParams::new();
+        params.insert("id".to_string(), "42".to_string());
+        request.extensions_mut().insert(params);
+
+        assert_eq!(request.path_params().get("id"), Some("42"));
+    }
+
+    #[test]
+    fn request_ext_path_params_mut() {
+        let mut request = TestRequestBuilder::get("/").build();
+
+        // Add a param using path_params_mut
+        request
+            .path_params_mut()
+            .insert("id".to_string(), "42".to_string());
+
+        assert_eq!(request.path_params().get("id"), Some("42"));
+    }
+
+    #[test]
+    fn request_ext_content_type() {
+        let mut request = TestRequestBuilder::get("/").build();
+        assert_eq!(request.content_type(), None);
+
+        request.headers_mut().insert(
+            http::header::CONTENT_TYPE,
+            http::HeaderValue::from_static("text/plain"),
+        );
+
+        assert_eq!(
+            request.content_type(),
+            Some(&http::HeaderValue::from_static("text/plain"))
+        );
+    }
+
+    #[test]
+    fn request_ext_expect_content_type() {
+        let mut request = TestRequestBuilder::get("/").build();
+
+        // Should fail with no content type
+        assert!(request.expect_content_type("text/plain").is_err());
+
+        request.headers_mut().insert(
+            http::header::CONTENT_TYPE,
+            http::HeaderValue::from_static("text/plain"),
+        );
+
+        // Should succeed with matching content type
+        assert!(request.expect_content_type("text/plain").is_ok());
+
+        // Should fail with non-matching content type
+        assert!(request.expect_content_type("application/json").is_err());
+    }
+
+    #[tokio::test]
+    async fn request_ext_extract_parts() {
+        async fn handler(mut request: Request) -> Result<Response> {
+            // Test extract_parts with Path extractor
+            let Path(id): Path<String> = request.extract_parts().await?;
+            assert_eq!(id, "42");
+
+            Ok(Response::new(Body::empty()))
+        }
+
+        let router = Router::with_urls([Route::with_handler("/{id}/", handler)]);
+
+        let request = TestRequestBuilder::get("/42/")
+            .router(router.clone())
+            .build();
+
+        // Test extract_parts with Path extractor
+        router.handle(request).await.unwrap();
+    }
+
+    #[test]
+    fn parts_ext_implementations() {
+        let (mut parts, _) = Request::new(Body::empty()).into_parts();
+
+        // Add path params
+        let mut params = PathParams::new();
+        params.insert("id".to_string(), "42".to_string());
+        parts.extensions.insert(params);
+
+        // Test access to path params
+        assert_eq!(parts.path_params().get("id"), Some("42"));
+
+        // Test mutating path params
+        parts
+            .path_params_mut()
+            .insert("page".to_string(), "1".to_string());
+        assert_eq!(parts.path_params().get("page"), Some("1"));
+
+        // Test app name
+        parts.extensions.insert(AppName("test_app".to_string()));
+        assert_eq!(parts.app_name(), Some("test_app"));
+
+        // Test route name
+        parts.extensions.insert(RouteName("test_route".to_string()));
+        assert_eq!(parts.route_name(), Some("test_route"));
+
+        // Test content type
+        parts.headers.insert(
+            http::header::CONTENT_TYPE,
+            http::HeaderValue::from_static("text/plain"),
+        );
+        assert_eq!(
+            parts.content_type(),
+            Some(&http::HeaderValue::from_static("text/plain"))
+        );
+    }
+
+    #[tokio::test]
+    async fn parts_extract_parts() {
+        let (mut parts, _) = Request::new(Body::empty()).into_parts();
+
+        // Add path params
+        let mut params = PathParams::new();
+        params.insert("id".to_string(), "42".to_string());
+        parts.extensions.insert(params);
+
+        // Test extract_parts with Path extractor
+        let Path(id): Path<String> = parts.extract_parts().await.unwrap();
+        assert_eq!(id, "42");
     }
 }

--- a/cot/src/request/extractors.rs
+++ b/cot/src/request/extractors.rs
@@ -553,6 +553,8 @@ mod tests {
 
     #[cfg(feature = "db")]
     #[cot::test]
+    // unsupported operation: can't call foreign function `sqlite3_open_v2` on OS `linux`
+    #[cfg_attr(miri, ignore)]
     async fn request_db() {
         let db = crate::test::TestDatabase::new_sqlite().await.unwrap();
         let mut test_request = TestRequestBuilder::get("/").database(db.database()).build();

--- a/cot/src/request/extractors.rs
+++ b/cot/src/request/extractors.rs
@@ -458,7 +458,7 @@ mod tests {
         let request = http::Request::builder()
             .method(http::Method::POST)
             .header(http::header::CONTENT_TYPE, cot::headers::JSON_CONTENT_TYPE)
-            .body(Body::fixed(r#"{}"#))
+            .body(Body::fixed("{}"))
             .unwrap();
 
         let Json(data): Json<TestData> = Json::from_request(request).await.unwrap();

--- a/cot/src/request/extractors.rs
+++ b/cot/src/request/extractors.rs
@@ -1,0 +1,565 @@
+//! Extractors for request data.
+//!
+//! An extractor is a function that extracts data as a request. The main benefit
+//! of using an extractor is that it can be used directly as a parameter in a
+//! route handler.
+//!
+//! An extractor implements either [`FromRequest`] or [`FromRequestParts`].
+//! There are two variants because the request body can only be read once, so it
+//! needs to be read in the [`FromRequest`] implementation. Therefore, there can
+//! only be one extractor that implements [`FromRequest`] per route handler.
+//!
+//! # Examples
+//!
+//! For example, the [`Path`] extractor is used to extract path parameters:
+//!
+//! ```
+//! use cot::request::extractors::{FromRequest, Path};
+//! use cot::request::{Request, RequestExt};
+//! use cot::response::{Response, ResponseExt};
+//! use cot::router::{Route, Router};
+//! use cot::test::TestRequestBuilder;
+//! use cot::{Body, RequestHandler};
+//!
+//! async fn my_handler(Path(my_param): Path<String>) -> cot::Result<Response> {
+//!     Ok(Response::new_html(
+//!         cot::StatusCode::OK,
+//!         Body::fixed(format!("Hello {my_param}!")),
+//!     ))
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> cot::Result<()> {
+//! let router = Router::with_urls([Route::with_handler_and_name(
+//!     "/{my_param}/",
+//!     my_handler,
+//!     "home",
+//! )]);
+//! let request = TestRequestBuilder::get("/world/")
+//!     .router(router.clone())
+//!     .build();
+//!
+//! assert_eq!(
+//!     router
+//!         .handle(request)
+//!         .await?
+//!         .into_body()
+//!         .into_bytes()
+//!         .await?,
+//!     "Hello world!"
+//! );
+//! # Ok(())
+//! # }
+//! ```
+
+use std::future::Future;
+
+use cot::Error;
+use cot::error::ErrorRepr;
+use cot::request::{PathParams, Request};
+use http::request::Parts;
+use serde::de::DeserializeOwned;
+
+use crate::auth::Auth;
+use crate::form::{Form, FormResult};
+use crate::request::RequestExt;
+use crate::router::Urls;
+use crate::session::Session;
+
+/// Trait for extractors that consume the request body.
+///
+/// Extractors implementing this trait are used in route handlers that consume
+/// the request body and therefore can only be used once per request.
+///
+/// See [`crate::request::extractors`] documentation for more information about
+/// extractors.
+pub trait FromRequest: Sized {
+    /// Extracts data from the request.
+    ///
+    /// # Errors
+    ///
+    /// Throws an error if the extractor fails to extract the data from the
+    /// request.
+    fn from_request(request: Request) -> impl Future<Output = cot::Result<Self>> + Send;
+}
+
+impl FromRequest for Request {
+    async fn from_request(request: Request) -> cot::Result<Self> {
+        Ok(request)
+    }
+}
+
+/// Trait for extractors that don't consume the request body.
+///
+/// Extractors implementing this trait are used in route handlers that don't
+/// consume the request and therefore can be used multiple times per request.
+///
+/// If you need to consume the body of the request, use [`FromRequest`] instead.
+///
+/// See [`crate::request::extractors`] documentation for more information about
+/// extractors.
+pub trait FromRequestParts: Sized {
+    /// Extracts data from the request parts.
+    ///
+    /// # Errors
+    ///
+    /// Throws an error if the extractor fails to extract the data from the
+    /// request parts.
+    fn from_request_parts(parts: &mut Parts) -> impl Future<Output = cot::Result<Self>> + Send;
+}
+
+impl FromRequestParts for Urls {
+    async fn from_request_parts(parts: &mut Parts) -> cot::Result<Self> {
+        Ok(Self::from_parts(parts))
+    }
+}
+
+/// An extractor that extract data from the URL params.
+///
+/// The extractor is generic over a type that implements
+/// `serde::de::DeserializeOwned`.
+///
+/// # Examples
+///
+/// ```
+/// use cot::request::extractors::{FromRequest, Path};
+/// use cot::request::{Request, RequestExt};
+/// use cot::response::{Response, ResponseExt};
+/// use cot::router::{Route, Router};
+/// use cot::test::TestRequestBuilder;
+/// use cot::{Body, RequestHandler};
+///
+/// async fn my_handler(Path(my_param): Path<String>) -> cot::Result<Response> {
+///     Ok(Response::new_html(
+///         cot::StatusCode::OK,
+///         Body::fixed(format!("Hello {my_param}!")),
+///     ))
+/// }
+///
+/// # #[tokio::main]
+/// # async fn main() -> cot::Result<()> {
+/// let router = Router::with_urls([Route::with_handler_and_name(
+///     "/{my_param}/",
+///     my_handler,
+///     "home",
+/// )]);
+/// let request = TestRequestBuilder::get("/world/")
+///     .router(router.clone())
+///     .build();
+///
+/// assert_eq!(
+///     router
+///         .handle(request)
+///         .await?
+///         .into_body()
+///         .into_bytes()
+///         .await?,
+///     "Hello world!"
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Path<D>(pub D);
+
+impl<D: DeserializeOwned> FromRequestParts for Path<D> {
+    async fn from_request_parts(parts: &mut Parts) -> cot::Result<Self> {
+        let params = parts
+            .extensions
+            .get::<PathParams>()
+            .expect("PathParams extension missing")
+            .parse()
+            .map_err(|error| Error::new(ErrorRepr::PathParametersParse(error)))?;
+        Ok(Self(params))
+    }
+}
+
+/// An extractor that extracts data from the URL query parameters.
+///
+/// The extractor is generic over a type that implements
+/// `serde::de::DeserializeOwned`.
+///
+/// # Example
+///
+/// ```
+/// use cot::request::extractors::{FromRequest, UrlQuery};
+/// use cot::request::{Request, RequestExt};
+/// use cot::response::{Response, ResponseExt};
+/// use cot::router::{Route, Router};
+/// use cot::test::TestRequestBuilder;
+/// use cot::{Body, RequestHandler};
+/// use serde::Deserialize;
+///
+/// #[derive(Deserialize)]
+/// struct MyQuery {
+///     hello: String,
+/// }
+///
+/// async fn my_handler(UrlQuery(query): UrlQuery<MyQuery>) -> cot::Result<Response> {
+///     Ok(Response::new_html(
+///         cot::StatusCode::OK,
+///         Body::fixed(format!("Hello {}!", query.hello)),
+///     ))
+/// }
+///
+/// # #[tokio::main]
+/// # async fn main() -> cot::Result<()> {
+/// let request = TestRequestBuilder::get("/?hello=world").build();
+///
+/// assert_eq!(
+///     my_handler
+///         .handle(request)
+///         .await?
+///         .into_body()
+///         .into_bytes()
+///         .await?,
+///     "Hello world!"
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UrlQuery<T>(pub T);
+
+impl<D: DeserializeOwned> FromRequestParts for UrlQuery<D>
+where
+    D: DeserializeOwned,
+{
+    async fn from_request_parts(parts: &mut Parts) -> cot::Result<Self> {
+        let query = parts.uri.query().unwrap_or_default();
+
+        let deserializer =
+            serde_html_form::Deserializer::new(form_urlencoded::parse(query.as_bytes()));
+
+        let value = serde_path_to_error::deserialize(deserializer)
+            .map_err(|error| Error::new(ErrorRepr::QueryParametersParse(error)))?;
+
+        Ok(UrlQuery(value))
+    }
+}
+
+/// Extractor that gets the request body as JSON and deserializes it into a type
+/// `T` implementing `serde::de::DeserializeOwned`.
+///
+/// The content type of the request must be `application/json`.
+///
+/// # Errors
+///
+/// Throws an error if the content type is not `application/json`.
+/// Throws an error if the request body could not be read.
+/// Throws an error if the request body could not be deserialized - either
+/// because the JSON is invalid or because the deserialization to the target
+/// structure failed.
+///
+/// # Example
+///
+/// ```
+/// use cot::RequestHandler;
+/// use cot::request::extractors::Json;
+/// use cot::request::{Request, RequestExt};
+/// use cot::response::{Response, ResponseExt};
+/// use cot::test::TestRequestBuilder;
+/// use serde::{Deserialize, Serialize};
+///
+/// #[derive(Serialize, Deserialize)]
+/// struct MyData {
+///     hello: String,
+/// }
+///
+/// async fn my_handler(Json(data): Json<MyData>) -> cot::Result<Response> {
+///     Ok(Response::new_json(cot::StatusCode::OK, &data)?)
+/// }
+///
+/// # #[tokio::main]
+/// # async fn main() -> cot::Result<()> {
+/// let request = TestRequestBuilder::get("/")
+///     .json(&MyData {
+///         hello: "world".to_string(),
+///     })
+///     .build();
+///
+/// assert_eq!(
+///     my_handler
+///         .handle(request)
+///         .await?
+///         .into_body()
+///         .into_bytes()
+///         .await?,
+///     "{\"hello\":\"world\"}"
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[cfg(feature = "json")]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Json<D>(pub D);
+
+#[cfg(feature = "json")]
+impl<D: DeserializeOwned> FromRequest for Json<D> {
+    async fn from_request(mut request: Request) -> cot::Result<Self> {
+        request.expect_content_type(cot::headers::JSON_CONTENT_TYPE)?;
+
+        let body = std::mem::take(request.body_mut());
+        let bytes = body.into_bytes().await?;
+
+        let deserializer = &mut serde_json::Deserializer::from_slice(&bytes);
+        let result = serde_path_to_error::deserialize(deserializer)
+            .map_err(|error| Error::new(ErrorRepr::Json(error)))?;
+
+        Ok(Self(result))
+    }
+}
+
+/// An extractor that gets the request body as form data and deserializes it
+/// into a type `F` implementing `cot::form::Form`.
+///
+/// The content type of the request must be `application/x-www-form-urlencoded`.
+///
+/// # Errors
+///
+/// Throws an error if the content type is not
+/// `application/x-www-form-urlencoded`. Throws an error if the request body
+/// could not be read. Throws an error if the request body could not be
+/// deserialized - either because the form data is invalid or because the
+/// deserialization to the target structure failed.
+///
+/// # Example
+///
+/// ```
+/// use cot::form::{Form, FormResult};
+/// use cot::request::extractors::RequestForm;
+/// use cot::request::{Request, RequestExt};
+/// use cot::response::{Response, ResponseExt};
+/// use cot::test::TestRequestBuilder;
+/// use cot::{Body, RequestHandler};
+/// use serde::Deserialize;
+///
+/// #[derive(Form)]
+/// struct MyForm {
+///     hello: String,
+/// }
+///
+/// async fn my_handler(RequestForm(form): RequestForm<MyForm>) -> cot::Result<Response> {
+///     let form = match form {
+///         FormResult::Ok(form) => form,
+///         FormResult::ValidationError(error) => {
+///             panic!("Form validation error!")
+///         }
+///     };
+///
+///     Ok(Response::new_html(
+///         cot::StatusCode::OK,
+///         Body::fixed(format!("Hello {}!", form.hello)),
+///     ))
+/// }
+///
+/// # #[tokio::main]
+/// # async fn main() -> cot::Result<()> {
+/// # let request = TestRequestBuilder::post("/").form_data(&[("hello", "world")]).build();
+/// # my_handler.handle(request).await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug)]
+pub struct RequestForm<F: Form>(pub FormResult<F>);
+
+impl<F: Form> FromRequest for RequestForm<F> {
+    async fn from_request(mut request: Request) -> cot::Result<Self> {
+        Ok(Self(F::from_request(&mut request).await?))
+    }
+}
+
+impl FromRequestParts for Session {
+    async fn from_request_parts(parts: &mut Parts) -> cot::Result<Self> {
+        Ok(Session::from_extensions(&parts.extensions).clone())
+    }
+}
+
+/// An extractor that gets the database from the request extensions.
+///
+/// # Example
+///
+/// ```
+/// use cot::request::extractors::RequestDb;
+/// use cot::request::{Request, RequestExt};
+/// use cot::response::{Response, ResponseExt};
+/// use cot::test::{TestDatabase, TestRequestBuilder};
+/// use cot::{Body, RequestHandler};
+///
+/// async fn my_handler(RequestDb(db): RequestDb) -> cot::Result<Response> {
+///     // ... do something with the database
+///     # db.close().await?;
+///     # Ok(Response::new_html(cot::StatusCode::OK, Body::empty()))
+/// }
+///
+/// # #[tokio::main]
+/// # async fn main() -> cot::Result<()> {
+/// # let request = TestRequestBuilder::get("/")
+/// #     .database(TestDatabase::new_sqlite().await?.database())
+/// #     .build();
+/// # my_handler.handle(request).await?;
+/// # Ok(())
+/// # }
+/// ```
+#[cfg(feature = "db")]
+#[derive(Debug)]
+pub struct RequestDb(pub std::sync::Arc<crate::db::Database>);
+
+#[cfg(feature = "db")]
+impl FromRequestParts for RequestDb {
+    async fn from_request_parts(parts: &mut Parts) -> cot::Result<Self> {
+        Ok(Self(parts.db().clone()))
+    }
+}
+
+impl FromRequestParts for Auth {
+    async fn from_request_parts(parts: &mut Parts) -> cot::Result<Self> {
+        let auth = parts
+            .extensions
+            .get::<Auth>()
+            .expect("Auth extension missing. Did you forget to add the AuthMiddleware?")
+            .clone();
+
+        Ok(auth)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+
+    use super::*;
+    use crate::request::extractors::{FromRequest, Json, Path, UrlQuery};
+    use crate::response::{Response, ResponseExt};
+    use crate::router::{Route, Router, Urls};
+    use crate::test::TestRequestBuilder;
+    use crate::{Body, reverse};
+
+    #[cfg(feature = "json")]
+    #[cot::test]
+    async fn json() {
+        let request = http::Request::builder()
+            .method(http::Method::POST)
+            .header(http::header::CONTENT_TYPE, cot::headers::JSON_CONTENT_TYPE)
+            .body(Body::fixed(r#"{"hello":"world"}"#))
+            .unwrap();
+
+        let Json(data): Json<serde_json::Value> = Json::from_request(request).await.unwrap();
+        assert_eq!(data, serde_json::json!({"hello": "world"}));
+    }
+
+    #[cot::test]
+    async fn path_extraction() {
+        #[derive(Deserialize, Debug, PartialEq)]
+        struct TestParams {
+            id: i32,
+            name: String,
+        }
+
+        let (mut parts, _body) = Request::new(Body::empty()).into_parts();
+
+        let mut params = PathParams::new();
+        params.insert("id".to_string(), "42".to_string());
+        params.insert("name".to_string(), "test".to_string());
+        parts.extensions.insert(params);
+
+        let Path(extracted): Path<TestParams> = Path::from_request_parts(&mut parts).await.unwrap();
+        let expected = TestParams {
+            id: 42,
+            name: "test".to_string(),
+        };
+
+        assert_eq!(extracted, expected);
+    }
+
+    #[cot::test]
+    async fn url_query_extraction() {
+        #[derive(Deserialize, Debug, PartialEq)]
+        struct QueryParams {
+            page: i32,
+            filter: String,
+        }
+
+        let (mut parts, _body) = Request::new(Body::empty()).into_parts();
+        parts.uri = "https://example.com/?page=2&filter=active".parse().unwrap();
+
+        let UrlQuery(query): UrlQuery<QueryParams> =
+            UrlQuery::from_request_parts(&mut parts).await.unwrap();
+
+        assert_eq!(query.page, 2);
+        assert_eq!(query.filter, "active");
+    }
+
+    #[cot::test]
+    async fn empty_url_query() {
+        #[derive(Deserialize, Debug, PartialEq)]
+        struct EmptyParams {}
+
+        let (mut parts, _body) = Request::new(Body::empty()).into_parts();
+        parts.uri = "https://example.com/".parse().unwrap();
+
+        let result: UrlQuery<EmptyParams> = UrlQuery::from_request_parts(&mut parts).await.unwrap();
+        assert!(matches!(result, UrlQuery(_)));
+    }
+
+    #[cfg(feature = "json")]
+    #[cot::test]
+    async fn json_invalid_content_type() {
+        let request = http::Request::builder()
+            .method(http::Method::POST)
+            .header(http::header::CONTENT_TYPE, "text/plain")
+            .body(Body::fixed(r#"{"hello":"world"}"#))
+            .unwrap();
+
+        let result = Json::<serde_json::Value>::from_request(request).await;
+        assert!(result.is_err());
+    }
+
+    #[cot::test]
+    async fn request_form() {
+        #[derive(Form)]
+        struct MyForm {
+            hello: String,
+        }
+
+        let request = TestRequestBuilder::post("/")
+            .form_data(&[("hello", "world")])
+            .build();
+
+        let RequestForm(form_result): RequestForm<MyForm> =
+            RequestForm::from_request(request).await.unwrap();
+
+        assert_eq!(form_result.unwrap().hello, "world");
+    }
+
+    #[cot::test]
+    async fn urls_extraction() {
+        async fn handler() -> cot::Result<Response> {
+            Ok(Response::new_html(cot::StatusCode::OK, Body::empty()))
+        }
+
+        let router = Router::with_urls([Route::with_handler_and_name(
+            "/test/",
+            handler,
+            "test_route",
+        )]);
+
+        let mut request = TestRequestBuilder::get("/test/").router(router).build();
+
+        let urls: Urls = request.extract_parts().await.unwrap();
+
+        assert!(reverse!(urls, "test_route").is_ok());
+    }
+
+    #[cfg(feature = "db")]
+    #[cot::test]
+    async fn request_db() {
+        let db = crate::test::TestDatabase::new_sqlite().await.unwrap();
+        let mut test_request = TestRequestBuilder::get("/").database(db.database()).build();
+
+        let RequestDb(extracted_db) = test_request.extract_parts().await.unwrap();
+
+        // check that we have a connection to the database
+        extracted_db.close().await.unwrap();
+    }
+}

--- a/cot/src/request/path_params_deserializer.rs
+++ b/cot/src/request/path_params_deserializer.rs
@@ -8,7 +8,7 @@ use crate::request::PathParams;
 
 /// An error that occurs when deserializing path parameters.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Error)]
-pub enum PathParamsDeserializerError {
+pub(super) enum PathParamsDeserializerError {
     /// Invalid number of path parameters
     #[error("Invalid number of path parameters: expected {expected}, got {actual}")]
     InvalidParamNumber {

--- a/cot/src/response.rs
+++ b/cot/src/response.rs
@@ -141,7 +141,10 @@ impl ResponseExt for Response {
 
     #[cfg(feature = "json")]
     fn new_json<T: ?Sized + serde::Serialize>(status: StatusCode, data: &T) -> crate::Result<Self> {
-        let mut buf = Vec::with_capacity(128);
+        // a "reasonable default" for a JSON response size
+        const DEFAULT_JSON_SIZE: usize = 128;
+
+        let mut buf = Vec::with_capacity(DEFAULT_JSON_SIZE);
         let mut serializer = serde_json::Serializer::new(&mut buf);
         serde_path_to_error::serialize(data, &mut serializer)
             .map_err(|error| crate::Error::new(crate::error::ErrorRepr::Json(error)))?;

--- a/cot/src/response.rs
+++ b/cot/src/response.rs
@@ -13,8 +13,8 @@
 //! ```
 
 use bytes::Bytes;
-use cot::error_page::ErrorPageTrigger;
 
+use crate::error_page::ErrorPageTrigger;
 use crate::headers::HTML_CONTENT_TYPE;
 #[cfg(feature = "json")]
 use crate::headers::JSON_CONTENT_TYPE;
@@ -141,10 +141,16 @@ impl ResponseExt for Response {
 
     #[cfg(feature = "json")]
     fn new_json<T: ?Sized + serde::Serialize>(status: StatusCode, data: &T) -> crate::Result<Self> {
+        let mut buf = Vec::with_capacity(128);
+        let mut serializer = serde_json::Serializer::new(&mut buf);
+        serde_path_to_error::serialize(data, &mut serializer)
+            .map_err(|error| crate::Error::new(crate::error::ErrorRepr::Json(error)))?;
+        let data = String::from_utf8(buf).expect("JSON serialization always returns valid UTF-8");
+
         Ok(http::Response::builder()
             .status(status)
             .header(http::header::CONTENT_TYPE, JSON_CONTENT_TYPE)
-            .body(Body::fixed(serde_json::to_string(data)?))
+            .body(Body::fixed(data))
             .expect(RESPONSE_BUILD_FAILURE))
     }
 

--- a/cot/src/router.rs
+++ b/cot/src/router.rs
@@ -601,11 +601,11 @@ enum RouteInner {
 /// # Examples
 ///
 /// ```
-/// use cot::project::WithConfig;
+/// use cot::project::RegisterAppsContext;
 /// use cot::request::Request;
 /// use cot::response::{Response, ResponseExt};
 /// use cot::router::{Route, Router};
-/// use cot::{App, AppBuilder, Body, Project, ProjectContext, StatusCode, reverse};
+/// use cot::{App, AppBuilder, Body, Project, StatusCode, reverse};
 ///
 /// async fn home(request: Request) -> cot::Result<Response> {
 ///     // any of below two lines returns the same:
@@ -635,7 +635,7 @@ enum RouteInner {
 /// struct MyProject;
 ///
 /// impl Project for MyProject {
-///     fn register_apps(&self, apps: &mut AppBuilder, context: &ProjectContext<WithConfig>) {
+///     fn register_apps(&self, apps: &mut AppBuilder, context: &RegisterAppsContext) {
 ///         apps.register_with_views(MyApp, "");
 ///     }
 /// }

--- a/cot/src/router.rs
+++ b/cot/src/router.rs
@@ -28,11 +28,12 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use derive_more::with_trait::Debug;
+use http::request::Parts;
 use tracing::debug;
 
 use crate::error::ErrorRepr;
-use crate::handler::RequestHandler;
-use crate::request::{AppName, PathParams, Request, RouteName};
+use crate::handler::{BoxRequestHandler, RequestHandler, into_box_request_handler};
+use crate::request::{AppName, PathParams, Request, RequestExt, RouteName};
 use crate::response::{Response, not_found_response};
 use crate::router::path::{CaptureResult, PathMatcher, ReverseParamMap};
 use crate::{Error, Result};
@@ -336,7 +337,7 @@ impl Default for Router {
 #[derive(Debug)]
 struct HandlerFound<'a> {
     #[debug("handler(...)")]
-    handler: &'a (dyn RequestHandler + Send + Sync),
+    handler: &'a (dyn BoxRequestHandler + Send + Sync),
     app_name: Option<AppName>,
     name: Option<RouteName>,
     params: Vec<(String, String)>,
@@ -445,10 +446,14 @@ impl Route {
     /// let route = Route::with_handler("/", home);
     /// ```
     #[must_use]
-    pub fn with_handler<V: RequestHandler + Send + Sync + 'static>(url: &str, view: V) -> Self {
+    pub fn with_handler<HandlerParams, H>(url: &str, handler: H) -> Self
+    where
+        HandlerParams: 'static,
+        H: RequestHandler<HandlerParams> + Send + Sync + 'static,
+    {
         Self {
             url: Arc::new(PathMatcher::new(url)),
-            view: RouteInner::Handler(Arc::new(view)),
+            view: RouteInner::Handler(Arc::new(into_box_request_handler(handler))),
             name: None,
         }
     }
@@ -469,14 +474,15 @@ impl Route {
     /// let route = Route::with_handler_and_name("/", home, "home");
     /// ```
     #[must_use]
-    pub fn with_handler_and_name<T: Into<String>, V: RequestHandler + Send + Sync + 'static>(
-        url: &str,
-        view: V,
-        name: T,
-    ) -> Self {
+    pub fn with_handler_and_name<N, HandlerParams, H>(url: &str, handler: H, name: N) -> Self
+    where
+        N: Into<String>,
+        HandlerParams: 'static,
+        H: RequestHandler<HandlerParams> + Send + Sync + 'static,
+    {
         Self {
             url: Arc::new(PathMatcher::new(url)),
-            view: RouteInner::Handler(Arc::new(view)),
+            view: RouteInner::Handler(Arc::new(into_box_request_handler(handler))),
             name: Some(RouteName(name.into())),
         }
     }
@@ -575,7 +581,7 @@ pub(crate) enum RouteKind {
 
 #[derive(Clone)]
 enum RouteInner {
-    Handler(Arc<dyn RequestHandler + Send + Sync>),
+    Handler(Arc<dyn BoxRequestHandler + Send + Sync>),
     Router(Router),
 }
 
@@ -595,7 +601,6 @@ enum RouteInner {
 /// # Examples
 ///
 /// ```
-/// ///
 /// use cot::project::WithConfig;
 /// use cot::request::Request;
 /// use cot::response::{Response, ResponseExt};
@@ -638,6 +643,7 @@ enum RouteInner {
 #[macro_export]
 macro_rules! reverse {
     ($request:expr, $view_name:literal $(, $($key:ident = $value:expr),*)?) => {{
+        #[allow(unused_imports)] // allow using either `Request` or `Urls` objects
         use $crate::request::RequestExt;
         let (app_name, view_name) = $crate::router::split_view_name($view_name);
         let app_name = app_name.or_else(|| $request.app_name());
@@ -645,6 +651,130 @@ macro_rules! reverse {
             .router()
             .reverse(app_name, view_name, &$crate::reverse_param_map!($( $($key = $value),* )?))
     }};
+}
+
+/// A helper structure to allow reversing URLs from a request handler.
+///
+/// This is mainly useful as an extractor to allow reversing URLs without
+/// access to a full [`Request`] object.
+///
+/// # Examples
+///
+/// ```
+/// use cot::request::Request;
+/// use cot::response::{Response, ResponseExt};
+/// use cot::router::{Route, Router, Urls};
+/// use cot::test::TestRequestBuilder;
+/// use cot::{Body, RequestHandler, StatusCode, reverse};
+///
+/// async fn my_handler(urls: Urls) -> cot::Result<Response> {
+///     let url = reverse!(urls, "home")?;
+///     Ok(Response::new_html(
+///         StatusCode::OK,
+///         Body::fixed(format!("{url}")),
+///     ))
+/// }
+///
+/// # #[tokio::main]
+/// # async fn main() -> cot::Result<()> {
+/// let router = Router::with_urls([Route::with_handler_and_name("/", my_handler, "home")]);
+/// let request = TestRequestBuilder::get("/").router(router).build();
+///
+/// assert_eq!(
+///     my_handler
+///         .handle(request)
+///         .await?
+///         .into_body()
+///         .into_bytes()
+///         .await?,
+///     "/"
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct Urls {
+    app_name: Option<String>,
+    router: Arc<Router>,
+}
+
+impl Urls {
+    /// Create a new `Urls` object from a [`Request`] object.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cot::request::Request;
+    /// use cot::response::{Response, ResponseExt};
+    /// use cot::router::Urls;
+    /// use cot::{Body, StatusCode, reverse};
+    ///
+    /// async fn my_handler(request: Request) -> cot::Result<Response> {
+    ///     let urls = Urls::from_request(&request);
+    ///     let url = reverse!(urls, "home")?;
+    ///     Ok(Response::new_html(
+    ///         StatusCode::OK,
+    ///         Body::fixed(format!("Hello! The URL for this view is: {}", url)),
+    ///     ))
+    /// }
+    /// ```
+    pub fn from_request(request: &Request) -> Self {
+        Self {
+            app_name: request.app_name().map(ToOwned::to_owned),
+            router: Arc::clone(request.router()),
+        }
+    }
+
+    pub(crate) fn from_parts(request_parts: &Parts) -> Self {
+        Self {
+            app_name: request_parts.app_name().map(ToOwned::to_owned),
+            router: Arc::clone(request_parts.router()),
+        }
+    }
+
+    /// Get the app name the current route belongs to, or [`None`] if the
+    /// request is not routed.
+    ///
+    /// This is mainly useful for providing context to reverse redirects, where
+    /// you want to redirect to a route in the same app.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cot::request::{Request, RequestExt};
+    /// use cot::response::Response;
+    /// use cot::router::Urls;
+    ///
+    /// async fn my_handler(urls: Urls) -> cot::Result<Response> {
+    ///     let app_name = urls.app_name();
+    ///     // ... do something with the app name
+    ///     # unimplemented!()
+    /// }
+    /// ```
+    #[must_use]
+    pub fn app_name(&self) -> Option<&str> {
+        self.app_name.as_deref()
+    }
+
+    /// Get the router.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cot::request::{Request, RequestExt};
+    /// use cot::response::Response;
+    /// use cot::router::Urls;
+    ///
+    /// async fn my_handler(urls: Urls) -> cot::Result<Response> {
+    ///     let router = urls.router();
+    ///     // ... do something with the router
+    ///     # unimplemented!()
+    /// }
+    /// ```
+    #[must_use]
+    pub fn router(&self) -> &Router {
+        &self.router
+    }
 }
 
 impl Debug for RouteInner {
@@ -705,7 +835,6 @@ mod tests {
 
     struct MockHandler;
 
-    #[async_trait::async_trait]
     impl RequestHandler for MockHandler {
         async fn handle(&self, _request: Request) -> Result<Response> {
             Ok(Response::new_html(

--- a/cot/src/session.rs
+++ b/cot/src/session.rs
@@ -1,0 +1,169 @@
+//! Session management
+//!
+//! This module provides a session management system that allows you to store
+//! and retrieve session data.
+//!
+//! # Examples
+//!
+//! ```
+//! use cot::request::Request;
+//! use cot::response::{Response, ResponseExt};
+//! use cot::router::{Route, Router};
+//! use cot::session::Session;
+//! use cot::test::TestRequestBuilder;
+//! use cot::{Body, RequestHandler, StatusCode};
+//!
+//! async fn my_handler(session: Session) -> cot::Result<Response> {
+//!     session.insert("user_name", "world".to_string()).await?;
+//!     let name: String = session
+//!         .get("user_name")
+//!         .await?
+//!         .expect("name was just added");
+//!     Ok(Response::new_html(
+//!         StatusCode::OK,
+//!         Body::fixed(format!("Hello, {}!", name)),
+//!     ))
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> cot::Result<()> {
+//! let request = TestRequestBuilder::get("/").with_session().build();
+//!
+//! assert_eq!(
+//!     my_handler
+//!         .handle(request)
+//!         .await?
+//!         .into_body()
+//!         .into_bytes()
+//!         .await?,
+//!     "Hello, world!"
+//! );
+//! # Ok(())
+//! # }
+//! ```
+
+use std::ops::{Deref, DerefMut};
+
+/// A session object.
+///
+/// This is a wrapper around the `tower_sessions::Session` type.
+///
+/// # Examples
+///
+/// ```
+/// use cot::request::Request;
+/// use cot::response::{Response, ResponseExt};
+/// use cot::router::{Route, Router};
+/// use cot::session::Session;
+/// use cot::test::TestRequestBuilder;
+/// use cot::{Body, RequestHandler, StatusCode};
+///
+/// async fn my_handler(session: Session) -> cot::Result<Response> {
+///     session.insert("user_name", "world".to_string()).await?;
+///     let name: String = session
+///         .get("user_name")
+///         .await?
+///         .expect("name was just added");
+///     Ok(Response::new_html(
+///         StatusCode::OK,
+///         Body::fixed(format!("Hello, {}!", name)),
+///     ))
+/// }
+///
+/// # #[tokio::main]
+/// # async fn main() -> cot::Result<()> {
+/// let request = TestRequestBuilder::get("/").with_session().build();
+///
+/// assert_eq!(
+///     my_handler
+///         .handle(request)
+///         .await?
+///         .into_body()
+///         .into_bytes()
+///         .await?,
+///     "Hello, world!"
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct Session {
+    // tower_sessions::Session internally is two Arcs, so it's cheap to clone
+    inner: tower_sessions::Session,
+}
+
+impl Session {
+    pub(crate) fn new(inner: tower_sessions::Session) -> Self {
+        Self { inner }
+    }
+
+    /// Get the session object from a request.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cot::request::Request;
+    /// use cot::response::{Response, ResponseExt};
+    /// use cot::router::{Route, Router};
+    /// use cot::session::Session;
+    /// use cot::test::TestRequestBuilder;
+    /// use cot::{Body, RequestHandler, StatusCode};
+    ///
+    /// async fn my_handler(request: Request) -> cot::Result<Response> {
+    ///     let session = Session::from_request(&request);
+    ///
+    ///     session.insert("user_name", "world".to_string()).await?;
+    ///     let name: String = session
+    ///         .get("user_name")
+    ///         .await?
+    ///         .expect("name was just added");
+    ///     Ok(Response::new_html(
+    ///         StatusCode::OK,
+    ///         Body::fixed(format!("Hello, {}!", name)),
+    ///     ))
+    /// }
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> cot::Result<()> {
+    /// let request = TestRequestBuilder::get("/").with_session().build();
+    ///
+    /// assert_eq!(
+    ///     my_handler
+    ///         .handle(request)
+    ///         .await?
+    ///         .into_body()
+    ///         .into_bytes()
+    ///         .await?,
+    ///     "Hello, world!"
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[track_caller]
+    #[must_use]
+    pub fn from_request(request: &crate::request::Request) -> &Self {
+        Self::from_extensions(request.extensions())
+    }
+
+    #[track_caller]
+    #[must_use]
+    pub(crate) fn from_extensions(extensions: &http::Extensions) -> &Self {
+        extensions
+            .get::<Self>()
+            .expect("Session extension missing. Did you forget to add the SessionMiddleware?")
+    }
+}
+
+impl Deref for Session {
+    type Target = tower_sessions::Session;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl DerefMut for Session {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}

--- a/cot/src/static_files.rs
+++ b/cot/src/static_files.rs
@@ -16,9 +16,9 @@ use http::{Request, header};
 use pin_project_lite::pin_project;
 use tower::Service;
 
+use crate::Body;
 use crate::project::MiddlewareContext;
 use crate::response::{Response, ResponseExt};
-use crate::{Body, ProjectContext};
 
 /// Macro to define static files by specifying their paths.
 ///
@@ -286,7 +286,7 @@ mod tests {
 
     use super::*;
     use crate::config::ProjectConfig;
-    use crate::project::WithConfig;
+    use crate::project::RegisterAppsContext;
     use crate::{App, AppBuilder, Bootstrapper, Project};
 
     #[test]
@@ -398,7 +398,7 @@ mod tests {
 
         struct TestProject;
         impl Project for TestProject {
-            fn register_apps(&self, apps: &mut AppBuilder, _context: &ProjectContext<WithConfig>) {
+            fn register_apps(&self, apps: &mut AppBuilder, _context: &RegisterAppsContext) {
                 apps.register(App1);
                 apps.register(App2);
             }

--- a/cot/src/static_files.rs
+++ b/cot/src/static_files.rs
@@ -16,7 +16,7 @@ use http::{Request, header};
 use pin_project_lite::pin_project;
 use tower::Service;
 
-use crate::project::WithApps;
+use crate::project::WithDatabase;
 use crate::response::{Response, ResponseExt};
 use crate::{Body, ProjectContext};
 
@@ -114,8 +114,8 @@ impl Default for StaticFiles {
     }
 }
 
-impl From<&ProjectContext<WithApps>> for StaticFiles {
-    fn from(context: &ProjectContext<WithApps>) -> Self {
+impl From<&ProjectContext<WithDatabase>> for StaticFiles {
+    fn from(context: &ProjectContext<WithDatabase>) -> Self {
         let mut static_files = StaticFiles::new();
 
         for module in context.apps() {
@@ -170,7 +170,7 @@ impl StaticFilesMiddleware {
     /// Creates a new `StaticFilesMiddleware` instance from the application
     /// context.
     #[must_use]
-    pub fn from_context(context: &ProjectContext<WithApps>) -> Self {
+    pub fn from_context(context: &ProjectContext<WithDatabase>) -> Self {
         Self {
             static_files: Arc::new(StaticFiles::from(context)),
         }
@@ -406,7 +406,10 @@ mod tests {
 
         let bootstrapper = Bootstrapper::new(TestProject)
             .with_config(ProjectConfig::default())
-            .with_apps();
+            .with_apps()
+            .with_database()
+            .await
+            .unwrap();
         let middleware = StaticFilesMiddleware::from_context(bootstrapper.context());
         let static_files = middleware.static_files;
 

--- a/cot/src/static_files.rs
+++ b/cot/src/static_files.rs
@@ -16,7 +16,7 @@ use http::{Request, header};
 use pin_project_lite::pin_project;
 use tower::Service;
 
-use crate::project::WithDatabase;
+use crate::project::MiddlewareContext;
 use crate::response::{Response, ResponseExt};
 use crate::{Body, ProjectContext};
 
@@ -114,8 +114,8 @@ impl Default for StaticFiles {
     }
 }
 
-impl From<&ProjectContext<WithDatabase>> for StaticFiles {
-    fn from(context: &ProjectContext<WithDatabase>) -> Self {
+impl From<&MiddlewareContext> for StaticFiles {
+    fn from(context: &MiddlewareContext) -> Self {
         let mut static_files = StaticFiles::new();
 
         for module in context.apps() {
@@ -167,10 +167,10 @@ pub struct StaticFilesMiddleware {
 }
 
 impl StaticFilesMiddleware {
-    /// Creates a new `StaticFilesMiddleware` instance from the application
+    /// Creates a new `StaticFilesMiddleware` instance from the project
     /// context.
     #[must_use]
-    pub fn from_context(context: &ProjectContext<WithDatabase>) -> Self {
+    pub fn from_context(context: &MiddlewareContext) -> Self {
         Self {
             static_files: Arc::new(StaticFiles::from(context)),
         }

--- a/cot/templates/admin/base.html
+++ b/cot/templates/admin/base.html
@@ -1,4 +1,4 @@
-{%- let request = request -%}
+{%- let urls = urls -%}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -10,7 +10,7 @@
 </head>
 <body class="{% block body_class %}{% endblock %}">
 <header id="header">
-    <div id="branding"><a href="{{ cot::reverse!(request, "index")? }}"><h1>Cot Administration</h1></a></div>
+    <div id="branding"><a href="{{ cot::reverse!(urls, "index")? }}"><h1>Cot Administration</h1></a></div>
 </header>
 <main>
     {% block content %}{% endblock %}

--- a/cot/templates/admin/model.html
+++ b/cot/templates/admin/model.html
@@ -3,12 +3,12 @@
 {% block title %}{{ model.name() }}{% endblock %}
 
 {% block content -%}
-{%- let request = request -%}
+{%- let urls = urls -%}
 {%- let model = model -%}
 <div class="model-header">
     <h2>{{ model.name() }}</h2>
     <div class="action-box">
-        <a class="btn primary" href="{{ cot::reverse!(request, "create_model_instance", model_name = model.url_name())? }}">Create {{ model.name() }} {% include "icons/plus.svg" %}</a>
+        <a class="btn primary" href="{{ cot::reverse!(urls, "create_model_instance", model_name = model.url_name())? }}">Create {{ model.name() }} {% include "icons/plus.svg" %}</a>
     </div>
 </div>
 
@@ -23,8 +23,8 @@
         <tbody>
         {%- for object in objects -%}
             <tr>
-                {%- let edit_link = cot::reverse!(request, "edit_model_instance", model_name = model.url_name(), pk = object.id())? -%}
-                {%- let remove_link = cot::reverse!(request, "remove_model_instance", model_name = model.url_name(), pk = object.id())? -%}
+                {%- let edit_link = cot::reverse!(urls, "edit_model_instance", model_name = model.url_name(), pk = object.id())? -%}
+                {%- let remove_link = cot::reverse!(urls, "remove_model_instance", model_name = model.url_name(), pk = object.id())? -%}
                 <td><a href="{{ edit_link }}">{{ object.display() }}</a></td>
                 <td class="model-actions-cell"><a href="{{ edit_link }}" class="edit-model" title="Edit this {{ model.name() }}">{% include "icons/pencil.svg" %}</a> <a href="{{ remove_link }}" class="remove-model" title="Remove this {{ model.name() }}">{% include "icons/trash.svg" %}</a></td>
             </tr>

--- a/cot/templates/admin/model_edit.html
+++ b/cot/templates/admin/model_edit.html
@@ -3,7 +3,6 @@
 {% block title %}{% if is_edit %}Edit{% else %}Create{% endif %} {{ model.name() }}{% endblock %}
 
 {% block content -%}
-{%- let request = request -%}
 <h2>{% if is_edit %}Edit{% else %}Create{% endif %} {{ model.name() }}</h2>
 
 <form class="model-form" action="" method="post">

--- a/cot/templates/admin/model_list.html
+++ b/cot/templates/admin/model_list.html
@@ -3,13 +3,13 @@
 {% block title %}Home{% endblock %}
 
 {% block content -%}
-{%- let request = request -%}
+{%- let urls = urls -%}
 
 <h2>Choose a model to manage</h2>
 
 <ul class="model-list">
 {%- for model in model_managers -%}
-    {%- let model_link = cot::reverse!(request, "view_model", model_name = model.url_name())? -%}
+    {%- let model_link = cot::reverse!(urls, "view_model", model_name = model.url_name())? -%}
     <li><a href="{{ model_link }}?page=1&page_size=10">{{ model.name() }}</a></li>
 {%- endfor -%}
 </ul>

--- a/cot/templates/admin/model_remove.html
+++ b/cot/templates/admin/model_remove.html
@@ -3,14 +3,14 @@
 {% block title %}Model{% endblock %}
 
 {% block content -%}
-{%- let request = request -%}
+{%- let urls = urls -%}
 {%- let model = model -%}
 <h2>Remove {{ model.name() }}</h2>
     <p class="main-dialog">Are you sure you want to remove <strong>{{ object.display() }}</strong>?</p>
 
     <form action="" method="post">
         <div class="form-actions">
-            <a href="{{ cot::reverse!(request, "view_model", model_name = model.url_name())? }}" class="btn secondary">Cancel</a>
+            <a href="{{ cot::reverse!(urls, "view_model", model_name = model.url_name())? }}" class="btn secondary">Cancel</a>
             <button type="submit" class="btn danger">Remove</button>
         </div>
     </form>

--- a/cot/tests/project.rs
+++ b/cot/tests/project.rs
@@ -1,11 +1,11 @@
 use bytes::Bytes;
 use cot::config::ProjectConfig;
-use cot::project::WithConfig;
+use cot::project::RegisterAppsContext;
 use cot::request::Request;
 use cot::response::{Response, ResponseExt};
 use cot::router::{Route, Router};
 use cot::test::Client;
-use cot::{App, AppBuilder, Body, Project, ProjectContext, StatusCode, reverse};
+use cot::{App, AppBuilder, Body, Project, StatusCode, reverse};
 
 #[cot::test]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `sqlite3_open_v2`
@@ -46,7 +46,7 @@ async fn cot_project_router_sub_path() {
             Ok(ProjectConfig::default())
         }
 
-        fn register_apps(&self, apps: &mut AppBuilder, _context: &ProjectContext<WithConfig>) {
+        fn register_apps(&self, apps: &mut AppBuilder, _context: &RegisterAppsContext) {
             apps.register_with_views(App1, "");
             apps.register_with_views(App2, "/app");
         }
@@ -96,7 +96,7 @@ async fn cot_router_reverse_local() {
             Ok(ProjectConfig::default())
         }
 
-        fn register_apps(&self, apps: &mut AppBuilder, _context: &ProjectContext<WithConfig>) {
+        fn register_apps(&self, apps: &mut AppBuilder, _context: &RegisterAppsContext) {
             apps.register_with_views(App1, "");
             apps.register_with_views(App2, "");
         }

--- a/cot/tests/router.rs
+++ b/cot/tests/router.rs
@@ -1,11 +1,11 @@
 use bytes::Bytes;
 use cot::config::ProjectConfig;
-use cot::project::WithConfig;
+use cot::project::RegisterAppsContext;
 use cot::request::{Request, RequestExt};
 use cot::response::{Response, ResponseExt};
 use cot::router::{Route, Router};
 use cot::test::Client;
-use cot::{App, AppBuilder, Body, Project, ProjectContext, StatusCode};
+use cot::{App, AppBuilder, Body, Project, StatusCode};
 
 async fn index(_request: Request) -> cot::Result<Response> {
     Ok(Response::new_html(
@@ -68,7 +68,7 @@ fn project() -> impl Project {
             Ok(ProjectConfig::default())
         }
 
-        fn register_apps(&self, apps: &mut AppBuilder, _context: &ProjectContext<WithConfig>) {
+        fn register_apps(&self, apps: &mut AppBuilder, _context: &RegisterAppsContext) {
             apps.register_with_views(RouterApp, "");
         }
     }

--- a/examples/admin/src/main.rs
+++ b/examples/admin/src/main.rs
@@ -4,7 +4,7 @@ use cot::auth::db::{DatabaseUser, DatabaseUserApp};
 use cot::cli::CliMetadata;
 use cot::config::{DatabaseConfig, MiddlewareConfig, ProjectConfig, SessionMiddlewareConfig};
 use cot::middleware::{AuthMiddleware, LiveReloadMiddleware, SessionMiddleware};
-use cot::project::{MiddlewareContext, WithConfig};
+use cot::project::{MiddlewareContext, RegisterAppsContext};
 use cot::response::{Response, ResponseExt};
 use cot::router::{Route, Router, Urls};
 use cot::static_files::StaticFilesMiddleware;
@@ -70,7 +70,7 @@ impl Project for AdminProject {
             .build())
     }
 
-    fn register_apps(&self, apps: &mut AppBuilder, _context: &ProjectContext<WithConfig>) {
+    fn register_apps(&self, apps: &mut AppBuilder, _context: &RegisterAppsContext) {
         apps.register(DatabaseUserApp::new());
         apps.register_with_views(AdminApp::new(), "/admin");
         apps.register_with_views(HelloApp, "");

--- a/examples/admin/src/main.rs
+++ b/examples/admin/src/main.rs
@@ -3,11 +3,10 @@ use cot::admin::AdminApp;
 use cot::auth::db::{DatabaseUser, DatabaseUserApp};
 use cot::cli::CliMetadata;
 use cot::config::{DatabaseConfig, MiddlewareConfig, ProjectConfig, SessionMiddlewareConfig};
-use cot::middleware::{LiveReloadMiddleware, SessionMiddleware};
-use cot::project::{WithApps, WithConfig};
-use cot::request::Request;
+use cot::middleware::{AuthMiddleware, LiveReloadMiddleware, SessionMiddleware};
+use cot::project::{MiddlewareContext, WithConfig};
 use cot::response::{Response, ResponseExt};
-use cot::router::{Route, Router};
+use cot::router::{Route, Router, Urls};
 use cot::static_files::StaticFilesMiddleware;
 use cot::{App, AppBuilder, Body, BoxedHandler, Project, ProjectContext, StatusCode};
 use rinja::Template;
@@ -15,11 +14,11 @@ use rinja::Template;
 #[derive(Debug, Template)]
 #[template(path = "index.html")]
 struct IndexTemplate<'a> {
-    request: &'a Request,
+    urls: &'a Urls,
 }
 
-async fn index(request: Request) -> cot::Result<Response> {
-    let index_template = IndexTemplate { request: &request };
+async fn index(urls: Urls) -> cot::Result<Response> {
+    let index_template = IndexTemplate { urls: &urls };
     let rendered = index_template.render()?;
 
     Ok(Response::new_html(StatusCode::OK, Body::fixed(rendered)))
@@ -80,11 +79,13 @@ impl Project for AdminProject {
     fn middlewares(
         &self,
         handler: cot::project::RootHandlerBuilder,
-        context: &ProjectContext<WithApps>,
+        context: &MiddlewareContext,
     ) -> BoxedHandler {
         handler
             .middleware(StaticFilesMiddleware::from_context(context))
             .middleware(SessionMiddleware::from_context(context))
+            .middleware(AuthMiddleware::new())
+            .middleware(SessionMiddleware::new())
             .middleware(LiveReloadMiddleware::new())
             .build()
     }

--- a/examples/admin/templates/index.html
+++ b/examples/admin/templates/index.html
@@ -1,4 +1,4 @@
-{% let request = request %}
+{% let urls = urls %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -9,7 +9,7 @@
 </head>
 <body>
 <h1>Hello!</h1>
-<p>Go to the <a href="{{ cot::reverse!(request, "cot_admin:login")? }}">admin panel</a>.</p>
+<p>Go to the <a href="{{ cot::reverse!(urls, "cot_admin:login")? }}">admin panel</a>.</p>
 <p>The username is <strong>admin</strong> and the password is <strong>admin</strong>.</p>
 </body>
 </html>

--- a/examples/custom-error-pages/src/main.rs
+++ b/examples/custom-error-pages/src/main.rs
@@ -1,9 +1,9 @@
 use cot::cli::CliMetadata;
 use cot::config::ProjectConfig;
-use cot::project::{ErrorPageHandler, WithConfig};
+use cot::project::{ErrorPageHandler, RegisterAppsContext};
 use cot::response::{Response, ResponseExt};
 use cot::router::{Route, Router};
-use cot::{App, AppBuilder, Body, Project, ProjectContext, StatusCode};
+use cot::{App, AppBuilder, Body, Project, StatusCode};
 
 async fn return_hello() -> cot::Result<Response> {
     panic!()
@@ -35,7 +35,7 @@ impl Project for HelloProject {
         Ok(config)
     }
 
-    fn register_apps(&self, apps: &mut AppBuilder, _context: &ProjectContext<WithConfig>) {
+    fn register_apps(&self, apps: &mut AppBuilder, _context: &RegisterAppsContext) {
         apps.register_with_views(HelloApp, "");
     }
 

--- a/examples/custom-error-pages/src/main.rs
+++ b/examples/custom-error-pages/src/main.rs
@@ -1,12 +1,11 @@
 use cot::cli::CliMetadata;
 use cot::config::ProjectConfig;
 use cot::project::{ErrorPageHandler, WithConfig};
-use cot::request::Request;
 use cot::response::{Response, ResponseExt};
 use cot::router::{Route, Router};
 use cot::{App, AppBuilder, Body, Project, ProjectContext, StatusCode};
 
-async fn return_hello(_request: Request) -> cot::Result<Response> {
+async fn return_hello() -> cot::Result<Response> {
     panic!()
 }
 

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,9 +1,9 @@
 use cot::cli::CliMetadata;
 use cot::config::ProjectConfig;
-use cot::project::WithConfig;
+use cot::project::RegisterAppsContext;
 use cot::response::{Response, ResponseExt};
 use cot::router::{Route, Router};
-use cot::{App, AppBuilder, Body, Project, ProjectContext, StatusCode};
+use cot::{App, AppBuilder, Body, Project, StatusCode};
 
 async fn return_hello() -> cot::Result<Response> {
     Ok(Response::new_html(
@@ -35,7 +35,7 @@ impl Project for HelloProject {
         Ok(ProjectConfig::dev_default())
     }
 
-    fn register_apps(&self, apps: &mut AppBuilder, _context: &ProjectContext<WithConfig>) {
+    fn register_apps(&self, apps: &mut AppBuilder, _context: &RegisterAppsContext) {
         apps.register_with_views(HelloApp, "");
     }
 }

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,12 +1,11 @@
 use cot::cli::CliMetadata;
 use cot::config::ProjectConfig;
 use cot::project::WithConfig;
-use cot::request::Request;
 use cot::response::{Response, ResponseExt};
 use cot::router::{Route, Router};
 use cot::{App, AppBuilder, Body, Project, ProjectContext, StatusCode};
 
-async fn return_hello(_request: Request) -> cot::Result<Response> {
+async fn return_hello() -> cot::Result<Response> {
     Ok(Response::new_html(
         StatusCode::OK,
         Body::fixed("<h1>Hello Cot!</h1>".as_bytes().to_vec()),

--- a/examples/json/src/main.rs
+++ b/examples/json/src/main.rs
@@ -1,10 +1,10 @@
 use cot::cli::CliMetadata;
 use cot::config::ProjectConfig;
-use cot::project::WithConfig;
-use cot::request::{Request, RequestExt};
+use cot::project::RegisterAppsContext;
+use cot::request::extractors::Json;
 use cot::response::{Response, ResponseExt};
 use cot::router::{Route, Router};
-use cot::{App, AppBuilder, Project, ProjectContext, StatusCode};
+use cot::{App, AppBuilder, Project, StatusCode};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize)]
@@ -18,8 +18,7 @@ struct AddResponse {
     result: i32,
 }
 
-async fn add(mut request: Request) -> cot::Result<Response> {
-    let add_request: AddRequest = request.json().await?;
+async fn add(Json(add_request): Json<AddRequest>) -> cot::Result<Response> {
     let response = AddResponse {
         result: add_request.a + add_request.b,
     };
@@ -40,7 +39,7 @@ impl App for AddApp {
 }
 
 // Test with:
-// curl --header "Content-Type: application/json" --request POST --data '{"a": 123, "b": 456}' 'http://127.0.0.1:8080/'
+// curl --header "Content-Type: application/json" --request POST --data '{"a": 123, "b": 456}' 'http://127.0.0.1:8000/'
 
 struct JsonProject;
 
@@ -53,7 +52,7 @@ impl Project for JsonProject {
         Ok(ProjectConfig::dev_default())
     }
 
-    fn register_apps(&self, apps: &mut AppBuilder, _context: &ProjectContext<WithConfig>) {
+    fn register_apps(&self, apps: &mut AppBuilder, _context: &RegisterAppsContext) {
         apps.register_with_views(AddApp, "");
     }
 }

--- a/examples/sessions/templates/index.html
+++ b/examples/sessions/templates/index.html
@@ -1,5 +1,3 @@
-{% let request = request %}
-
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/examples/sessions/templates/name.html
+++ b/examples/sessions/templates/name.html
@@ -1,4 +1,4 @@
-{% let request = request %}
+{% let urls = urls %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -9,7 +9,7 @@
 </head>
 <body>
 <h1>Hello!</h1>
-<form id="todo-form" action="{{ cot::reverse!(request, "name")? }}" method="post">
+<form id="todo-form" action="{{ cot::reverse!(urls, "name")? }}" method="post">
     <input type="text" id="name" name="name" placeholder="Please enter your name" required>
     <button type="submit">Submit</button>
 </form>

--- a/examples/todo-list/templates/index.html
+++ b/examples/todo-list/templates/index.html
@@ -1,4 +1,4 @@
-{% let request = request %}
+{% let urls = urls %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -9,7 +9,7 @@
 </head>
 <body>
 <h1>TODO List</h1>
-<form id="todo-form" action="{{ cot::reverse!(request, "add-todo")? }}" method="post">
+<form id="todo-form" action="{{ cot::reverse!(urls, "add-todo")? }}" method="post">
     <input type="text" id="title" name="title" placeholder="Enter a new TODO" required>
     <button type="submit">Add TODO</button>
 </form>
@@ -17,7 +17,7 @@
     {% for todo in todo_items %}
     <li>
         {% let todo_id = todo.id %}
-        <form action="{{ cot::reverse!(request, "remove-todo", todo_id = todo_id)? }}" method="post">
+        <form action="{{ cot::reverse!(urls, "remove-todo", todo_id = todo_id)? }}" method="post">
             <span>{{ todo.title }}</span>
             <button type="submit">Remove</button>
         </form>


### PR DESCRIPTION
This is a massive change and the transition probably isn't even fully done yet. This should be a good starting point, though.

The remaining work includes:

* Removing more of the `RequestExt` trait
* Creating `IntoResponse` trait so that the consumers can return other types than `cot::Result<Response>`
* More work on maintaining consistency in the API

Note that this is a (quite big) breaking change, mostly because it removes a lot of methods from the `RequestExt` trait.

This change is needed to implement automatic OpenAPI spec generation in #159.