### PR TITLE
chore(ci): run Rust CI on workflow_dispatch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This should fix the Rust CI not being run after approving the workflows for new contributors.