### PR TITLE
chore: allow `clippy::needless_continue`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,12 @@ rust_2018_idioms = { level = "warn", priority = -1 }
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }
-pedantic = "warn"
+pedantic = { level = "warn", priority = -1 }
 future_not_send = "warn"
 allow_attributes = "warn"
+# TODO: consider removing this if/when this is fixed:
+# https://github.com/rust-lang/rust-clippy/issues/16175
+needless_continue = "allow"
 
 [workspace.dependencies]
 ahash = { version = "0.8.12", default-features = false }


### PR DESCRIPTION
Seems like there was a clippy regression (rust-lang/rust-clippy#16175) that causes the CI to fail now; let's just allow the problematic lint since it's in the pedantic category anyway.