### PR TITLE
fix: ignored doctest

### DIFF
--- a/cot/src/session/store/redis.rs
+++ b/cot/src/session/store/redis.rs
@@ -126,13 +126,17 @@ impl RedisStore {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```no_run
     /// use cot::config::CacheUrl;
     /// use cot::session::store::redis::RedisStore;
     ///
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), cot::session::store::redis::RedisStoreError> {
     /// let store = RedisStore::new(&CacheUrl::from("redis://127.0.0.1/"))?;
     /// // Actual TCP connection happens here:
     /// let mut conn = store.get_connection().await?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn get_connection(&self) -> Result<deadpool_redis::Connection, RedisStoreError> {
         self.pool


### PR DESCRIPTION
Ignored doctests are not even compiled, so they are at higher risk of being out-of-date. If build failure is deliberate, there is `compile_fail` annotation to indicate this.