### PR TITLE
fix: ForeignKey<Self> doesn't compileFix self foreignkey

### DIFF
--- a/cot-codegen/src/lib.rs
+++ b/cot-codegen/src/lib.rs
@@ -2,5 +2,4 @@
 
 pub mod expr;
 pub mod model;
-#[cfg(feature = "symbol-resolver")]
 pub mod symbol_resolver;

--- a/cot-codegen/src/model.rs
+++ b/cot-codegen/src/model.rs
@@ -2,7 +2,6 @@ use darling::{FromDeriveInput, FromField, FromMeta};
 use heck::ToSnakeCase;
 use syn::spanned::Spanned;
 
-#[cfg(feature = "symbol-resolver")]
 use crate::symbol_resolver::SymbolResolver;
 
 #[expect(clippy::module_name_repetitions)]
@@ -67,12 +66,10 @@ impl ModelOpts {
     pub fn as_model(
         &self,
         args: &ModelArgs,
-        #[cfg(feature = "symbol-resolver")] symbol_resolver: &SymbolResolver,
+        symbol_resolver: &SymbolResolver,
     ) -> Result<Model, syn::Error> {
-        #[cfg(feature = "symbol-resolver")]
-        let as_field = |field: &&FieldOpts| field.as_field(symbol_resolver);
-        #[cfg(not(feature = "symbol-resolver"))]
-        let as_field = |field: &&FieldOpts| field.as_field();
+        let self_reference = self.ident.to_string();
+        let as_field = |field: &&FieldOpts| field.as_field(symbol_resolver, Some(&self_reference));
 
         let fields = self
             .fields()
@@ -100,7 +97,6 @@ impl ModelOpts {
 
         let primary_key_field = self.get_primary_key_field(&fields)?;
 
-        #[cfg(feature = "symbol-resolver")]
         let ty = {
             let mut ty = syn::Type::Path(syn::TypePath {
                 qself: None,
@@ -114,7 +110,6 @@ impl ModelOpts {
             name: self.ident.clone(),
             vis: self.vis.clone(),
             original_name,
-            #[cfg(feature = "symbol-resolver")]
             resolved_ty: ty,
             model_type: args.model_type,
             table_name,
@@ -153,15 +148,12 @@ pub struct FieldOpts {
 }
 
 impl FieldOpts {
-    #[cfg(feature = "symbol-resolver")]
     fn find_type(&self, type_to_find: &str, symbol_resolver: &SymbolResolver) -> Option<syn::Type> {
         let mut ty = self.ty.clone();
-        let self_reference = self.ident.as_ref().map(ToString::to_string);
-        symbol_resolver.resolve(&mut ty, self_reference.as_ref());
+        symbol_resolver.resolve(&mut ty, None);
         Self::find_type_resolved(&ty, type_to_find)
     }
 
-    #[cfg(feature = "symbol-resolver")]
     fn find_type_resolved(ty: &syn::Type, type_to_find: &str) -> Option<syn::Type> {
         if let syn::Type::Path(type_path) = ty {
             let name = type_path
@@ -188,7 +180,6 @@ impl FieldOpts {
         None
     }
 
-    #[cfg(feature = "symbol-resolver")]
     fn find_type_in_generics(
         arg: &syn::AngleBracketedGenericArguments,
         type_to_find: &str,
@@ -208,16 +199,14 @@ impl FieldOpts {
     ///
     /// Panics if the field does not have an identifier (i.e. it is a tuple
     /// struct).
-    // we use `?` if the `symbol-resolver` feature is enabled
-    #[cfg_attr(not(feature = "symbol-resolver"), expect(clippy::unnecessary_wraps))]
     pub fn as_field(
         &self,
-        #[cfg(feature = "symbol-resolver")] symbol_resolver: &SymbolResolver,
+        symbol_resolver: &SymbolResolver,
+        self_reference: Option<&String>,
     ) -> Result<Field, syn::Error> {
         let name = self.ident.as_ref().unwrap();
         let column_name = name.to_string();
 
-        #[cfg(feature = "symbol-resolver")]
         let (auto_value, foreign_key) = (
             self.find_type("cot::db::Auto", symbol_resolver).is_some(),
             self.find_type("cot::db::ForeignKey", symbol_resolver)
@@ -225,15 +214,14 @@ impl FieldOpts {
                 .transpose()?,
         );
         let is_primary_key = self.primary_key.is_present();
-
+        let mut resolved_ty = self.ty.clone();
+        symbol_resolver.resolve(&mut resolved_ty, self_reference);
         Ok(Field {
             name: name.clone(),
             column_name,
-            ty: self.ty.clone(),
-            #[cfg(feature = "symbol-resolver")]
+            ty: resolved_ty,
             auto_value,
             primary_key: is_primary_key,
-            #[cfg(feature = "symbol-resolver")]
             foreign_key,
             unique: self.unique.is_present(),
         })
@@ -245,10 +233,8 @@ pub struct Model {
     pub name: syn::Ident,
     pub vis: syn::Visibility,
     pub original_name: String,
-    /// The type of the model resolved by symbol resolver.
-    #[cfg(feature = "symbol-resolver")]
     pub resolved_ty: syn::Type,
-    #[expect(clippy::struct_field_names)] // `type` is not an allowed identifier in Rust
+    #[expect(clippy::struct_field_names)]
     pub model_type: ModelType,
     pub table_name: String,
     pub pk_field: Field,
@@ -268,12 +254,10 @@ pub struct Field {
     pub column_name: String,
     pub ty: syn::Type,
     /// Whether the field is an auto field (e.g. `id`).
-    #[cfg(feature = "symbol-resolver")]
     pub auto_value: bool,
     pub primary_key: bool,
     /// [`Some`] if this field is a foreign key; [`None`] if this field is
     /// determined not to be a foreign key.
-    #[cfg(feature = "symbol-resolver")]
     pub foreign_key: Option<ForeignKeySpec>,
     pub unique: bool,
 }
@@ -330,8 +314,7 @@ mod tests {
     use syn::parse_quote;
 
     use super::*;
-    #[cfg(feature = "symbol-resolver")]
-    use crate::symbol_resolver::{VisibleSymbol, VisibleSymbolKind};
+    use crate::symbol_resolver::{SymbolResolver, VisibleSymbol, VisibleSymbolKind};
 
     #[test]
     fn model_args_default() {
@@ -361,7 +344,6 @@ mod tests {
         assert_eq!(fields[1].ident.as_ref().unwrap().to_string(), "name");
     }
 
-    #[cfg(feature = "symbol-resolver")]
     #[test]
     fn model_opts_as_model() {
         let input: syn::DeriveInput = parse_quote! {
@@ -380,7 +362,6 @@ mod tests {
         assert_eq!(model.field_count(), 2);
     }
 
-    #[cfg(feature = "symbol-resolver")]
     #[test]
     fn model_opts_as_model_migration() {
         let input: syn::DeriveInput = parse_quote! {
@@ -401,7 +382,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "symbol-resolver")]
     #[test]
     fn model_opts_as_model_pk_attr() {
         let input: syn::DeriveInput = parse_quote! {
@@ -418,7 +398,6 @@ mod tests {
         assert!(model.fields[0].primary_key);
     }
 
-    #[cfg(feature = "symbol-resolver")]
     #[test]
     fn model_opts_as_model_no_pk() {
         let input: syn::DeriveInput = parse_quote! {
@@ -439,7 +418,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "symbol-resolver")]
     #[test]
     fn model_opts_as_model_multiple_pks() {
         let input: syn::DeriveInput = parse_quote! {
@@ -463,7 +441,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "symbol-resolver")]
     #[test]
     fn field_opts_as_field() {
         let input: syn::Field = parse_quote! {
@@ -471,14 +448,15 @@ mod tests {
             name: String
         };
         let field_opts = FieldOpts::from_field(&input).unwrap();
-        let field = field_opts.as_field(&SymbolResolver::new(vec![])).unwrap();
+        let field = field_opts
+            .as_field(&SymbolResolver::new(vec![]), Some(&"TestModel".to_string()))
+            .unwrap();
         assert_eq!(field.name.to_string(), "name");
         assert_eq!(field.column_name, "name");
         assert_eq!(field.ty, parse_quote!(String));
         assert!(field.unique);
     }
 
-    #[cfg(feature = "symbol-resolver")]
     #[test]
     fn find_type_resolved() {
         let input: syn::Type =
@@ -489,7 +467,6 @@ mod tests {
         assert!(FieldOpts::find_type_resolved(&input, "OtherType").is_none());
     }
 
-    #[cfg(feature = "symbol-resolver")]
     #[test]
     fn find_type() {
         let symbols = vec![VisibleSymbol::new(

--- a/cot-codegen/src/model.rs
+++ b/cot-codegen/src/model.rs
@@ -106,7 +106,7 @@ impl ModelOpts {
                 qself: None,
                 path: syn::Path::from(self.ident.clone()),
             });
-            symbol_resolver.resolve(&mut ty);
+            symbol_resolver.resolve(&mut ty, Some(&original_name));
             ty
         };
 
@@ -156,7 +156,8 @@ impl FieldOpts {
     #[cfg(feature = "symbol-resolver")]
     fn find_type(&self, type_to_find: &str, symbol_resolver: &SymbolResolver) -> Option<syn::Type> {
         let mut ty = self.ty.clone();
-        symbol_resolver.resolve(&mut ty);
+        let self_reference = self.ident.as_ref().map(ToString::to_string);
+        symbol_resolver.resolve(&mut ty, self_reference.as_ref());
         Self::find_type_resolved(&ty, type_to_find)
     }
 

--- a/cot-codegen/src/model.rs
+++ b/cot-codegen/src/model.rs
@@ -233,8 +233,9 @@ pub struct Model {
     pub name: syn::Ident,
     pub vis: syn::Visibility,
     pub original_name: String,
+    /// The type of the model resolved by symbol resolver.
     pub resolved_ty: syn::Type,
-    #[expect(clippy::struct_field_names)]
+    #[expect(clippy::struct_field_names)] // `type` is not an allowed identifier in Rust
     pub model_type: ModelType,
     pub table_name: String,
     pub pk_field: Field,

--- a/cot-codegen/src/symbol_resolver.rs
+++ b/cot-codegen/src/symbol_resolver.rs
@@ -494,7 +494,7 @@ const MY_CONSTANT: u8 = 42;
     fn import_resolver_resolve_struct_with_self() {
         let resolver = SymbolResolver::new(vec![
             VisibleSymbol::new_use("ForeignKey", "cot::db::ForeignKey"),
-            VisibleSymbol::new_use("MyModel", "crate::MyModel"),
+            VisibleSymbol::new("MyModel", "crate::MyModel", VisibleSymbolKind::Struct),
         ]);
 
         let mut actual = parse_quote! {

--- a/cot-codegen/src/symbol_resolver.rs
+++ b/cot-codegen/src/symbol_resolver.rs
@@ -1,9 +1,13 @@
 use std::collections::HashMap;
+#[cfg(feature = "symbol-resolver")]
 use std::fmt::Display;
 use std::iter::FromIterator;
+#[cfg(feature = "symbol-resolver")]
 use std::path::Path;
 
+#[cfg(feature = "symbol-resolver")]
 use syn::UseTree;
+#[cfg(feature = "symbol-resolver")]
 use tracing::warn;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -25,6 +29,7 @@ impl SymbolResolver {
         }
     }
 
+    #[cfg(feature = "symbol-resolver")]
     #[must_use]
     pub fn from_file(file: &syn::File, module_path: &Path) -> Self {
         let imports = Self::get_imports(file, &ModulePath::from_fs_path(module_path));
@@ -33,6 +38,7 @@ impl SymbolResolver {
 
     /// Return the list of top-level `use` statements, structs, and constants as
     /// a list of [`VisibleSymbol`]s from the file.
+    #[cfg(feature = "symbol-resolver")]
     fn get_imports(file: &syn::File, module_path: &ModulePath) -> Vec<VisibleSymbol> {
         let mut imports = Vec::new();
 
@@ -198,14 +204,17 @@ impl VisibleSymbol {
         self.full_path.split("::")
     }
 
+    #[cfg(feature = "symbol-resolver")]
     fn new_use(alias: &str, full_path: &str) -> Self {
         Self::new(alias, full_path, VisibleSymbolKind::Use)
     }
 
+    #[cfg(feature = "symbol-resolver")]
     fn from_item_use(item: &syn::ItemUse, module_path: &ModulePath) -> Vec<Self> {
         Self::from_tree(&item.tree, module_path)
     }
 
+    #[cfg(feature = "symbol-resolver")]
     fn from_item_struct(item: &syn::ItemStruct, module_path: &ModulePath) -> Self {
         let ident = item.ident.to_string();
         let full_path = Self::module_path(module_path, &ident);
@@ -217,6 +226,7 @@ impl VisibleSymbol {
         }
     }
 
+    #[cfg(feature = "symbol-resolver")]
     fn from_item_const(item: &syn::ItemConst, module_path: &ModulePath) -> Self {
         let ident = item.ident.to_string();
         let full_path = Self::module_path(module_path, &ident);
@@ -228,10 +238,12 @@ impl VisibleSymbol {
         }
     }
 
+    #[cfg(feature = "symbol-resolver")]
     fn module_path(module_path: &ModulePath, ident: &str) -> String {
         format!("{module_path}::{ident}")
     }
 
+    #[cfg(feature = "symbol-resolver")]
     fn from_tree(tree: &UseTree, current_module: &ModulePath) -> Vec<Self> {
         match tree {
             UseTree::Path(path) => {
@@ -282,11 +294,13 @@ impl VisibleSymbol {
     }
 }
 
+#[cfg(feature = "symbol-resolver")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModulePath {
     parts: Vec<String>,
 }
 
+#[cfg(feature = "symbol-resolver")]
 impl ModulePath {
     #[must_use]
     pub fn from_fs_path(path: &Path) -> Self {
@@ -333,6 +347,7 @@ impl ModulePath {
     }
 }
 
+#[cfg(feature = "symbol-resolver")]
 impl Display for ModulePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.parts.join("::"))

--- a/cot-macros/src/model.rs
+++ b/cot-macros/src/model.rs
@@ -28,12 +28,12 @@ pub(super) fn impl_model_for_struct(
             return err.write_errors();
         }
     };
-    let symbol_resplver = SymbolResolver::new(vec![VisibleSymbol::new(
+    let symbol_resolver = SymbolResolver::new(vec![VisibleSymbol::new(
         &opts.ident.to_string(),
         &opts.ident.to_string(),
         VisibleSymbolKind::Struct,
     )]);
-    let model = match opts.as_model(&args, &symbol_resplver) {
+    let model = match opts.as_model(&args, &symbol_resolver) {
         Ok(val) => val,
         Err(err) => {
             return err.to_compile_error();

--- a/cot-macros/src/model.rs
+++ b/cot-macros/src/model.rs
@@ -1,4 +1,5 @@
 use cot_codegen::model::{Field, Model, ModelArgs, ModelOpts, ModelType};
+use cot_codegen::symbol_resolver::{SymbolResolver, VisibleSymbol, VisibleSymbolKind};
 use darling::FromMeta;
 use darling::ast::NestedMeta;
 use heck::ToSnakeCase;
@@ -27,8 +28,12 @@ pub(super) fn impl_model_for_struct(
             return err.write_errors();
         }
     };
-
-    let model = match opts.as_model(&args) {
+    let symbol_resplver = SymbolResolver::new(vec![VisibleSymbol::new(
+        &opts.ident.to_string(),
+        &opts.ident.to_string(),
+        VisibleSymbolKind::Struct,
+    )]);
+    let model = match opts.as_model(&args, &symbol_resplver) {
         Ok(val) => val,
         Err(err) => {
             return err.to_compile_error();


### PR DESCRIPTION
In database models, if you used `ForeignKey<Self>` you'd get an error as described by https://github.com/cot-rs/cot/issues/298

In this PR, I added a check in the symbol resolver to check for any generic `Self` and replace it with the struct name.
This also affects migration generation which now references `Self` with full struct crate name.