### PR TITLE
fix: don't clone string in `<Html as IntoResponse>`

### DIFF
--- a/cot/src/response/into_response.rs
+++ b/cot/src/response/into_response.rs
@@ -324,8 +324,7 @@ impl IntoResponse for Html {
     /// let response = html.into_response();
     /// ```
     fn into_response(self) -> cot::Result<Response> {
-        self.as_str()
-            .to_owned()
+        self.0
             .into_response()
             .with_content_type(HTML_CONTENT_TYPE)
             .into_response()


### PR DESCRIPTION
`Html` already owns its containing `String`, and `IntoResponse::into_response()` consumes `self`, so there is no need to clone the string.