### PR TITLE
ci: run `cargo build` with `--all-features` in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,7 @@ jobs:
           tool: nextest
 
       - name: Build
-        run: cargo +${{ matrix.rust }} build
+        run: cargo +${{ matrix.rust }} build --all-features --tests
 
       - name: Test
         run: cargo +${{ matrix.rust }} nextest run --all-features
@@ -107,10 +107,10 @@ jobs:
           tool: nextest
 
       - name: Build
-        run: cargo build
+        run: cargo build --all-features --tests
 
       - name: Run the external dependencies
-        run: docker compose up -d
+        run: docker compose up -d --wait
 
       - name: Test
         run: cargo nextest run --all-features --run-ignored only

--- a/compose.yml
+++ b/compose.yml
@@ -9,6 +9,11 @@ services:
       MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 1
     ports:
       - "3306:3306"
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   postgres:
     image: docker.io/postgres:17-alpine
@@ -18,3 +23,8 @@ services:
       POSTGRES_PASSWORD: cot
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD", "pg_isready"]
+      interval: 5s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
This doesn't change the behavior as the tests have still been run with `--all-features`, but this should lead to a slightly more acurrate timings in CI.