### PR TITLE
Form support for Email Field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,6 +568,7 @@ dependencies = [
  "cot_macros",
  "derive_builder",
  "derive_more",
+ "email_address",
  "fake",
  "form_urlencoded",
  "futures",
@@ -910,6 +911,15 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ cot_macros = { version = "0.2.1", path = "cot-macros" }
 darling = "0.20"
 derive_builder = "0.20"
 derive_more = "2"
+email_address = "0.2.9"
 fake = "4"
 form_urlencoded = "1"
 futures = { version = "0.3", default-features = false }

--- a/cot/Cargo.toml
+++ b/cot/Cargo.toml
@@ -28,6 +28,7 @@ cot_macros.workspace = true
 derive_builder.workspace = true
 derive_more = { workspace = true, features = ["debug", "deref", "display", "from"] }
 fake = { workspace = true, optional = true, features = ["derive", "chrono"] }
+email_address.workspace = true
 form_urlencoded.workspace = true
 futures-core.workspace = true
 futures-util.workspace = true

--- a/cot/src/admin.rs
+++ b/cot/src/admin.rs
@@ -21,7 +21,8 @@ use derive_more::Debug;
 use http::request::Parts;
 use serde::Deserialize;
 
-use crate::auth::{Auth, Password};
+use crate::auth::Auth;
+use crate::form::types::Password;
 use crate::form::{
     Form, FormContext, FormErrorTarget, FormField, FormFieldValidationError, FormResult,
 };

--- a/cot/src/admin.rs
+++ b/cot/src/admin.rs
@@ -22,7 +22,7 @@ use http::request::Parts;
 use serde::Deserialize;
 
 use crate::auth::Auth;
-use crate::form::types::Password;
+use crate::common_types::Password;
 use crate::form::{
     Form, FormContext, FormErrorTarget, FormField, FormFieldValidationError, FormResult,
 };

--- a/cot/src/auth.rs
+++ b/cot/src/auth.rs
@@ -13,11 +13,8 @@ use std::any::Any;
 use std::borrow::Cow;
 use std::sync::{Arc, Mutex, MutexGuard};
 
-#[deprecated(
-    since = "0.3.0",
-    note = "use `cot::form::types::Password` instead"
-)]
-pub use crate::form::types::Password;
+#[deprecated(since = "0.3.0", note = "use `cot::form::types::Password` instead")]
+pub type Password = crate::form::types::Password;
 use crate::config::SecretKey;
 #[cfg(feature = "db")]
 use crate::db::{ColumnType, DatabaseField, DbValue, FromDbValue, SqlxValueRef, ToDbValue};
@@ -1137,6 +1134,7 @@ mod tests {
 
     use super::*;
     use crate::config::ProjectConfig;
+    use crate::form::types::Password;
     use crate::test::TestRequestBuilder;
 
     struct MockAuthBackend<F> {

--- a/cot/src/auth.rs
+++ b/cot/src/auth.rs
@@ -587,7 +587,8 @@ impl PasswordHash {
     /// # Examples
     ///
     /// ```
-    /// use cot::auth::{Password, PasswordHash};
+    /// use cot::auth::PasswordHash;
+    /// use cot::form::types::Password;
     ///
     /// let hash = PasswordHash::from_password(&Password::new("password"));
     /// assert!(!hash.as_str().is_empty());
@@ -607,7 +608,8 @@ impl PasswordHash {
     /// # Examples
     ///
     /// ```
-    /// use cot::auth::{Password, PasswordHash};
+    /// use cot::auth::PasswordHash;
+    /// use cot::form::types::Password;
     ///
     /// let hash = PasswordHash::from_password(&Password::new("password"));
     /// assert!(!hash.into_string().is_empty());

--- a/cot/src/auth.rs
+++ b/cot/src/auth.rs
@@ -16,11 +16,6 @@ use std::sync::{Arc, Mutex, MutexGuard};
 /// backwards compatible shim for form Password type.
 #[deprecated(since = "0.3.0", note = "use `cot::form::types::Password` instead")]
 pub type Password = crate::form::types::Password;
-use crate::config::SecretKey;
-#[cfg(feature = "db")]
-use crate::db::{ColumnType, DatabaseField, DbValue, FromDbValue, SqlxValueRef, ToDbValue};
-use crate::request::{Request, RequestExt};
-use crate::session::Session;
 use async_trait::async_trait;
 use chrono::{DateTime, FixedOffset};
 use derive_more::with_trait::Debug;
@@ -30,6 +25,12 @@ use password_auth::VerifyError;
 use serde::{Deserialize, Serialize};
 use subtle::ConstantTimeEq;
 use thiserror::Error;
+
+use crate::config::SecretKey;
+#[cfg(feature = "db")]
+use crate::db::{ColumnType, DatabaseField, DbValue, FromDbValue, SqlxValueRef, ToDbValue};
+use crate::request::{Request, RequestExt};
+use crate::session::Session;
 
 /// An error that occurs during authentication.
 #[derive(Debug, Error)]

--- a/cot/src/auth.rs
+++ b/cot/src/auth.rs
@@ -14,8 +14,8 @@ use std::borrow::Cow;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 /// backwards compatible shim for form Password type.
-#[deprecated(since = "0.3.0", note = "use `cot::form::types::Password` instead")]
-pub type Password = crate::form::types::Password;
+#[deprecated(since = "0.3.0", note = "use `cot::common_types::Password` instead")]
+pub type Password = crate::common_types::Password;
 use async_trait::async_trait;
 use chrono::{DateTime, FixedOffset};
 use derive_more::with_trait::Debug;
@@ -514,12 +514,12 @@ impl PasswordHash {
     ///
     /// ```
     /// use cot::auth::PasswordHash;
-    /// use cot::form::types::Password;
+    /// use cot::common_types::Password;
     ///
     /// let hash = PasswordHash::from_password(&Password::new("password"));
     /// ```
     #[must_use]
-    pub fn from_password(password: &crate::form::types::Password) -> Self {
+    pub fn from_password(password: &crate::common_types::Password) -> Self {
         let hash = password_auth::generate_hash(password.as_str());
 
         if hash.len() > MAX_PASSWORD_HASH_LENGTH as usize {
@@ -542,7 +542,7 @@ impl PasswordHash {
     ///
     /// ```
     /// use cot::auth::{PasswordHash, PasswordVerificationResult};
-    /// use cot::form::types::Password;
+    /// use cot::common_types::Password;
     ///
     /// let password = Password::new("password");
     /// let hash = PasswordHash::from_password(&password);
@@ -556,7 +556,7 @@ impl PasswordHash {
     ///     PasswordVerificationResult::Invalid => println!("Password is invalid"),
     /// }
     /// ```
-    pub fn verify(&self, password: &crate::form::types::Password) -> PasswordVerificationResult {
+    pub fn verify(&self, password: &crate::common_types::Password) -> PasswordVerificationResult {
         const VALID_ERROR_STR: &str = "password hash should always be valid if created with `PasswordHash::new` or `PasswordHash::from_password`";
 
         match password_auth::verify_password(password.as_str(), &self.0) {
@@ -588,7 +588,7 @@ impl PasswordHash {
     ///
     /// ```
     /// use cot::auth::PasswordHash;
-    /// use cot::form::types::Password;
+    /// use cot::common_types::Password;
     ///
     /// let hash = PasswordHash::from_password(&Password::new("password"));
     /// assert!(!hash.as_str().is_empty());
@@ -609,7 +609,7 @@ impl PasswordHash {
     ///
     /// ```
     /// use cot::auth::PasswordHash;
-    /// use cot::form::types::Password;
+    /// use cot::common_types::Password;
     ///
     /// let hash = PasswordHash::from_password(&Password::new("password"));
     /// assert!(!hash.into_string().is_empty());
@@ -1029,7 +1029,7 @@ mod tests {
 
     use super::*;
     use crate::config::ProjectConfig;
-    use crate::form::types::Password;
+    use crate::common_types::Password;
     use crate::test::TestRequestBuilder;
 
     struct MockAuthBackend<F> {

--- a/cot/src/auth.rs
+++ b/cot/src/auth.rs
@@ -13,6 +13,11 @@ use std::any::Any;
 use std::borrow::Cow;
 use std::sync::{Arc, Mutex, MutexGuard};
 
+#[deprecated(
+    since = "0.3.0",
+    note = "use `cot::form::types::Password` instead"
+)]
+pub use crate::form::types::Password;
 use crate::config::SecretKey;
 #[cfg(feature = "db")]
 use crate::db::{ColumnType, DatabaseField, DbValue, FromDbValue, SqlxValueRef, ToDbValue};
@@ -1221,19 +1226,6 @@ mod tests {
     fn session_auth_hash_debug() {
         let hash = SessionAuthHash::from([1, 2, 3].as_ref());
         assert_eq!(format!("{hash:?}"), "SessionAuthHash(\"**********\")");
-    }
-
-    #[test]
-    fn password_debug() {
-        let password = Password::new("password");
-        assert_eq!(format!("{password:?}"), "Password(\"**********\")");
-    }
-
-    #[test]
-    fn password_str() {
-        let password = Password::new("password");
-        assert_eq!(password.as_str(), "password");
-        assert_eq!(password.into_string(), "password");
     }
 
     const TEST_PASSWORD_HASH: &str = "$argon2id$v=19$m=19456,t=2,p=1$QAAI3EMU1eTLT9NzzBhQjg$khq4zuHsEyk9trGjuqMBFYnTbpqkmn0wXGxFn1nkPBc";

--- a/cot/src/auth.rs
+++ b/cot/src/auth.rs
@@ -13,6 +13,7 @@ use std::any::Any;
 use std::borrow::Cow;
 use std::sync::{Arc, Mutex, MutexGuard};
 
+/// backwards compatible shim for form Password type.
 #[deprecated(since = "0.3.0", note = "use `cot::form::types::Password` instead")]
 pub type Password = crate::form::types::Password;
 use crate::config::SecretKey;
@@ -511,12 +512,13 @@ impl PasswordHash {
     /// # Examples
     ///
     /// ```
-    /// use cot::auth::{Password, PasswordHash};
+    /// use cot::auth::PasswordHash;
+    /// use cot::form::types::Password;
     ///
     /// let hash = PasswordHash::from_password(&Password::new("password"));
     /// ```
     #[must_use]
-    pub fn from_password(password: &Password) -> Self {
+    pub fn from_password(password: &crate::form::types::Password) -> Self {
         let hash = password_auth::generate_hash(password.as_str());
 
         if hash.len() > MAX_PASSWORD_HASH_LENGTH as usize {
@@ -538,7 +540,8 @@ impl PasswordHash {
     /// # Examples
     ///
     /// ```
-    /// use cot::auth::{Password, PasswordHash, PasswordVerificationResult};
+    /// use cot::auth::{PasswordHash, PasswordVerificationResult};
+    /// use cot::form::types::Password;
     ///
     /// let password = Password::new("password");
     /// let hash = PasswordHash::from_password(&password);
@@ -552,7 +555,7 @@ impl PasswordHash {
     ///     PasswordVerificationResult::Invalid => println!("Password is invalid"),
     /// }
     /// ```
-    pub fn verify(&self, password: &Password) -> PasswordVerificationResult {
+    pub fn verify(&self, password: &crate::form::types::Password) -> PasswordVerificationResult {
         const VALID_ERROR_STR: &str = "password hash should always be valid if created with `PasswordHash::new` or `PasswordHash::from_password`";
 
         match password_auth::verify_password(password.as_str(), &self.0) {
@@ -678,117 +681,6 @@ impl FromDbValue for PasswordHash {
 impl ToDbValue for PasswordHash {
     fn to_db_value(&self) -> DbValue {
         self.0.clone().into()
-    }
-}
-
-/// A password.
-///
-/// It is always recommended to store passwords in memory using this newtype
-/// instead of a raw String, as it has a [`Debug`] implementation that hides
-/// the password value.
-///
-/// For persisting passwords in the database, and verifying passwords against
-/// the hash, use [`PasswordHash`].
-///
-/// # Security
-///
-/// The implementation of the [`Debug`] trait for this type hides the password
-/// value to prevent it from being leaked in logs or other debug output.
-///
-/// ## Password Comparison
-///
-/// When comparing passwords, there are two recommended approaches:
-///
-/// 1. The most secure approach is to use [`PasswordHash::from_password`] to
-///    create a hash from one password, and then use [`PasswordHash::verify`] to
-///    compare it with the other password. This method uses constant-time
-///    equality comparison, which protects against timing attacks.
-///
-/// 2. An alternative is to use the [`Password::as_str`] method and compare the
-///    strings directly. This approach uses non-constant-time comparison, which
-///    is less secure but may be acceptable in certain legitimate use cases
-///    where the security tradeoff is understood, e.g., when you're creating a
-///    user registration form with the "retype your password" field, where both
-///    passwords come from the same source anyway.
-///
-/// # Examples
-///
-/// ```
-/// use cot::auth::Password;
-///
-/// let password = Password::new("pass");
-/// assert_eq!(&format!("{:?}", password), "Password(\"**********\")");
-/// ```
-#[derive(Clone)]
-pub struct Password(String);
-
-impl Debug for Password {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("Password").field(&"**********").finish()
-    }
-}
-
-impl Password {
-    /// Creates a new password object.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use cot::auth::Password;
-    ///
-    /// let password = Password::new("password");
-    /// ```
-    #[must_use]
-    pub fn new<T: Into<String>>(password: T) -> Self {
-        Self(password.into())
-    }
-
-    /// Returns the password as a string.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use cot::auth::Password;
-    ///
-    /// let password = Password::new("password");
-    /// assert_eq!(password.as_str(), "password");
-    /// ```
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-
-    /// Consumes the object and returns the password as a string.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use cot::auth::Password;
-    ///
-    /// let password = Password::new("password");
-    /// assert_eq!(password.into_string(), "password");
-    /// ```
-    #[must_use]
-    pub fn into_string(self) -> String {
-        self.0
-    }
-}
-
-impl From<&Password> for Password {
-    fn from(password: &Password) -> Self {
-        password.clone()
-    }
-}
-
-impl From<&str> for Password {
-    fn from(password: &str) -> Self {
-        Self::new(password)
-    }
-}
-
-impl From<String> for Password {
-    fn from(password: String) -> Self {
-        Self::new(password)
     }
 }
 

--- a/cot/src/auth.rs
+++ b/cot/src/auth.rs
@@ -11,23 +11,27 @@ pub mod db;
 
 use std::any::Any;
 use std::borrow::Cow;
+use std::str::FromStr;
 use std::sync::{Arc, Mutex, MutexGuard};
-
-use async_trait::async_trait;
-use chrono::{DateTime, FixedOffset};
-use derive_more::with_trait::Debug;
-#[cfg(test)]
-use mockall::automock;
-use password_auth::VerifyError;
-use serde::{Deserialize, Serialize};
-use subtle::ConstantTimeEq;
-use thiserror::Error;
 
 use crate::config::SecretKey;
 #[cfg(feature = "db")]
 use crate::db::{ColumnType, DatabaseField, DbValue, FromDbValue, SqlxValueRef, ToDbValue};
 use crate::request::{Request, RequestExt};
 use crate::session::Session;
+use async_trait::async_trait;
+use chrono::{DateTime, FixedOffset};
+use cot::db::impl_mysql::MySqlValueRef;
+use cot::db::impl_postgres::PostgresValueRef;
+use cot::db::impl_sqlite::SqliteValueRef;
+use derive_more::with_trait::Debug;
+use email_address::{EmailAddress, Error};
+#[cfg(test)]
+use mockall::automock;
+use password_auth::VerifyError;
+use serde::{Deserialize, Serialize};
+use subtle::ConstantTimeEq;
+use thiserror::Error;
 
 /// An error that occurs during authentication.
 #[derive(Debug, Error)]
@@ -644,6 +648,8 @@ impl Debug for PasswordHash {
 }
 
 const MAX_PASSWORD_HASH_LENGTH: u32 = 128;
+// Maximum email length as specified in the RFC 5321
+const MAX_EMAIL_LENGTH: u32 = 254;
 
 #[cfg(feature = "db")]
 impl DatabaseField for PasswordHash {
@@ -789,6 +795,82 @@ impl From<String> for Password {
     fn from(password: String) -> Self {
         Self::new(password)
     }
+}
+
+#[derive(Clone, Debug)]
+pub struct Email(EmailAddress);
+
+impl Email {
+    #[must_use]
+    fn new<S: AsRef<str>>(email: S) -> std::result::Result<Email, email_address::Error> {
+        EmailAddress::from_str(email.as_ref()).map(Self)
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    pub fn as_inner(&self) -> &EmailAddress {
+        &self.0
+    }
+}
+
+impl FromStr for Email {
+    type Err = email_address::Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Email::new(s)
+    }
+}
+
+impl TryFrom<&str> for Email {
+    type Error = email_address::Error;
+
+    fn try_from(value: &str) -> std::result::Result<Self, Self::Error> {
+        Email::new(value)
+    }
+}
+
+impl TryFrom<String> for Email {
+    type Error = email_address::Error;
+
+    fn try_from(value: String) -> std::result::Result<Self, Self::Error> {
+        Email::new(value)
+    }
+}
+
+impl ToDbValue for Email {
+    fn to_db_value(&self) -> DbValue {
+        self.0.clone().to_string().into()
+    }
+}
+
+impl FromDbValue for Email {
+    fn from_sqlite(value: SqliteValueRef<'_>) -> cot::db::Result<Self>
+    where
+        Self: Sized,
+    {
+        Email::new(value.get::<String>()?).map_err(cot::db::DatabaseError::value_decode)
+    }
+
+    fn from_postgres(value: PostgresValueRef<'_>) -> cot::db::Result<Self>
+    where
+        Self: Sized,
+    {
+        Email::new(value.get::<String>()?).map_err(cot::db::DatabaseError::value_decode)
+    }
+
+    fn from_mysql(value: MySqlValueRef<'_>) -> cot::db::Result<Self>
+    where
+        Self: Sized,
+    {
+        Email::new(value.get::<String>()?).map_err(cot::db::DatabaseError::value_decode)
+    }
+}
+
+impl DatabaseField for Email {
+    const TYPE: ColumnType = ColumnType::String(MAX_EMAIL_LENGTH);
 }
 
 /// Authentication helper structure.

--- a/cot/src/auth.rs
+++ b/cot/src/auth.rs
@@ -1028,8 +1028,8 @@ mod tests {
     use mockall::predicate::eq;
 
     use super::*;
-    use crate::config::ProjectConfig;
     use crate::common_types::Password;
+    use crate::config::ProjectConfig;
     use crate::test::TestRequestBuilder;
 
     struct MockAuthBackend<F> {

--- a/cot/src/auth/db.rs
+++ b/cot/src/auth/db.rs
@@ -20,13 +20,14 @@ use thiserror::Error;
 use crate::App;
 use crate::admin::{AdminModelManager, DefaultAdminModelManager};
 use crate::auth::{
-    AuthBackend, AuthError, Password, PasswordHash, PasswordVerificationResult, Result,
-    SessionAuthHash, User, UserId,
+    AuthBackend, AuthError, PasswordHash, PasswordVerificationResult, Result, SessionAuthHash,
+    User, UserId,
 };
 use crate::config::SecretKey;
 use crate::db::migrations::SyncDynMigration;
 use crate::db::{Database, DatabaseBackend, LimitedString, Model, model, query};
 use crate::form::Form;
+use crate::form::types::Password;
 
 pub mod migrations;
 

--- a/cot/src/auth/db.rs
+++ b/cot/src/auth/db.rs
@@ -23,11 +23,11 @@ use crate::auth::{
     AuthBackend, AuthError, PasswordHash, PasswordVerificationResult, Result, SessionAuthHash,
     User, UserId,
 };
+use crate::common_types::Password;
 use crate::config::SecretKey;
 use crate::db::migrations::SyncDynMigration;
 use crate::db::{Database, DatabaseBackend, LimitedString, Model, model, query};
 use crate::form::Form;
-use crate::common_types::Password;
 
 pub mod migrations;
 

--- a/cot/src/auth/db.rs
+++ b/cot/src/auth/db.rs
@@ -27,7 +27,7 @@ use crate::config::SecretKey;
 use crate::db::migrations::SyncDynMigration;
 use crate::db::{Database, DatabaseBackend, LimitedString, Model, model, query};
 use crate::form::Form;
-use crate::form::types::Password;
+use crate::common_types::Password;
 
 pub mod migrations;
 

--- a/cot/src/common_types.rs
+++ b/cot/src/common_types.rs
@@ -363,11 +363,12 @@ impl TryFrom<String> for Email {
 
 /// Implements database value conversion for `Email`.
 ///
-/// This allows `Email` to be stored in the database as a text value.
+/// This allows a normalized `Email` to be stored in the database as a text
+/// value.
 #[cfg(feature = "db")]
 impl ToDbValue for Email {
     fn to_db_value(&self) -> DbValue {
-        self.0.clone().to_string().into()
+        self.0.clone().email().into()
     }
 }
 
@@ -469,6 +470,17 @@ mod tests {
             let email_str = email.as_str();
             let db_value_str = format!("{db_value:?}");
             assert!(db_value_str.contains(email_str));
+        }
+
+        #[test]
+        fn test_to_db_value_is_normalized() {
+            let with_display = Email::new("John Doe <user@example.com>").unwrap();
+            let bare = Email::new("user@example.com").unwrap();
+
+            let db1 = with_display.to_db_value();
+            let db2 = bare.to_db_value();
+
+            assert_eq!(db1, db2);
         }
     }
 }

--- a/cot/src/common_types.rs
+++ b/cot/src/common_types.rs
@@ -207,6 +207,7 @@ impl Email {
     /// let email = Email::from_str("user@example.com").unwrap();
     /// assert_eq!(email.domain(), "example.com");
     /// ```
+    #[must_use]
     pub fn domain(&self) -> &str {
         self.0.domain()
     }
@@ -224,6 +225,7 @@ impl Email {
     /// let email = Email::from_str("user@example.com").unwrap();
     /// assert_eq!(email.to_uri(), "mailto:user@example.com");
     /// ```
+    #[must_use]
     pub fn to_uri(&self) -> String {
         self.0.to_uri()
     }
@@ -243,6 +245,7 @@ impl Email {
     /// let email = Email::from_str("user@example.com").unwrap();
     /// assert_eq!(email.to_display("John Doe"), "John Doe <user@example.com>");
     /// ```
+    #[must_use]
     pub fn to_display(&self, display_name: &str) -> String {
         self.0.to_display(display_name)
     }
@@ -259,6 +262,7 @@ impl Email {
     /// let email = Email::from_str("user@example.com").unwrap();
     /// assert_eq!(email.email(), "user@example.com");
     /// ```
+    #[must_use]
     pub fn email(&self) -> String {
         self.0.email()
     }
@@ -276,6 +280,7 @@ impl Email {
     /// let email = Email::from_str("user@example.com").unwrap();
     /// assert_eq!(email.local_part(), "user");
     /// ```
+    #[must_use]
     pub fn local_part(&self) -> &str {
         self.0.local_part()
     }
@@ -296,6 +301,7 @@ impl Email {
     /// let email = Email::from_str("Name <name@example.org>").unwrap();
     /// assert_eq!(email.display_part(), "Name".to_owned());
     /// ```
+    #[must_use]
     pub fn display_part(&self) -> &str {
         self.0.display_part()
     }

--- a/cot/src/common_types.rs
+++ b/cot/src/common_types.rs
@@ -75,7 +75,7 @@ impl Password {
     /// # Examples
     ///
     /// ```
-    /// use cot::form::types::Password;
+    /// use cot::common_types::Password;
     ///
     /// let password = Password::new("password");
     /// ```
@@ -89,7 +89,7 @@ impl Password {
     /// # Examples
     ///
     /// ```
-    /// use cot::form::types::Password;
+    /// use cot::common_types::Password;
     ///
     /// let password = Password::new("password");
     /// assert_eq!(password.as_str(), "password");
@@ -104,7 +104,7 @@ impl Password {
     /// # Examples
     ///
     /// ```
-    /// use cot::form::types::Password;
+    /// use cot::common_types::Password;
     ///
     /// let password = Password::new("password");
     /// assert_eq!(password.into_string(), "password");
@@ -145,7 +145,7 @@ impl From<String> for Password {
 /// ```
 /// use std::str::FromStr;
 ///
-/// use cot::form::types::Email;
+/// use cot::common_types::Email;
 ///
 /// // Parse from a string
 /// let email = Email::from_str("user@example.com").unwrap();
@@ -168,7 +168,7 @@ impl Email {
     /// # Examples
     ///
     /// ```
-    /// use cot::form::types::Email;
+    /// use cot::common_types::Email;
     ///
     /// let email = Email::new("user@example.com").unwrap();
     /// assert!(Email::new("invalid").is_err());
@@ -184,7 +184,7 @@ impl Email {
     /// ```
     /// use std::str::FromStr;
     ///
-    /// use cot::form::types::Email;
+    /// use cot::common_types::Email;
     ///
     /// let email = Email::from_str("user@example.com").unwrap();
     /// assert_eq!(email.as_str(), "user@example.com");
@@ -204,7 +204,7 @@ impl Email {
     /// ```
     /// use std::str::FromStr;
     ///
-    /// use cot::form::types::Email;
+    /// use cot::common_types::Email;
     ///
     /// let email = Email::from_str("user@example.com").unwrap();
     /// let domain = email.as_inner().domain();
@@ -223,7 +223,7 @@ impl Email {
 /// ```
 /// use std::str::FromStr;
 ///
-/// use cot::form::types::Email;
+/// use cot::common_types::Email;
 ///
 /// let email = Email::from_str("user@example.com").unwrap();
 /// ```
@@ -240,7 +240,7 @@ impl FromStr for Email {
 /// # Examples
 ///
 /// ```
-/// use cot::form::types::Email;
+/// use cot::common_types::Email;
 ///
 /// let email = Email::try_from("user@example.com").unwrap();
 /// ```
@@ -257,7 +257,7 @@ impl TryFrom<&str> for Email {
 /// # Examples
 ///
 /// ```
-/// use cot::form::types::Email;
+/// use cot::common_types::Email;
 ///
 /// let email = Email::try_from(String::from("user@example.com")).unwrap();
 /// ```

--- a/cot/src/common_types.rs
+++ b/cot/src/common_types.rs
@@ -194,10 +194,8 @@ impl Email {
         self.0.as_str()
     }
 
-    /// Returns a reference to the underlying `EmailAddress`.
-    ///
-    /// This is useful when you need to access functionality provided by the
-    /// `email_address` crate directly.
+    /// Returns the domain part of the email address (the part after the '@'
+    /// symbol).
     ///
     /// # Examples
     ///
@@ -207,12 +205,102 @@ impl Email {
     /// use cot::common_types::Email;
     ///
     /// let email = Email::from_str("user@example.com").unwrap();
-    /// let domain = email.as_inner().domain();
-    /// assert_eq!(domain, "example.com");
+    /// assert_eq!(email.domain(), "example.com");
     /// ```
-    #[must_use]
-    pub fn as_inner(&self) -> &EmailAddress {
-        &self.0
+    pub fn domain(&self) -> &str {
+        self.0.domain()
+    }
+
+    /// Formats the email address as a URI, typically for use in `mailto:`
+    /// links.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::str::FromStr;
+    ///
+    /// use cot::common_types::Email;
+    ///
+    /// let email = Email::from_str("user@example.com").unwrap();
+    /// assert_eq!(email.to_uri(), "mailto:user@example.com");
+    /// ```
+    pub fn to_uri(&self) -> String {
+        self.0.to_uri()
+    }
+
+    /// Formats the email address with a display name.
+    ///
+    /// This creates a formatted email address with the format: `"Display Name"
+    /// <user@example.com>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::str::FromStr;
+    ///
+    /// use cot::common_types::Email;
+    ///
+    /// let email = Email::from_str("user@example.com").unwrap();
+    /// assert_eq!(
+    ///     email.to_display("John Doe"),
+    ///     "\"John Doe\" <user@example.com>"
+    /// );
+    /// ```
+    pub fn to_display(&self, display_name: &str) -> String {
+        self.0.to_display(display_name)
+    }
+
+    /// Returns the full email address as a string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::str::FromStr;
+    ///
+    /// use cot::common_types::Email;
+    ///
+    /// let email = Email::from_str("user@example.com").unwrap();
+    /// assert_eq!(email.email(), "user@example.com");
+    /// ```
+    pub fn email(&self) -> String {
+        self.0.email()
+    }
+
+    /// Returns the local part of the email address (the part before the '@'
+    /// symbol).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::str::FromStr;
+    ///
+    /// use cot::common_types::Email;
+    ///
+    /// let email = Email::from_str("user@example.com").unwrap();
+    /// assert_eq!(email.local_part(), "user");
+    /// ```
+    pub fn local_part(&self) -> &str {
+        self.0.local_part()
+    }
+
+    /// Returns the display part of the email address.
+    ///
+    /// For simple email addresses, this is typically the same as the local
+    /// part. For email addresses with display names, this returns the
+    /// display name portion.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::str::FromStr;
+    ///
+    /// use cot::common_types::Email;
+    ///
+    /// let email = Email::from_str("user@example.com").unwrap();
+    /// assert_eq!(email.display_part(), "user");
+    /// ```
+    pub fn display_part(&self) -> &str {
+        self.0.display_part()
     }
 }
 
@@ -344,7 +432,7 @@ mod tests {
     fn test_valid_email_creation() {
         let email = Email::new("user@example.com").unwrap();
         assert_eq!(email.as_str(), "user@example.com");
-        assert_eq!(email.as_inner().domain(), "example.com");
+        assert_eq!(email.domain(), "example.com");
     }
 
     #[test]

--- a/cot/src/common_types.rs
+++ b/cot/src/common_types.rs
@@ -241,10 +241,7 @@ impl Email {
     /// use cot::common_types::Email;
     ///
     /// let email = Email::from_str("user@example.com").unwrap();
-    /// assert_eq!(
-    ///     email.to_display("John Doe"),
-    ///     "\"John Doe\" <user@example.com>"
-    /// );
+    /// assert_eq!(email.to_display("John Doe"), "John Doe <user@example.com>");
     /// ```
     pub fn to_display(&self, display_name: &str) -> String {
         self.0.to_display(display_name)
@@ -296,8 +293,8 @@ impl Email {
     ///
     /// use cot::common_types::Email;
     ///
-    /// let email = Email::from_str("user@example.com").unwrap();
-    /// assert_eq!(email.display_part(), "user");
+    /// let email = Email::from_str("Name <name@example.org>").unwrap();
+    /// assert_eq!(email.display_part(), "Name".to_owned());
     /// ```
     pub fn display_part(&self) -> &str {
         self.0.display_part()

--- a/cot/src/form.rs
+++ b/cot/src/form.rs
@@ -157,6 +157,12 @@ impl FormFieldValidationError {
     }
 }
 
+impl From<email_address::Error> for FormFieldValidationError {
+    fn from(error: email_address::Error) -> Self {
+        FormFieldValidationError::from_string(error.to_string())
+    }
+}
+
 /// An enum indicating the target of a form validation error.
 #[derive(Debug)]
 pub enum FormErrorTarget<'a> {

--- a/cot/src/form.rs
+++ b/cot/src/form.rs
@@ -22,7 +22,6 @@
 
 /// Built-in form fields that can be used in a form.
 pub mod fields;
-pub mod types;
 
 use std::borrow::Cow;
 use std::fmt::{Debug, Display};

--- a/cot/src/form.rs
+++ b/cot/src/form.rs
@@ -22,6 +22,7 @@
 
 /// Built-in form fields that can be used in a form.
 pub mod fields;
+pub mod types;
 
 use std::borrow::Cow;
 use std::fmt::{Debug, Display};

--- a/cot/src/form.rs
+++ b/cot/src/form.rs
@@ -118,6 +118,13 @@ pub enum FormFieldValidationError {
         /// The maximum length of the field.
         max_length: u32,
     },
+
+    /// The field value is too short.
+    #[error("This is below the minimum length of {min_length}.")]
+    MinimumLengthNotMet {
+        /// The minimum length of the field.
+        min_length: u32,
+    },
     /// The field value is required to be true.
     #[error("This field must be checked.")]
     BooleanRequiredToBeTrue,
@@ -142,6 +149,13 @@ impl FormFieldValidationError {
     #[must_use]
     pub fn maximum_length_exceeded(max_length: u32) -> Self {
         Self::MaximumLengthExceeded { max_length }
+    }
+
+    /// Creates a new `FormFieldValidationError` for a field value that is too
+    /// short.
+    #[must_use]
+    pub fn minimum_length_not_met(min_length: u32) -> Self {
+        FormFieldValidationError::MinimumLengthNotMet { min_length }
     }
 
     /// Creates a new `FormFieldValidationError` from a `String`.

--- a/cot/src/form/fields.rs
+++ b/cot/src/form/fields.rs
@@ -9,10 +9,10 @@ use askama::filters::HtmlSafe;
 #[cfg(feature = "db")]
 use cot::db::Auto;
 
-use crate::auth::{Password, PasswordHash};
+use crate::auth::PasswordHash;
 #[cfg(feature = "db")]
 use crate::db::LimitedString;
-use crate::form::types::Email;
+use crate::form::types::{Email, Password};
 use crate::form::{AsFormField, FormField, FormFieldOptions, FormFieldValidationError};
 use crate::html::HtmlTag;
 

--- a/cot/src/form/fields.rs
+++ b/cot/src/form/fields.rs
@@ -10,9 +10,9 @@ use askama::filters::HtmlSafe;
 use cot::db::Auto;
 
 use crate::auth::PasswordHash;
+use crate::common_types::{Email, Password};
 #[cfg(feature = "db")]
 use crate::db::LimitedString;
-use crate::common_types::{Email, Password};
 use crate::form::{AsFormField, FormField, FormFieldOptions, FormFieldValidationError};
 use crate::html::HtmlTag;
 

--- a/cot/src/form/fields.rs
+++ b/cot/src/form/fields.rs
@@ -808,7 +808,10 @@ mod tests {
         field.set_value(Cow::Borrowed("averylongemail@example.com"));
         let result = Email::clean_value(&field);
 
-        assert!(matches!(result, Err(FormFieldValidationError::MaximumLengthExceeded { max_length: _ })));
+        assert!(matches!(
+            result,
+            Err(FormFieldValidationError::MaximumLengthExceeded { max_length: _ })
+        ));
     }
 
     #[test]

--- a/cot/src/form/fields.rs
+++ b/cot/src/form/fields.rs
@@ -205,10 +205,10 @@ impl_form_field!(EmailField, EmailFieldOptions, "an email");
 /// Custom options for [`EmailField`]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct EmailFieldOptions {
-    /// The maximum length of the field. used to set the `maxlength` attribute
+    /// The maximum length of the field used to set the `maxlength` attribute
     /// in the HTML input element.
     pub max_length: Option<u32>,
-    /// The minimum length of the field. used to set the `minlength` attribute
+    /// The minimum length of the field used to set the `minlength` attribute
     /// in the HTML input element.
     pub min_length: Option<u32>,
 }

--- a/cot/src/form/fields.rs
+++ b/cot/src/form/fields.rs
@@ -12,7 +12,7 @@ use cot::db::Auto;
 use crate::auth::PasswordHash;
 #[cfg(feature = "db")]
 use crate::db::LimitedString;
-use crate::form::types::{Email, Password};
+use crate::common_types::{Email, Password};
 use crate::form::{AsFormField, FormField, FormFieldOptions, FormFieldValidationError};
 use crate::html::HtmlTag;
 

--- a/cot/src/form/types.rs
+++ b/cot/src/form/types.rs
@@ -31,6 +31,22 @@ const MAX_EMAIL_LENGTH: u32 = 254;
 /// The implementation of the [`Debug`] trait for this type hides the password
 /// value to prevent it from being leaked in logs or other debug output.
 ///
+/// ## Password Comparison
+///
+/// When comparing passwords, there are two recommended approaches:
+///
+/// 1. The most secure approach is to use [`PasswordHash::from_password`] to
+///    create a hash from one password, and then use [`PasswordHash::verify`] to
+///    compare it with the other password. This method uses constant-time
+///    equality comparison, which protects against timing attacks.
+///
+/// 2. An alternative is to use the [`Password::as_str`] method and compare the
+///    strings directly. This approach uses non-constant-time comparison, which
+///    is less secure but may be acceptable in certain legitimate use cases
+///    where the security tradeoff is understood, e.g., when you're creating a
+///    user registration form with the "retype your password" field, where both
+///    passwords come from the same source anyway.
+///
 /// # Examples
 ///
 /// ```

--- a/cot/src/form/types.rs
+++ b/cot/src/form/types.rs
@@ -1,18 +1,20 @@
 //! Form Field Types for Cot
 //!
-//! This module provides a collection of form field types and utilities for validating,
-//! parsing, and converting user input within Cot. It includes general-purpose newtype wrappers
-//! and associated trait implementations to ensure consistent and safe processing of form data.
+//! This module provides a collection of form field types and utilities for
+//! validating, parsing, and converting user input within Cot. It includes
+//! general-purpose newtype wrappers and associated trait implementations to
+//! ensure consistent and safe processing of form data.
 
 use std::fmt::Debug;
 use std::str::FromStr;
 
-#[cfg(feature = "db")]
-use crate::db::{ColumnType, DatabaseField, DbValue, FromDbValue, SqlxValueRef, ToDbValue};
 use cot::db::impl_mysql::MySqlValueRef;
 use cot::db::impl_postgres::PostgresValueRef;
 use cot::db::impl_sqlite::SqliteValueRef;
 use email_address::EmailAddress;
+
+#[cfg(feature = "db")]
+use crate::db::{ColumnType, DatabaseField, DbValue, FromDbValue, SqlxValueRef, ToDbValue};
 
 // Maximum email length as specified in the RFC 5321
 const MAX_EMAIL_LENGTH: u32 = 254;
@@ -130,15 +132,17 @@ impl From<String> for Password {
 
 /// A validated email address.
 ///
-/// This is a newtype wrapper around [`EmailAddress`](email_address::EmailAddress) that provides
-/// validation and integration with Cot's database system. It ensures email addresses
+/// This is a newtype wrapper around
+/// [`EmailAddress`](email_address::EmailAddress) that provides validation and
+/// integration with Cot's database system. It ensures email addresses
 /// comply with RFC 5321/5322 standards.
 ///
 /// # Examples
 ///
 /// ```
-/// use cot::form::types::Email;
 /// use std::str::FromStr;
+///
+/// use cot::form::types::Email;
 ///
 /// // Parse from a string
 /// let email = Email::from_str("user@example.com").unwrap();
@@ -150,11 +154,13 @@ impl From<String> for Password {
 pub struct Email(EmailAddress);
 
 impl Email {
-    /// Creates a new `Email` from a string, validating that it's a proper email address.
+    /// Creates a new `Email` from a string, validating that it's a proper email
+    /// address.
     ///
     /// # Errors
     ///
-    /// Returns an error if the email address is invalid according to RFC standards.
+    /// Returns an error if the email address is invalid according to RFC
+    /// standards.
     ///
     /// # Examples
     ///
@@ -174,6 +180,7 @@ impl Email {
     ///
     /// ```
     /// use std::str::FromStr;
+    ///
     /// use cot::form::types::Email;
     ///
     /// let email = Email::from_str("user@example.com").unwrap();
@@ -193,6 +200,7 @@ impl Email {
     ///
     /// ```
     /// use std::str::FromStr;
+    ///
     /// use cot::form::types::Email;
     ///
     /// let email = Email::from_str("user@example.com").unwrap();
@@ -211,6 +219,7 @@ impl Email {
 ///
 /// ```
 /// use std::str::FromStr;
+///
 /// use cot::form::types::Email;
 ///
 /// let email = Email::from_str("user@example.com").unwrap();
@@ -267,9 +276,11 @@ impl ToDbValue for Email {
     }
 }
 
-/// Implements database value conversion for retrieving `Email` from the database.
+/// Implements database value conversion for retrieving `Email` from the
+/// database.
 ///
-/// This allows `Email` to be retrieved from the database and properly converted and validated.
+/// This allows `Email` to be retrieved from the database and properly converted
+/// and validated.
 #[cfg(feature = "db")]
 impl FromDbValue for Email {
     #[cfg(feature = "sqlite")]
@@ -308,8 +319,9 @@ impl DatabaseField for Email {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::convert::TryFrom;
+
+    use super::*;
 
     #[test]
     fn password_debug() {

--- a/cot/src/form/types.rs
+++ b/cot/src/form/types.rs
@@ -8,11 +8,11 @@
 use std::fmt::Debug;
 use std::str::FromStr;
 
-#[cfg(feature = "db")]
+#[cfg(feature = "mysql")]
 use cot::db::impl_mysql::MySqlValueRef;
-#[cfg(feature = "db")]
+#[cfg(feature = "postgres")]
 use cot::db::impl_postgres::PostgresValueRef;
-#[cfg(feature = "db")]
+#[cfg(feature = "sqlite")]
 use cot::db::impl_sqlite::SqliteValueRef;
 use email_address::EmailAddress;
 

--- a/cot/src/form/types.rs
+++ b/cot/src/form/types.rs
@@ -1,0 +1,242 @@
+//! Form Field Types for Cot
+//!
+//! This module provides a collection of form field types and utilities for validating,
+//! parsing, and converting user input within Cot. It includes general-purpose newtype wrappers
+//! and associated trait implementations to ensure consistent and safe processing of form data.
+
+use std::str::FromStr;
+
+#[cfg(feature = "db")]
+use crate::db::{ColumnType, DatabaseField, DbValue, FromDbValue, SqlxValueRef, ToDbValue};
+use cot::db::impl_mysql::MySqlValueRef;
+use cot::db::impl_postgres::PostgresValueRef;
+use cot::db::impl_sqlite::SqliteValueRef;
+use email_address::EmailAddress;
+
+// Maximum email length as specified in the RFC 5321
+const MAX_EMAIL_LENGTH: u32 = 254;
+
+/// A validated email address.
+///
+/// This is a newtype wrapper around [`EmailAddress`](email_address::EmailAddress) that provides
+/// validation and integration with Cot's database system. It ensures email addresses
+/// comply with RFC 5321/5322 standards.
+///
+/// # Examples
+///
+/// ```
+/// use cot::form::types::Email;
+/// use std::str::FromStr;
+///
+/// // Parse from a string
+/// let email = Email::from_str("user@example.com").unwrap();
+///
+/// // Convert using TryFrom
+/// let email = Email::try_from("user@example.com").unwrap();
+/// ```
+#[derive(Clone, Debug)]
+pub struct Email(EmailAddress);
+
+impl Email {
+    /// Creates a new `Email` from a string, validating that it's a proper email address.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the email address is invalid according to RFC standards.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cot::form::types::Email;
+    ///
+    /// let email = Email::new("user@example.com").unwrap();
+    /// assert!(Email::new("invalid").is_err());
+    /// ```
+    pub fn new<S: AsRef<str>>(email: S) -> Result<Email, email_address::Error> {
+        EmailAddress::from_str(email.as_ref()).map(Self)
+    }
+
+    /// Returns the email address as a string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::str::FromStr;
+    /// use cot::form::types::Email;
+    ///
+    /// let email = Email::from_str("user@example.com").unwrap();
+    /// assert_eq!(email.as_str(), "user@example.com");
+    /// ```
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    /// Returns a reference to the underlying `EmailAddress`.
+    ///
+    /// This is useful when you need to access functionality provided by the
+    /// `email_address` crate directly.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::str::FromStr;
+    /// use cot::form::types::Email;
+    ///
+    /// let email = Email::from_str("user@example.com").unwrap();
+    /// let domain = email.as_inner().domain();
+    /// assert_eq!(domain, "example.com");
+    /// ```
+    #[must_use] pub fn as_inner(&self) -> &EmailAddress {
+        &self.0
+    }
+}
+
+/// Implements string parsing for `Email`.
+///
+/// # Examples
+///
+/// ```
+/// use std::str::FromStr;
+/// use cot::form::types::Email;
+///
+/// let email = Email::from_str("user@example.com").unwrap();
+/// ```
+impl FromStr for Email {
+    type Err = email_address::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Email::new(s)
+    }
+}
+
+/// Implements conversion from string references to `Email`.
+///
+/// # Examples
+///
+/// ```
+/// use cot::form::types::Email;
+///
+/// let email = Email::try_from("user@example.com").unwrap();
+/// ```
+impl TryFrom<&str> for Email {
+    type Error = email_address::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Email::new(value)
+    }
+}
+
+/// Implements conversion from `String` to `Email`.
+///
+/// # Examples
+///
+/// ```
+/// use cot::form::types::Email;
+///
+/// let email = Email::try_from(String::from("user@example.com")).unwrap();
+/// ```
+#[cfg(feature = "db")]
+impl TryFrom<String> for Email {
+    type Error = email_address::Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Email::new(value)
+    }
+}
+
+/// Implements database value conversion for `Email`.
+///
+/// This allows `Email` to be stored in the database as a text value.
+impl ToDbValue for Email {
+    fn to_db_value(&self) -> DbValue {
+        self.0.clone().to_string().into()
+    }
+}
+
+/// Implements database value conversion for retrieving `Email` from the database.
+///
+/// This allows `Email` to be retrieved from the database and properly converted and validated.
+#[cfg(feature = "db")]
+impl FromDbValue for Email {
+    #[cfg(feature = "sqlite")]
+    fn from_sqlite(value: SqliteValueRef<'_>) -> cot::db::Result<Self>
+    where
+        Self: Sized,
+    {
+        Email::new(value.get::<String>()?).map_err(cot::db::DatabaseError::value_decode)
+    }
+
+    #[cfg(feature = "postgres")]
+    fn from_postgres(value: PostgresValueRef<'_>) -> cot::db::Result<Self>
+    where
+        Self: Sized,
+    {
+        Email::new(value.get::<String>()?).map_err(cot::db::DatabaseError::value_decode)
+    }
+
+    #[cfg(feature = "mysql")]
+    fn from_mysql(value: MySqlValueRef<'_>) -> cot::db::Result<Self>
+    where
+        Self: Sized,
+    {
+        Email::new(value.get::<String>()?).map_err(cot::db::DatabaseError::value_decode)
+    }
+}
+
+/// Defines the database field type for `Email`.
+///
+/// Emails are stored as strings with a maximum length of 254 characters,
+/// as specified in RFC 5321.
+#[cfg(feature = "db")]
+impl DatabaseField for Email {
+    const TYPE: ColumnType = ColumnType::String(MAX_EMAIL_LENGTH);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::convert::TryFrom;
+    
+
+    #[test]
+    fn test_valid_email_creation() {
+        let email = Email::new("user@example.com").unwrap();
+        assert_eq!(email.as_str(), "user@example.com");
+        assert_eq!(email.as_inner().domain(), "example.com");
+    }
+
+    #[test]
+    fn test_invalid_email_creation() {
+        let result = Email::new("invalid");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_str_trait() {
+        let email: Email = "user@example.com".parse().unwrap();
+        assert_eq!(email.as_str(), "user@example.com");
+    }
+
+    #[test]
+    fn test_try_from_trait() {
+        let email = Email::try_from("user@example.com").unwrap();
+        assert_eq!(email.as_str(), "user@example.com");
+    }
+
+    #[cfg(feature = "db")]
+    mod db_tests {
+        use super::*;
+        use crate::db::ToDbValue;
+
+        #[test]
+        fn test_to_db_value() {
+            let email = Email::new("user@example.com").unwrap();
+            let db_value = email.to_db_value();
+
+            let email_str = email.as_str();
+            let db_value_str = format!("{db_value:?}");
+            assert!(db_value_str.contains(email_str));
+        }
+    }
+}

--- a/cot/src/form/types.rs
+++ b/cot/src/form/types.rs
@@ -87,7 +87,8 @@ impl Email {
     /// let domain = email.as_inner().domain();
     /// assert_eq!(domain, "example.com");
     /// ```
-    #[must_use] pub fn as_inner(&self) -> &EmailAddress {
+    #[must_use]
+    pub fn as_inner(&self) -> &EmailAddress {
         &self.0
     }
 }
@@ -197,7 +198,6 @@ impl DatabaseField for Email {
 mod tests {
     use super::*;
     use std::convert::TryFrom;
-    
 
     #[test]
     fn test_valid_email_creation() {

--- a/cot/src/form/types.rs
+++ b/cot/src/form/types.rs
@@ -8,8 +8,11 @@
 use std::fmt::Debug;
 use std::str::FromStr;
 
+#[cfg(feature = "db")]
 use cot::db::impl_mysql::MySqlValueRef;
+#[cfg(feature = "db")]
 use cot::db::impl_postgres::PostgresValueRef;
+#[cfg(feature = "db")]
 use cot::db::impl_sqlite::SqliteValueRef;
 use email_address::EmailAddress;
 
@@ -270,6 +273,7 @@ impl TryFrom<String> for Email {
 /// Implements database value conversion for `Email`.
 ///
 /// This allows `Email` to be stored in the database as a text value.
+#[cfg(feature = "db")]
 impl ToDbValue for Email {
     fn to_db_value(&self) -> DbValue {
         self.0.clone().to_string().into()

--- a/cot/src/lib.rs
+++ b/cot/src/lib.rs
@@ -81,6 +81,7 @@ pub mod session;
 pub mod static_files;
 pub mod test;
 pub(crate) mod utils;
+pub mod common_types;
 
 #[cfg(feature = "openapi")]
 pub use aide;
@@ -93,7 +94,7 @@ pub use {bytes, http};
 
 pub use crate::handler::{BoxedHandler, RequestHandler};
 pub use crate::project::{
-    App, AppBuilder, Bootstrapper, Project, ProjectContext, run, run_at, run_cli,
+    run, run_at, run_cli, App, AppBuilder, Bootstrapper, Project, ProjectContext,
 };
 
 /// A type alias for a result that can return a [`cot::Error`].

--- a/cot/src/lib.rs
+++ b/cot/src/lib.rs
@@ -66,6 +66,7 @@ pub mod admin;
 pub mod auth;
 mod body;
 pub mod cli;
+pub mod common_types;
 pub mod config;
 mod error_page;
 mod handler;
@@ -81,7 +82,6 @@ pub mod session;
 pub mod static_files;
 pub mod test;
 pub(crate) mod utils;
-pub mod common_types;
 
 #[cfg(feature = "openapi")]
 pub use aide;
@@ -94,7 +94,7 @@ pub use {bytes, http};
 
 pub use crate::handler::{BoxedHandler, RequestHandler};
 pub use crate::project::{
-    run, run_at, run_cli, App, AppBuilder, Bootstrapper, Project, ProjectContext,
+    App, AppBuilder, Bootstrapper, Project, ProjectContext, run, run_at, run_cli,
 };
 
 /// A type alias for a result that can return a [`cot::Error`].

--- a/cot/tests/auth.rs
+++ b/cot/tests/auth.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
 
+use cot::auth::Auth;
 use cot::auth::db::{DatabaseUser, DatabaseUserCredentials};
-use cot::auth::{Auth, Password};
+use cot::form::types::Password;
 use cot::request::RequestExt;
 use cot::test::{TestDatabase, TestRequestBuilder};
 

--- a/cot/tests/auth.rs
+++ b/cot/tests/auth.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use cot::auth::Auth;
 use cot::auth::db::{DatabaseUser, DatabaseUserCredentials};
-use cot::form::types::Password;
+use cot::common_types::Password;
 use cot::request::RequestExt;
 use cot::test::{TestDatabase, TestRequestBuilder};
 


### PR DESCRIPTION
Add support for form email fields. This wraps over the `EmailAddress` type in the [email_address crate](https://docs.rs/email_address/latest/email_address/index.html).

Also refactors and deprecates `cot::auth::Password` which is replaced by `cot::form::types::Passsword`.

Example usage:

```rust
use cot::db::{model, Auto, Model};
use cot::form::types::{Email, Password};
use cot::auth::PasswordHash

[derive(Debug, Form)]
struct SignupForm {
    fullname: String,
    email: Email,
    username: String,
    password1: Password,
    password2: Password,
}

#[derive(Debug, Clone)]
#[model]
struct User {
    #[model(primary_key)]
    id: Auto<i32>,
    name: String,
    username: String,
    email: Email,
    password: PasswordHash,
}

```