### PR TITLE
ci: use sccache

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: 'false'
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -53,7 +55,7 @@ jobs:
           tool: nextest
 
       - name: Fetch dependencies
-        run: cargo +${{ matrix.rust }} fetch
+        run: cargo +${{ matrix.rust }} fetch --locked
 
       - name: Build
         run: cargo +${{ matrix.rust }} build --all-features --tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,8 +43,6 @@ jobs:
 
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2
-        with:
-          cache-targets: 'false'
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,11 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
+      - name: Cache Cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: 'false'
+
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
 
@@ -80,6 +85,11 @@ jobs:
           toolchain: stable
           components: clippy
 
+      - name: Cache Cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: 'false'
+
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
 
@@ -105,6 +115,11 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
+
+      - name: Cache Cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: 'false'
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -159,6 +174,11 @@ jobs:
               /usr/local/lib/dotnet \
               /usr/local/lib/swift
 
+      - name: Cache Cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: 'false'
+
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
 
@@ -200,6 +220,11 @@ jobs:
           toolchain: nightly
           components: rustfmt
 
+      - name: Cache Cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: 'false'
+
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
 
@@ -226,6 +251,11 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Cache Cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: 'false'
+
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
 
@@ -251,6 +281,11 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
+
+      - name: Cache Cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: 'false'
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
@@ -287,6 +322,11 @@ jobs:
         with:
           toolchain: nightly
 
+      - name: Cache Cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: 'false'
+
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
 
@@ -317,18 +357,15 @@ jobs:
           toolchain: nightly
           components: miri
 
+      - name: Cache Cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: 'false'
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
           tool: nextest
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Set sccache environment variables
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
       - name: Miri setup
         run: cargo miri setup

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,8 @@ env:
   CARGO_INCREMENTAL: 0
   # Required by cargo-insta: https://insta.rs/docs/quickstart/#continuous-integration
   CI: true
+  SCCACHE_GHA_ENABLED: true
+  RUSTC_WRAPPER: sccache
 
 # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
 # This will ensure that only one commit will be running tests at a time on each PR.
@@ -46,11 +48,6 @@ jobs:
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Set sccache environment variables
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
@@ -93,11 +90,6 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Set sccache environment variables
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-
       - name: Run clippy
         run: cargo clippy --no-deps --all-targets -- -D warnings
 
@@ -123,11 +115,6 @@ jobs:
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Set sccache environment variables
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
@@ -182,11 +169,6 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Set sccache environment variables
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-
       - name: Run the external dependencies
         run: docker compose up -d
 
@@ -228,11 +210,6 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Set sccache environment variables
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-
       - name: Run fmt
         run: cargo fmt --all -- --check
 
@@ -258,11 +235,6 @@ jobs:
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Set sccache environment variables
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
       - name: Run cargo-machete
         uses: bnjbvr/cargo-machete@v0.8.0
@@ -292,11 +264,6 @@ jobs:
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Set sccache environment variables
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
       - name: Run cargo check with minimal versions
         run: |
@@ -332,11 +299,6 @@ jobs:
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Set sccache environment variables
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
       - name: Run cargo check with every combination of features
         run: cargo hack check --feature-powerset --exclude-features db --no-dev-deps

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,6 +90,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: 'rust-ci'
+          cache-bin: 'false'
           save-if: 'false'
 
       - name: Run sccache-cache
@@ -117,6 +118,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: 'rust-ci'
+          cache-bin: 'false'
           save-if: 'false'
 
       - name: Run sccache-cache
@@ -171,6 +173,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: 'rust-ci'
+          cache-bin: 'false'
           save-if: 'false'
 
       - name: Run sccache-cache
@@ -213,6 +216,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: 'rust-ci'
+          cache-bin: 'false'
           save-if: 'false'
 
       - name: Run sccache-cache
@@ -240,6 +244,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: 'rust-ci'
+          cache-bin: 'false'
           save-if: 'false'
 
       - name: Run sccache-cache
@@ -267,6 +272,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: 'rust-ci'
+          cache-bin: 'false'
           save-if: 'false'
 
       - name: Install cargo-hack
@@ -303,6 +309,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: 'rust-ci'
+          cache-bin: 'false'
           save-if: 'false'
 
       - name: Install cargo-hack
@@ -334,6 +341,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: 'rust-ci'
+          cache-bin: 'false'
           save-if: 'false'
 
       - name: Install cargo-nextest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,6 +52,9 @@ jobs:
         with:
           tool: nextest
 
+      - name: Fetch dependencies
+        run: cargo +${{ matrix.rust }} fetch
+
       - name: Build
         run: cargo +${{ matrix.rust }} build --all-features --tests
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,8 +39,13 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
-      - name: Cache Cargo registry
-        uses: Swatinem/rust-cache@v2
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Set sccache environment variables
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
@@ -75,10 +80,13 @@ jobs:
           toolchain: stable
           components: clippy
 
-      - name: Cache Cargo registry
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: false
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Set sccache environment variables
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
       - name: Run clippy
         run: cargo clippy --no-deps --all-targets -- -D warnings
@@ -98,10 +106,13 @@ jobs:
         with:
           toolchain: nightly
 
-      - name: Cache Cargo registry
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: false
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Set sccache environment variables
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
@@ -148,10 +159,13 @@ jobs:
               /usr/local/lib/dotnet \
               /usr/local/lib/swift
 
-      - name: Cache Cargo registry
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: false
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Set sccache environment variables
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
       - name: Run the external dependencies
         run: docker compose up -d
@@ -186,10 +200,13 @@ jobs:
           toolchain: nightly
           components: rustfmt
 
-      - name: Cache Cargo registry
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: false
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Set sccache environment variables
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
       - name: Run fmt
         run: cargo fmt --all -- --check
@@ -209,10 +226,13 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Cache Cargo registry
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: false
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Set sccache environment variables
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
       - name: Run cargo-machete
         uses: bnjbvr/cargo-machete@v0.8.0
@@ -235,10 +255,13 @@ jobs:
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
 
-      - name: Cache Cargo registry
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: false
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Set sccache environment variables
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
       - name: Run cargo check with minimal versions
         run: |
@@ -267,10 +290,13 @@ jobs:
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
 
-      - name: Cache Cargo registry
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: false
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Set sccache environment variables
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
       - name: Run cargo check with every combination of features
         run: cargo hack check --feature-powerset --exclude-features db --no-dev-deps
@@ -296,10 +322,13 @@ jobs:
         with:
           tool: nextest
 
-      - name: Cache Cargo registry
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: false
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Set sccache environment variables
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
       - name: Miri setup
         run: cargo miri setup

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2
         with:
+          shared-key: 'rust-ci'
           cache-bin: 'false'
 
       - name: Run sccache-cache
@@ -88,6 +89,7 @@ jobs:
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2
         with:
+          shared-key: 'rust-ci'
           save-if: 'false'
 
       - name: Run sccache-cache
@@ -114,6 +116,7 @@ jobs:
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2
         with:
+          shared-key: 'rust-ci'
           save-if: 'false'
 
       - name: Run sccache-cache
@@ -167,6 +170,7 @@ jobs:
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2
         with:
+          shared-key: 'rust-ci'
           save-if: 'false'
 
       - name: Run sccache-cache
@@ -208,6 +212,7 @@ jobs:
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2
         with:
+          shared-key: 'rust-ci'
           save-if: 'false'
 
       - name: Run sccache-cache
@@ -234,6 +239,7 @@ jobs:
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2
         with:
+          shared-key: 'rust-ci'
           save-if: 'false'
 
       - name: Run sccache-cache
@@ -260,6 +266,7 @@ jobs:
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2
         with:
+          shared-key: 'rust-ci'
           save-if: 'false'
 
       - name: Install cargo-hack
@@ -295,6 +302,7 @@ jobs:
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2
         with:
+          shared-key: 'rust-ci'
           save-if: 'false'
 
       - name: Install cargo-hack
@@ -325,6 +333,7 @@ jobs:
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2
         with:
+          shared-key: 'rust-ci'
           save-if: 'false'
 
       - name: Install cargo-nextest


### PR DESCRIPTION
This PR adds `sccache` for improved caching as well as fixes a bunch of other issues.

- The `Build & test` stage is faster by around 30-60 seconds on average. 
- Excluding Miri, the second stage of jobs is faster by around 1.5-3.5 minutes on average.
- Binaries are no longer saved by `Swatinem/rust-cache` to reduce the cache size.
- Set the shared key to a fixed value so that the cache created in the first stage can actually be used by the second stage.

The most impactful further work is speeding up Windows build and Miri test, but that can be a topic for another PR.