### PR TITLE
feat: add validated `Url` type (#339)

### DIFF
--- a/cot/Cargo.toml
+++ b/cot/Cargo.toml
@@ -64,7 +64,7 @@ tower = { workspace = true, features = ["util"] }
 tower-livereload = { workspace = true, optional = true }
 tower-sessions = { workspace = true, features = ["memory-store"] }
 tracing.workspace = true
-url = { workspace = true, features = ["serde"], optional = true }
+url = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 async-stream.workspace = true
@@ -97,7 +97,7 @@ ignored = [
 default = ["sqlite", "postgres", "mysql", "json"]
 full = ["default", "fake", "live-reload", "test"]
 fake = ["dep:fake"]
-db = ["dep:url", "dep:sea-query", "dep:sea-query-binder", "dep:sqlx"]
+db = ["dep:sea-query", "dep:sea-query-binder", "dep:sqlx"]
 sqlite = ["db", "sea-query/backend-sqlite", "sea-query-binder/sqlx-sqlite", "sqlx/sqlite"]
 postgres = ["db", "sea-query/backend-postgres", "sea-query-binder/sqlx-postgres", "sqlx/postgres"]
 mysql = ["db", "sea-query/backend-mysql", "sea-query-binder/sqlx-mysql", "sqlx/mysql"]

--- a/cot/src/form.rs
+++ b/cot/src/form.rs
@@ -220,12 +220,6 @@ impl FormFieldValidationError {
     }
 }
 
-impl From<email_address::Error> for FormFieldValidationError {
-    fn from(error: email_address::Error) -> Self {
-        FormFieldValidationError::from_string(error.to_string())
-    }
-}
-
 /// An enum indicating the target of a form validation error.
 #[derive(Debug)]
 pub enum FormErrorTarget<'a> {


### PR DESCRIPTION
Accidentally closed #339 by overwriting the source branch's content.

This just contains a squash of the original code.