### PR TITLE
chore(ci): limit the max number of features tested `cargo check`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -320,7 +320,7 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Run cargo check with every combination of features
-        run: cargo hack check --feature-powerset --exclude-features db --no-dev-deps
+        run: cargo hack check --feature-powerset --depth 3 --exclude-features db --no-dev-deps
 
   miri:
     if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.head.repo.full_name != github.repository


### PR DESCRIPTION
With each added feature flag, the number of checks that needs to be perfomed increased exponentially. This causes the "Build with each feature combination" job to take up 1.5 hours!

This commit sets the depth (max number of features tested at once) to 3, decreasing the total number of checks from 794 to 232, which should greatly reduce the pipeline times without reducing the check usefulness too much.

We might be forced to reduce this even more (to two) in the future if we keep increasing the number of feature flags. We might think about splitting the code into more crates then.