### PR TITLE
chore: fix clippy warnings on Rust 1.88

### DIFF
--- a/cot-cli/src/utils.rs
+++ b/cot-cli/src/utils.rs
@@ -342,8 +342,10 @@ mod tests {
         use super::*;
 
         #[test]
-        // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-        #[cfg_attr(miri, ignore)]
+        #[cfg_attr(
+            miri,
+            ignore = "unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`"
+        )]
         fn find_cargo_toml() {
             let temp_dir = tempfile::TempDir::with_prefix("cot-test-").unwrap();
             test_utils::make_package(temp_dir.path()).unwrap();
@@ -354,8 +356,10 @@ mod tests {
         }
 
         #[test]
-        // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-        #[cfg_attr(miri, ignore)]
+        #[cfg_attr(
+            miri,
+            ignore = "unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`"
+        )]
         fn find_cargo_toml_recursive() {
             let temp_dir = tempfile::tempdir().unwrap();
             let nested_dir = temp_dir.path().join("nested");
@@ -373,8 +377,10 @@ mod tests {
         }
 
         #[test]
-        // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-        #[cfg_attr(miri, ignore)]
+        #[cfg_attr(
+            miri,
+            ignore = "unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`"
+        )]
         fn load_valid_virtual_workspace_manifest() {
             let cot_cli_root = env!("CARGO_MANIFEST_DIR");
             let cot_root = Path::new(cot_cli_root).parent().unwrap();
@@ -390,8 +396,10 @@ mod tests {
         }
 
         #[test]
-        // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-        #[cfg_attr(miri, ignore)]
+        #[cfg_attr(
+            miri,
+            ignore = "unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`"
+        )]
         fn load_valid_workspace_from_package_manifest() {
             let temp_dir = tempfile::TempDir::with_prefix("cot-test-").unwrap();
             let package_name = temp_dir.path().file_name().unwrap().to_str().unwrap();
@@ -421,8 +429,10 @@ mod tests {
         }
 
         #[test]
-        // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-        #[cfg_attr(miri, ignore)]
+        #[cfg_attr(
+            miri,
+            ignore = "unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`"
+        )]
         fn load_valid_workspace_from_workspace_manifest() {
             let temp_dir = tempfile::TempDir::with_prefix("cot-test-").unwrap();
             test_utils::make_workspace_package(temp_dir.path(), 3).unwrap();
@@ -446,8 +456,10 @@ mod tests {
         }
 
         #[test]
-        // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-        #[cfg_attr(miri, ignore)]
+        #[cfg_attr(
+            miri,
+            ignore = "unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`"
+        )]
         fn load_valid_package_manifest() {
             let temp_dir = tempfile::TempDir::with_prefix("cot-test-").unwrap();
             let package_name = temp_dir.path().file_name().unwrap().to_str().unwrap();
@@ -467,8 +479,10 @@ mod tests {
         }
 
         #[test]
-        // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-        #[cfg_attr(miri, ignore)]
+        #[cfg_attr(
+            miri,
+            ignore = "unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`"
+        )]
         fn load_valid_package_manifest_current_dir() {
             let temp_dir = tempfile::TempDir::with_prefix("cot-test-").unwrap();
             let package_name = temp_dir.path().file_name().unwrap().to_str().unwrap();
@@ -499,8 +513,10 @@ mod tests {
         use super::*;
 
         #[test]
-        // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-        #[cfg_attr(miri, ignore)]
+        #[cfg_attr(
+            miri,
+            ignore = "unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`"
+        )]
         fn get_root_manifest() {
             let (temp_dir, manager) = get_workspace(1);
             let manifest_path = temp_dir.path().join("Cargo.toml");
@@ -512,8 +528,10 @@ mod tests {
         }
 
         #[test]
-        // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-        #[cfg_attr(miri, ignore)]
+        #[cfg_attr(
+            miri,
+            ignore = "unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`"
+        )]
         fn get_package_manager() {
             let (_, manager) = get_workspace(2);
             let package_name = test_utils::get_nth_crate_name(1);
@@ -537,8 +555,10 @@ mod tests {
         }
 
         #[test]
-        // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-        #[cfg_attr(miri, ignore)]
+        #[cfg_attr(
+            miri,
+            ignore = "unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`"
+        )]
         fn get_package_manager_by_path() {
             let (temp_dir, manager) = get_workspace(1);
             let package_name = test_utils::get_nth_crate_name(1);
@@ -580,8 +600,10 @@ mod tests {
         use super::*;
 
         #[test]
-        // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-        #[cfg_attr(miri, ignore)]
+        #[cfg_attr(
+            miri,
+            ignore = "unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`"
+        )]
         fn get_package_name() {
             let (temp_dir, manager) = get_package();
             let package_name = temp_dir.path().file_name().unwrap().to_str().unwrap();
@@ -590,8 +612,10 @@ mod tests {
         }
 
         #[test]
-        // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-        #[cfg_attr(miri, ignore)]
+        #[cfg_attr(
+            miri,
+            ignore = "unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`"
+        )]
         fn get_package_path() {
             let (temp_dir, manager) = get_package();
 
@@ -599,8 +623,10 @@ mod tests {
         }
 
         #[test]
-        // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-        #[cfg_attr(miri, ignore)]
+        #[cfg_attr(
+            miri,
+            ignore = "unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`"
+        )]
         fn get_manifest_path() {
             let (temp_dir, manager) = get_package();
 
@@ -611,8 +637,10 @@ mod tests {
         }
 
         #[test]
-        // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-        #[cfg_attr(miri, ignore)]
+        #[cfg_attr(
+            miri,
+            ignore = "unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`"
+        )]
         fn get_manifest() {
             let (temp_dir, manager) = get_package();
             let manifest_path = temp_dir.path().join("Cargo.toml");

--- a/cot-cli/tests/manpages.rs
+++ b/cot-cli/tests/manpages.rs
@@ -1,5 +1,8 @@
 #[test]
-#[cfg_attr(miri, ignore)] // unsupported operation: extern static `pidfd_spawnp` is not supported by Miri
+#[cfg_attr(
+    miri,
+    ignore = "unsupported operation: extern static `pidfd_spawnp` is not supported by Miri"
+)]
 fn generate_manpages() {
     let tempdir = tempfile::TempDir::new().unwrap();
     let args = cot_cli::args::ManpagesArgs {

--- a/cot-cli/tests/migration_generator.rs
+++ b/cot-cli/tests/migration_generator.rs
@@ -163,7 +163,10 @@ fn create_models_foreign_key_two_migrations() {
 /// Test that the migration generator can generate a "create model" migration
 /// for a given model which compiles successfully.
 #[test]
-#[cfg_attr(miri, ignore)] // unsupported operation: extern static `pidfd_spawnp` is not supported by Miri
+#[cfg_attr(
+    miri,
+    ignore = "unsupported operation: extern static `pidfd_spawnp` is not supported by Miri"
+)]
 fn create_model_compile_test() {
     let generator = test_generator();
     let src = include_str!("migration_generator/create_model.rs");
@@ -255,7 +258,10 @@ fn find_source_files() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // unsupported operation: extern static `pidfd_spawnp` is not supported by Miri
+#[cfg_attr(
+    miri,
+    ignore = "unsupported operation: extern static `pidfd_spawnp` is not supported by Miri"
+)]
 fn list_migrations() {
     let temp_dir = tempfile::TempDir::with_prefix("cot-test-").unwrap();
     let package_name = temp_dir.path().file_name().unwrap().to_str().unwrap();
@@ -291,7 +297,10 @@ fn list_migrations_missing_cargo_toml() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // unsupported operation: extern static `pidfd_spawnp` is not supported by Miri
+#[cfg_attr(
+    miri,
+    ignore = "unsupported operation: extern static `pidfd_spawnp` is not supported by Miri"
+)]
 fn list_migrations_missing_migrations_dir() {
     let temp_dir = tempfile::TempDir::with_prefix("cot-test-").unwrap();
     test_utils::make_package(temp_dir.path()).unwrap();

--- a/cot-cli/tests/new_project.rs
+++ b/cot-cli/tests/new_project.rs
@@ -4,7 +4,10 @@ use std::path::PathBuf;
 use cot_cli::new_project::{CotSource, new_project};
 
 #[test]
-#[cfg_attr(miri, ignore)] // unsupported operation: extern static `pidfd_spawnp` is not supported by Miri
+#[cfg_attr(
+    miri,
+    ignore = "unsupported operation: extern static `pidfd_spawnp` is not supported by Miri"
+)]
 fn new_project_compile_test() {
     let temp_dir = tempfile::tempdir().unwrap();
     let project_path = temp_dir.path().join("my_project");

--- a/cot-macros/src/dbtest.rs
+++ b/cot-macros/src/dbtest.rs
@@ -17,7 +17,7 @@ pub(super) fn fn_to_dbtest(test_function_decl: ItemFn) -> syn::Result<TokenStrea
 
     let result = quote! {
         #[::cot::test]
-        #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `sqlite3_open_v2`
+        #[cfg_attr(miri, ignore = "unsupported operation: can't call foreign function `sqlite3_open_v2`")]
         async fn #sqlite_ident() {
             let mut database = cot::test::TestDatabase::new_sqlite().await.unwrap();
 

--- a/cot-macros/tests/compile_tests.rs
+++ b/cot-macros/tests/compile_tests.rs
@@ -1,14 +1,26 @@
-#[rustversion::attr(not(nightly), ignore)]
+#[rustversion::attr(
+    not(nightly),
+    ignore = "only test on nightly for consistent error messages"
+)]
 #[test]
-#[cfg_attr(miri, ignore)] // unsupported operation: extern static `pidfd_spawnp` is not supported by Miri
+#[cfg_attr(
+    miri,
+    ignore = "unsupported operation: extern static `pidfd_spawnp` is not supported by Miri"
+)]
 fn derive_form() {
     let t = trybuild::TestCases::new();
     t.pass("tests/ui/derive_form.rs");
 }
 
-#[rustversion::attr(not(nightly), ignore)]
+#[rustversion::attr(
+    not(nightly),
+    ignore = "only test on nightly for consistent error messages"
+)]
 #[test]
-#[cfg_attr(miri, ignore)] // unsupported operation: extern static `pidfd_spawnp` is not supported by Miri
+#[cfg_attr(
+    miri,
+    ignore = "unsupported operation: extern static `pidfd_spawnp` is not supported by Miri"
+)]
 fn attr_model() {
     let t = trybuild::TestCases::new();
     t.pass("tests/ui/attr_model.rs");
@@ -20,18 +32,30 @@ fn attr_model() {
     t.compile_fail("tests/ui/attr_model_multiple_pks.rs");
 }
 
-#[rustversion::attr(not(nightly), ignore)]
+#[rustversion::attr(
+    not(nightly),
+    ignore = "only test on nightly for consistent error messages"
+)]
 #[test]
-#[cfg_attr(miri, ignore)] // unsupported operation: extern static `pidfd_spawnp` is not supported by Miri
+#[cfg_attr(
+    miri,
+    ignore = "unsupported operation: extern static `pidfd_spawnp` is not supported by Miri"
+)]
 fn derive_admin_model() {
     let t = trybuild::TestCases::new();
     t.pass("tests/ui/derive_admin_model.rs");
     t.pass("tests/ui/derive_admin_model_derive_first.rs");
 }
 
-#[rustversion::attr(not(nightly), ignore)]
+#[rustversion::attr(
+    not(nightly),
+    ignore = "only test on nightly for consistent error messages"
+)]
 #[test]
-#[cfg_attr(miri, ignore)] // unsupported operation: extern static `pidfd_spawnp` is not supported by Miri
+#[cfg_attr(
+    miri,
+    ignore = "unsupported operation: extern static `pidfd_spawnp` is not supported by Miri"
+)]
 fn func_query() {
     let t = trybuild::TestCases::new();
     t.pass("tests/ui/func_query.rs");
@@ -42,18 +66,30 @@ fn func_query() {
     t.compile_fail("tests/ui/func_query_method_call_on_db_field.rs");
 }
 
-#[rustversion::attr(not(nightly), ignore)]
+#[rustversion::attr(
+    not(nightly),
+    ignore = "only test on nightly for consistent error messages"
+)]
 #[test]
-#[cfg_attr(miri, ignore)] // unsupported operation: extern static `pidfd_spawnp` is not supported by Miri
+#[cfg_attr(
+    miri,
+    ignore = "unsupported operation: extern static `pidfd_spawnp` is not supported by Miri"
+)]
 fn attr_main() {
     let t = trybuild::TestCases::new();
     t.pass("tests/ui/attr_main.rs");
     t.compile_fail("tests/ui/attr_main_args.rs");
 }
 
-#[rustversion::attr(not(nightly), ignore)]
+#[rustversion::attr(
+    not(nightly),
+    ignore = "only test on nightly for consistent error messages"
+)]
 #[test]
-#[cfg_attr(miri, ignore)] // unsupported operation: extern static `pidfd_spawnp` is not supported by Miri
+#[cfg_attr(
+    miri,
+    ignore = "unsupported operation: extern static `pidfd_spawnp` is not supported by Miri"
+)]
 fn derive_from_struct() {
     let t = trybuild::TestCases::new();
     t.pass("tests/ui/derive_from_request_parts.rs");

--- a/cot/src/cli.rs
+++ b/cot/src/cli.rs
@@ -484,7 +484,10 @@ mod tests {
     }
 
     #[cot::test]
-    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `sqlite3_open_v2`
+    #[cfg_attr(
+        miri,
+        ignore = "unsupported operation: can't call foreign function `sqlite3_open_v2`"
+    )]
     async fn collect_static_execute() {
         struct TestApp;
         impl App for TestApp {
@@ -528,7 +531,10 @@ mod tests {
     }
 
     #[cot::test]
-    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `geteuid` on OS `linux`
+    #[cfg_attr(
+        miri,
+        ignore = "unsupported operation: can't call foreign function `geteuid` on OS `linux`"
+    )]
     #[cfg(feature = "db")]
     async fn check_execute_db_fail() {
         let config = r#"

--- a/cot/src/project.rs
+++ b/cot/src/project.rs
@@ -2128,7 +2128,10 @@ mod tests {
     }
 
     #[cot::test]
-    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `sqlite3_open_v2`
+    #[cfg_attr(
+        miri,
+        ignore = "unsupported operation: can't call foreign function `sqlite3_open_v2`"
+    )]
     async fn bootstrapper() {
         struct TestProject;
         impl Project for TestProject {

--- a/cot/src/request/extractors.rs
+++ b/cot/src/request/extractors.rs
@@ -743,8 +743,10 @@ mod tests {
 
     #[cfg(feature = "db")]
     #[cot::test]
-    // unsupported operation: can't call foreign function `sqlite3_open_v2` on OS `linux`
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(
+        miri,
+        ignore = "unsupported operation: can't call foreign function `sqlite3_open_v2` on OS `linux`"
+    )]
     async fn request_db() {
         let db = crate::test::TestDatabase::new_sqlite().await.unwrap();
         let mut test_request = TestRequestBuilder::get("/").database(db.database()).build();

--- a/cot/src/static_files.rs
+++ b/cot/src/static_files.rs
@@ -402,7 +402,10 @@ mod tests {
     use crate::{App, AppBuilder, Bootstrapper, Project};
 
     #[test]
-    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `sqlite3_open_v2`
+    #[cfg_attr(
+        miri,
+        ignore = "unsupported operation: can't call foreign function `sqlite3_open_v2`"
+    )]
     fn static_files_add_and_get_file() {
         let mut static_files = StaticFiles::new(&StaticFilesConfig::default());
         static_files.add_file(StaticFile::new("test.txt", "This is a test file"));
@@ -522,7 +525,10 @@ mod tests {
     }
 
     #[cot::test]
-    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `sqlite3_open_v2`
+    #[cfg_attr(
+        miri,
+        ignore = "unsupported operation: can't call foreign function `sqlite3_open_v2`"
+    )]
     async fn static_files_middleware_from_context() {
         struct App1;
         impl App for App1 {

--- a/cot/src/utils/graph.rs
+++ b/cot/src/utils/graph.rs
@@ -59,7 +59,7 @@ impl Graph {
         Ok(sorted_indices_stack)
     }
 
-    #[expect(clippy::match_on_vec_items)]
+    #[expect(clippy::indexing_slicing)]
     fn toposort_visit(
         &self,
         index: usize,

--- a/cot/tests/compile_tests.rs
+++ b/cot/tests/compile_tests.rs
@@ -1,5 +1,8 @@
 #[test]
-#[cfg_attr(miri, ignore)] // unsupported operation: extern static `pidfd_spawnp` is not supported by Miri
+#[cfg_attr(
+    miri,
+    ignore = "unsupported operation: extern static `pidfd_spawnp` is not supported by Miri"
+)]
 fn diagnostic_on_unimplemented() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/unimplemented_db_model.rs");

--- a/cot/tests/project.rs
+++ b/cot/tests/project.rs
@@ -8,7 +8,10 @@ use cot::test::Client;
 use cot::{App, AppBuilder, Project, StatusCode, reverse};
 
 #[cot::test]
-#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `sqlite3_open_v2`
+#[cfg_attr(
+    miri,
+    ignore = "unsupported operation: can't call foreign function `sqlite3_open_v2`"
+)]
 async fn cot_project_router_sub_path() {
     async fn hello(_request: Request) -> Html {
         Html::new("OK")
@@ -59,7 +62,10 @@ async fn cot_project_router_sub_path() {
 }
 
 #[cot::test]
-#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `sqlite3_open_v2`
+#[cfg_attr(
+    miri,
+    ignore = "unsupported operation: can't call foreign function `sqlite3_open_v2`"
+)]
 async fn cot_router_reverse_local() {
     async fn get_index(request: Request) -> cot::Result<Html> {
         let reversed = reverse!(request, "index")?;

--- a/cot/tests/router.rs
+++ b/cot/tests/router.rs
@@ -18,7 +18,10 @@ async fn parameterized(request: Request) -> Html {
 }
 
 #[cot::test]
-#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `sqlite3_open_v2`
+#[cfg_attr(
+    miri,
+    ignore = "unsupported operation: can't call foreign function `sqlite3_open_v2`"
+)]
 async fn test_index() {
     let client = Client::new(project());
 
@@ -31,7 +34,10 @@ async fn test_index() {
 }
 
 #[cot::test]
-#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `sqlite3_open_v2`
+#[cfg_attr(
+    miri,
+    ignore = "unsupported operation: can't call foreign function `sqlite3_open_v2`"
+)]
 async fn path_params() {
     let client = Client::new(project());
 


### PR DESCRIPTION
Also, use `ignore = ""` syntax for miri-ignored tests.