### PR TITLE
Fix session config in admin app example

### DIFF
--- a/examples/admin/src/main.rs
+++ b/examples/admin/src/main.rs
@@ -121,9 +121,8 @@ impl Project for AdminProject {
     ) -> BoxedHandler {
         handler
             .middleware(StaticFilesMiddleware::from_context(context))
-            .middleware(SessionMiddleware::from_context(context))
             .middleware(AuthMiddleware::new())
-            .middleware(SessionMiddleware::new())
+            .middleware(SessionMiddleware::from_context(context))
             .middleware(LiveReloadMiddleware::new())
             .build()
     }


### PR DESCRIPTION
The second session config overrides the first which sets `secure` to true. Safari doesn't handle this well. 