### PR TITLE
feat: Added derive macro `SelectAsFormField`

### DIFF
--- a/cot-macros/src/lib.rs
+++ b/cot-macros/src/lib.rs
@@ -6,6 +6,7 @@ mod from_request;
 mod main_fn;
 mod model;
 mod query;
+mod select_as_form_field;
 mod select_choice;
 
 use darling::Error;
@@ -23,6 +24,7 @@ use crate::from_request::impl_from_request_head_for_struct;
 use crate::main_fn::{fn_to_cot_e2e_test, fn_to_cot_main, fn_to_cot_test};
 use crate::model::impl_model_for_struct;
 use crate::query::{Query, query_to_tokens};
+use crate::select_as_form_field::impl_select_as_form_field_for_enum;
 use crate::select_choice::impl_select_choice_for_enum;
 
 #[proc_macro_derive(Form, attributes(form))]
@@ -210,6 +212,13 @@ pub fn derive_from_request_head(input: TokenStream) -> TokenStream {
 pub fn derive_select_choice(input: TokenStream) -> TokenStream {
     let ast = syn::parse_macro_input!(input as DeriveInput);
     let token_stream = impl_select_choice_for_enum(&ast);
+    token_stream.into()
+}
+
+#[proc_macro_derive(SelectAsFormField)]
+pub fn derive_select_as_form_field(input: TokenStream) -> TokenStream {
+    let ast = syn::parse_macro_input!(input as DeriveInput);
+    let token_stream = impl_select_as_form_field_for_enum(&ast);
     token_stream.into()
 }
 

--- a/cot-macros/src/select_as_form_field.rs
+++ b/cot-macros/src/select_as_form_field.rs
@@ -1,0 +1,42 @@
+use darling::Error;
+use quote::quote;
+use syn::{Data, DeriveInput};
+
+use crate::cot_ident;
+
+pub(super) fn impl_select_as_form_field_for_enum(ast: &DeriveInput) -> proc_macro2::TokenStream {
+    let enum_name = &ast.ident;
+    let cot = cot_ident();
+
+    match &ast.data {
+        Data::Enum(_) => {}
+        _ => {
+            return Error::custom("`SelectAsFormField` can only be derived for enums")
+                .write_errors();
+        }
+    }
+
+    let impl_single = quote! {
+        #[automatically_derived]
+        impl #cot::form::AsFormField for #enum_name {
+            type Type = #cot::form::fields::SelectField<Self>;
+
+            fn clean_value(
+                field: &Self::Type
+            ) -> ::core::result::Result<Self, #cot::form::FormFieldValidationError> {
+                match #cot::form::FormField::value(field) {
+                    ::core::option::Option::Some(v) if !v.is_empty() => <Self as #cot::form::fields::SelectChoice>::from_str(v),
+                    _ => ::core::result::Result::Err(#cot::form::FormFieldValidationError::Required),
+                }
+            }
+
+            fn to_field_value(&self) -> ::std::string::String {
+                <Self as #cot::form::fields::SelectChoice>::to_string(self)
+            }
+        }
+    };
+
+    quote! {
+        #impl_single
+    }
+}

--- a/cot-macros/tests/compile_tests.rs
+++ b/cot-macros/tests/compile_tests.rs
@@ -122,6 +122,21 @@ fn derive_select_choice() {
     miri,
     ignore = "unsupported operation: extern static `pidfd_spawnp` is not supported by Miri"
 )]
+fn derive_select_as_form_field() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/derive_select_as_form_field.rs");
+    t.compile_fail("tests/ui/derive_select_as_form_field_struct.rs");
+}
+
+#[rustversion::attr(
+    not(nightly),
+    ignore = "only test on nightly for consistent error messages"
+)]
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "unsupported operation: extern static `pidfd_spawnp` is not supported by Miri"
+)]
 fn derive_into_response() {
     let t = trybuild::TestCases::new();
     t.pass("tests/ui/derive_into_response.rs");

--- a/cot-macros/tests/ui/derive_select_as_form_field.rs
+++ b/cot-macros/tests/ui/derive_select_as_form_field.rs
@@ -1,0 +1,11 @@
+use cot::form::fields::{SelectChoice, SelectAsFormField};
+
+#[derive(SelectChoice, SelectAsFormField, Debug, Clone, PartialEq, Eq, Hash)]
+enum Status {
+    Draft,
+    Published,
+    Archived,
+}
+
+fn main() {}
+

--- a/cot-macros/tests/ui/derive_select_as_form_field_struct.rs
+++ b/cot-macros/tests/ui/derive_select_as_form_field_struct.rs
@@ -1,0 +1,9 @@
+use cot_macros::SelectAsFormField;
+
+#[derive(SelectAsFormField)]
+struct NotAnEnum {
+    x: u8,
+}
+
+fn main() {}
+

--- a/cot-macros/tests/ui/derive_select_as_form_field_struct.stderr
+++ b/cot-macros/tests/ui/derive_select_as_form_field_struct.stderr
@@ -1,0 +1,7 @@
+error: `SelectAsFormField` can only be derived for enums
+ --> tests/ui/derive_select_as_form_field_struct.rs:3:10
+  |
+3 | #[derive(SelectAsFormField)]
+  |          ^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `SelectAsFormField` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/cot/src/form/fields.rs
+++ b/cot/src/form/fields.rs
@@ -18,7 +18,8 @@ pub use chrono::{
 pub use files::{FileField, FileFieldOptions, InMemoryUploadedFile};
 pub(crate) use select::check_required_multiple;
 pub use select::{
-    SelectChoice, SelectField, SelectFieldOptions, SelectMultipleField, SelectMultipleFieldOptions,
+    SelectAsFormField, SelectChoice, SelectField, SelectFieldOptions, SelectMultipleField,
+    SelectMultipleFieldOptions,
 };
 
 use crate::auth::PasswordHash;

--- a/cot/src/form/fields/chrono.rs
+++ b/cot/src/form/fields/chrono.rs
@@ -60,7 +60,6 @@ macro_rules! impl_as_form_field_mult_collection {
     };
 }
 
-impl_as_form_field_mult!(Weekday);
 impl_as_form_field_mult_collection!(WeekdaySet, Weekday);
 
 const MONDAY_ID: &str = "mon";

--- a/cot/src/private.rs
+++ b/cot/src/private.rs
@@ -15,7 +15,7 @@ pub use askama;
 pub use async_trait::async_trait;
 pub use bytes::Bytes;
 pub use cot_macros::ModelHelper;
-pub use tokio;
+pub use {indexmap, tokio};
 
 // used in the CLI
 #[cfg(feature = "db")]


### PR DESCRIPTION
As per the requirements of the #356 I implemented the `SelectAsFormField` derive macro. There were two directions for this either creating a derive macro or create a wrapper struct. Since I love derive macro and comfortable implementing it, I went with that. 

After this change the `impl_as_form_field_mult` macro is now unused, I would like to know what is the preference for that?