### PR TITLE
implement `AsFormField` for floating point types

### DIFF
--- a/cot/src/form.rs
+++ b/cot/src/form.rs
@@ -178,15 +178,19 @@ impl FormFieldValidationError {
     /// Creates a new `FormFieldValidatorError`for a field value below the
     /// permitted minimum value.
     #[must_use]
-    pub fn minimum_value_not_met(min_value: String) -> Self {
-        FormFieldValidationError::MinimumValueNotMet { min_value }
+    pub fn minimum_value_not_met<T: Display>(min_value: T) -> Self {
+        FormFieldValidationError::MinimumValueNotMet {
+            min_value: min_value.to_string(),
+        }
     }
 
     /// Creates a new `FormFieldValidationError` for a field value that exceeds
     /// the permitted maximum value
     #[must_use]
-    pub fn maximum_value_exceeded(max_value: String) -> Self {
-        FormFieldValidationError::MaximumValueExceeded { max_value }
+    pub fn maximum_value_exceeded<T: Display>(max_value: T) -> Self {
+        FormFieldValidationError::MaximumValueExceeded {
+            max_value: max_value.to_string(),
+        }
     }
 
     /// Creates a new `FormFieldValidationError` from a `String`.

--- a/cot/src/form.rs
+++ b/cot/src/form.rs
@@ -127,6 +127,21 @@ pub enum FormFieldValidationError {
         /// The minimum length of the field.
         min_length: u32,
     },
+
+    /// The field value is below the permitted minimum.
+    #[error("This is below the minimum value of {min_value}.")]
+    MinimumValueNotMet {
+        /// The minimum permitted value.
+        min_value: String,
+    },
+
+    /// The field value exceeds the permitted maximum.
+    #[error("This exceeds the maximum value of {max_value}.")]
+    MaximumValueExceeded {
+        /// The maximum permitted value.
+        max_value: String,
+    },
+
     /// The field value is required to be true.
     #[error("This field must be checked.")]
     BooleanRequiredToBeTrue,
@@ -158,6 +173,20 @@ impl FormFieldValidationError {
     #[must_use]
     pub fn minimum_length_not_met(min_length: u32) -> Self {
         FormFieldValidationError::MinimumLengthNotMet { min_length }
+    }
+
+    /// Creates a new `FormFieldValidatorError`for a field value below the
+    /// permitted minimum value.
+    #[must_use]
+    pub fn minimum_value_not_met(min_value: String) -> Self {
+        FormFieldValidationError::MinimumValueNotMet { min_value }
+    }
+
+    /// Creates a new `FormFieldValidationError` for a field value that exceeds
+    /// the permitted maximum value
+    #[must_use]
+    pub fn maximum_value_exceeded(max_value: String) -> Self {
+        FormFieldValidationError::MaximumValueExceeded { max_value }
     }
 
     /// Creates a new `FormFieldValidationError` from a `String`.

--- a/cot/src/form/fields.rs
+++ b/cot/src/form/fields.rs
@@ -602,7 +602,7 @@ fn check_required<T: FormField>(field: &T) -> Result<&str, FormFieldValidationEr
     }
 }
 
-impl_form_field!(FloatField, FloatFieldOptions, "a float",  T: Float + Debug);
+impl_form_field!(FloatField, FloatFieldOptions, "a float",  T: Float);
 
 /// Custom options for a `FloatField`.
 #[derive(Debug, Copy, Clone)]
@@ -624,7 +624,7 @@ impl<T: Float> Default for FloatFieldOptions<T> {
     }
 }
 
-impl<T: Float + Debug> Display for FloatField<T> {
+impl<T: Float> Display for FloatField<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut tag: HtmlTag = HtmlTag::input("number");
         tag.attr("name", self.name());
@@ -634,12 +634,10 @@ impl<T: Float + Debug> Display for FloatField<T> {
         }
 
         if let Some(min) = &self.custom_options.min {
-            let min = format!("{:?}", min);
-            tag.attr("min", &min);
+            tag.attr("min", &min.to_string());
         }
         if let Some(max) = &self.custom_options.max {
-            let max = format!("{:?}", max);
-            tag.attr("max", &max);
+            tag.attr("max", &max.to_string());
         }
         if let Some(value) = &self.value {
             tag.attr("value", value);
@@ -649,7 +647,7 @@ impl<T: Float + Debug> Display for FloatField<T> {
     }
 }
 
-impl<T: Float + Debug> HtmlSafe for FloatField<T> {}
+impl<T: Float> HtmlSafe for FloatField<T> {}
 
 /// A trait for types that can be represented as a float.
 ///
@@ -829,16 +827,16 @@ mod tests {
                 required: true,
             },
             FloatFieldOptions {
-                min: Some(1.0),
-                max: Some(10.0),
+                min: Some(1.5),
+                max: Some(10.7),
             },
         );
         let html = field.to_string();
         println!("html: {}", html);
         assert!(html.contains("type=\"number\""));
         assert!(html.contains("required"));
-        assert!(html.contains("min=\"1.0\""));
-        assert!(html.contains("max=\"10.0\""));
+        assert!(html.contains("min=\"1.5\""));
+        assert!(html.contains("max=\"10.7\""));
     }
     #[test]
     fn bool_field_render() {

--- a/cot/src/form/fields.rs
+++ b/cot/src/form/fields.rs
@@ -832,7 +832,6 @@ mod tests {
             },
         );
         let html = field.to_string();
-        println!("html: {}", html);
         assert!(html.contains("type=\"number\""));
         assert!(html.contains("required"));
         assert!(html.contains("min=\"1.5\""));
@@ -1085,7 +1084,7 @@ mod tests {
         );
         field.set_value(Cow::Borrowed("5.0"));
         let value = f32::clean_value(&field).unwrap();
-        assert_eq!(value, 5.0);
+        assert_eq!(value, 5.0f32);
     }
     #[test]
     fn float_field_clean_value_nan_and_inf() {

--- a/cot/src/form/fields.rs
+++ b/cot/src/form/fields.rs
@@ -1112,6 +1112,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn float_field_clean_value() {
         let mut field = FloatField::<f32>::with_options(
             FormFieldOptions {

--- a/cot/src/form/fields.rs
+++ b/cot/src/form/fields.rs
@@ -396,9 +396,27 @@ macro_rules! impl_integer_as_form_field {
             fn clean_value(field: &Self::Type) -> Result<Self, FormFieldValidationError> {
                 let value = check_required(field)?;
 
-                value
+                let parsed: $type = value
                     .parse()
-                    .map_err(|_| FormFieldValidationError::invalid_value(value))
+                    .map_err(|_| FormFieldValidationError::invalid_value(value))?;
+
+                if let Some(min) = field.custom_options.min {
+                    if parsed < min {
+                        return Err(FormFieldValidationError::from_string(format!(
+                            "This is below the minimum value of {min}"
+                        )));
+                    }
+                }
+
+                if let Some(max) = field.custom_options.max {
+                    if parsed > max {
+                        return Err(FormFieldValidationError::from_string(format!(
+                            "This exceeds the maximum value of {max}"
+                        )));
+                    }
+                }
+
+                Ok(parsed)
             }
 
             fn to_field_value(&self) -> String {
@@ -687,6 +705,23 @@ macro_rules! impl_float_as_form_field {
                         "Cannot have NaN or inf as form input values",
                     ));
                 }
+
+                if let Some(min) = field.custom_options.min {
+                    if parsed < min {
+                        return Err(FormFieldValidationError::from_string(format!(
+                            "This is below the minimum value of {min}"
+                        )));
+                    }
+                }
+
+                if let Some(max) = field.custom_options.max {
+                    if parsed > max {
+                        return Err(FormFieldValidationError::from_string(format!(
+                            "This exceeds the maximum value of {max}"
+                        )));
+                    }
+                }
+
                 Ok(parsed)
             }
 


### PR DESCRIPTION

```rust
#[derive(Debug, Form)]
struct TodoForm {
    #[form(opt(max_length = 100))]
    title: String,
    foo: f32,
    #[form(opt(max = 40.5))]
    bar: f64
    #[form(opt(min=10.0 ,max = 40.0))]
    range: f64,
}

```