### PR TITLE
feat: make changelog prettier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,7 @@
 [workspace]
 git_release_enable = false
 changelog_update = false
+git_release_draft = true
 git_release_body = """
 {{ changelog }}
 {% if remote.contributors %}
@@ -12,6 +13,44 @@ git_release_body = """
 """
 
 [changelog]
+header = """# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), \
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+"""
+
+body = """
+
+## [{{ version }}]\
+    {%- if release_link -%}\
+        ({{ release_link }})\
+    {% endif %} \
+    - {{ timestamp | date(format="%Y-%m-%d") }}
+
+    {% if previous.version -%}\
+        [View diff on diff.rs](https://diff.rs/{{ package }}/{{ previous.version }}/{{ package }}/{{ version }}/Cargo.toml)
+    {%- endif %}
+{% for group, commits in commits | sort(attribute="remote.pr_number") | reverse | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+
+    {% for commit in commits | sort(attribute="breaking") | reverse %}
+        {%- if commit.scope -%}
+            - {% if commit.breaking %}[**breaking**] {% endif %}*({{commit.scope}})* \
+                {{ commit.message | upper_first }}{{ self::username(commit=commit) }}
+        {% else -%}
+            - {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}{{ self::username(commit=commit) }}
+        {% endif -%}
+    {% endfor -%}
+{% endfor %}
+{%- macro username(commit) -%}
+    {% if commit.remote.username %} (by [@{{ commit.remote.username }}](https://github.com/{{ commit.remote.username }})){% endif -%}
+{% endmacro -%}
+"""
+
 protect_breaking_commits = true
 commit_parsers = [
     { message = "^.*\\(security\\)", group = "<!-- 0 -->Security", scope = "" },


### PR DESCRIPTION
This PR modifies Release-plz's default changelog template to accomplish the following:

- Remove HTML comments (used for internal sorting) from the final changelog
- Add [diff.rs](https://diff.rs/)'s version comparison
- Capitalize the first letter of each commit for a nicer standard look
- Sort commits chronologically
- List breaking commits first, as those should get the most attention
- Removed the contributors list at the end in favor of listing the author of the PR on each entry

Additionally, I've made Release-plz make draft release, so that we can prettify it and add examples before making it an official release.

---

# Old

## [0.4.0](https://github.com/cot-rs/cot/compare/cot-v0.3.1...cot-v0.4.0) - 2025-07-10

### <!-- 1 -->New features

- AsFormField for Date, Time, DateTime ([#342](https://github.com/cot-rs/cot/pull/342))
- *(macros)* derive macro for `SelectChoice` trait ([#351](https://github.com/cot-rs/cot/pull/351))
- support multiple session stores ([#277](https://github.com/cot-rs/cot/pull/277))
- more Session config knobs ([#337](https://github.com/cot-rs/cot/pull/337))
- `ToDbValue` for `Url` and bug fixes for `Url` and `Email` ([#353](https://github.com/cot-rs/cot/pull/353))
- add validated `Url` type ([#339](https://github.com/cot-rs/cot/pull/339))
- FromRequestParts derive macro ([#336](https://github.com/cot-rs/cot/pull/336))
- [**breaking**] add `SelectField`; support more chrono form fields ([#345](https://github.com/cot-rs/cot/pull/345))
- support more chrono datatypes in the framework ([#332](https://github.com/cot-rs/cot/pull/332))
- add simple `AsFormField` impl for `ForeignKey`s ([#335](https://github.com/cot-rs/cot/pull/335))
- [**breaking**] add support for file fields in forms ([#334](https://github.com/cot-rs/cot/pull/334))

### <!-- 2 -->Fixes

- ignored doctest ([#372](https://github.com/cot-rs/cot/pull/372))
- clippy warning in the latest nightly ([#346](https://github.com/cot-rs/cot/pull/346))
- [**breaking**] OpenAPI specs with item references ([#333](https://github.com/cot-rs/cot/pull/333))

### <!-- 3 -->Other

- [**breaking**] `FromRequest(Parts)` only gets immutable request parts ([#377](https://github.com/cot-rs/cot/pull/377))
- extract `LiveReloadMiddleware` to a separate file ([#375](https://github.com/cot-rs/cot/pull/375))
- [**breaking**] add `#[non_exhaustive]` to `FormError` variants ([#374](https://github.com/cot-rs/cot/pull/374))
- style fixes; replace todo!() with unimplemented!() ([#370](https://github.com/cot-rs/cot/pull/370))
- *(pre-commit)* add HTML/Jinja2 linter & formatter ([#365](https://github.com/cot-rs/cot/pull/365))
- *(deps)* [**breaking**] bump all dependencies ([#361](https://github.com/cot-rs/cot/pull/361))
- fix warning on stable clippy ([#364](https://github.com/cot-rs/cot/pull/364))
- warn on `clippy::allow_attributes`; fix clippy warnings ([#363](https://github.com/cot-rs/cot/pull/363))
- custom `Default` impl for `SessionMiddlewareConfig` ([#359](https://github.com/cot-rs/cot/pull/359))
- fix clippy warnings on Rust 1.88 ([#355](https://github.com/cot-rs/cot/pull/355))
- [**breaking**] add `#[non_exhaustive]` to config structs ([#354](https://github.com/cot-rs/cot/pull/354))
- [**breaking**] remove deprecated items ([#349](https://github.com/cot-rs/cot/pull/349))
- tiny doc and code consistency fixes ([#348](https://github.com/cot-rs/cot/pull/348))

---

# New

## [0.4.0](https://github.com/cot-rs/cot/compare/cot-v0.3.1...cot-v0.4.0) - 2025-07-10

[View diff on diff.rs](https://diff.rs/cot/0.3.1/cot/0.4.0/Cargo.toml)

### New features

- [**breaking**] Add support for file fields in forms ([#334](https://github.com/cot-rs/cot/pull/334)) (by [@m4tx](https://github.com/m4tx))
- [**breaking**] Add `SelectField`; support more chrono form fields ([#345](https://github.com/cot-rs/cot/pull/345)) (by [@m4tx](https://github.com/m4tx))
- Support multiple session stores ([#277](https://github.com/cot-rs/cot/pull/277)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
- Support more chrono datatypes in the framework ([#332](https://github.com/cot-rs/cot/pull/332)) (by [@seqre](https://github.com/seqre))
- Add simple `AsFormField` impl for `ForeignKey`s ([#335](https://github.com/cot-rs/cot/pull/335)) (by [@m4tx](https://github.com/m4tx))
- FromRequestParts derive macro ([#336](https://github.com/cot-rs/cot/pull/336)) (by [@kumarUjjawal](https://github.com/kumarUjjawal))
- More Session config knobs ([#337](https://github.com/cot-rs/cot/pull/337)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
- AsFormField for Date, Time, DateTime ([#342](https://github.com/cot-rs/cot/pull/342)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
- Add validated `Url` type ([#339](https://github.com/cot-rs/cot/pull/339)) (by [@kingzcheung](https://github.com/kingzcheung))
- *(macros)* Derive macro for `SelectChoice` trait ([#351](https://github.com/cot-rs/cot/pull/351)) (by [@kumarUjjawal](https://github.com/kumarUjjawal))
- `ToDbValue` for `Url` and bug fixes for `Url` and `Email` ([#353](https://github.com/cot-rs/cot/pull/353)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))

### Fixes

- [**breaking**] OpenAPI specs with item references ([#333](https://github.com/cot-rs/cot/pull/333)) (by [@m4tx](https://github.com/m4tx))
- Clippy warning in the latest nightly ([#346](https://github.com/cot-rs/cot/pull/346)) (by [@m4tx](https://github.com/m4tx))
- Ignored doctest ([#372](https://github.com/cot-rs/cot/pull/372)) (by [@m4tx](https://github.com/m4tx))

### Other

- [**breaking**] Remove deprecated items ([#349](https://github.com/cot-rs/cot/pull/349)) (by [@m4tx](https://github.com/m4tx))
- [**breaking**] Add `#[non_exhaustive]` to config structs ([#354](https://github.com/cot-rs/cot/pull/354)) (by [@m4tx](https://github.com/m4tx))
- [**breaking**] *(deps)* Bump all dependencies ([#361](https://github.com/cot-rs/cot/pull/361)) (by [@dependabot[bot]](https://github.com/dependabot[bot]))
- [**breaking**] Add `#[non_exhaustive]` to `FormError` variants ([#374](https://github.com/cot-rs/cot/pull/374)) (by [@m4tx](https://github.com/m4tx))
- [**breaking**] `FromRequest(Parts)` only gets immutable request parts ([#377](https://github.com/cot-rs/cot/pull/377)) (by [@m4tx](https://github.com/m4tx))
- Tiny doc and code consistency fixes ([#348](https://github.com/cot-rs/cot/pull/348)) (by [@m4tx](https://github.com/m4tx))
- Fix clippy warnings on Rust 1.88 ([#355](https://github.com/cot-rs/cot/pull/355)) (by [@m4tx](https://github.com/m4tx))
- Custom `Default` impl for `SessionMiddlewareConfig` ([#359](https://github.com/cot-rs/cot/pull/359)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
- Warn on `clippy::allow_attributes`; fix clippy warnings ([#363](https://github.com/cot-rs/cot/pull/363)) (by [@m4tx](https://github.com/m4tx))
- Fix warning on stable clippy ([#364](https://github.com/cot-rs/cot/pull/364)) (by [@m4tx](https://github.com/m4tx))
- *(pre-commit)* Add HTML/Jinja2 linter & formatter ([#365](https://github.com/cot-rs/cot/pull/365)) (by [@melroy12](https://github.com/melroy12))
- Style fixes; replace todo!() with unimplemented!() ([#370](https://github.com/cot-rs/cot/pull/370)) (by [@m4tx](https://github.com/m4tx))
- Extract `LiveReloadMiddleware` to a separate file ([#375](https://github.com/cot-rs/cot/pull/375)) (by [@m4tx](https://github.com/m4tx))
