### PR TITLE
refactor!: `Cache` instead of `Arc<Cache>` in public APIs

### DIFF
--- a/cot/src/project.rs
+++ b/cot/src/project.rs
@@ -1334,8 +1334,8 @@ impl Bootstrapper<WithDatabase> {
     }
 
     #[cfg(feature = "cache")]
-    async fn init_cache(config: &CacheConfig) -> cot::Result<Arc<Cache>> {
-        let cache = Cache::from_config(config).await.map(Arc::new)?;
+    async fn init_cache(config: &CacheConfig) -> cot::Result<Cache> {
+        let cache = Cache::from_config(config).await?;
         Ok(cache)
     }
 }
@@ -1652,7 +1652,7 @@ impl BootstrapPhase for WithCache {
     type Database = Option<Arc<Database>>;
     type AuthBackend = <WithApps as BootstrapPhase>::AuthBackend;
     #[cfg(feature = "cache")]
-    type Cache = Arc<Cache>;
+    type Cache = Cache;
 }
 
 /// The final phase of bootstrapping a Cot project, the initialized phase.
@@ -1808,7 +1808,7 @@ impl ProjectContext<WithApps> {
 
 impl ProjectContext<WithDatabase> {
     #[must_use]
-    fn with_cache(self, #[cfg(feature = "cache")] cache: Arc<Cache>) -> ProjectContext<WithCache> {
+    fn with_cache(self, #[cfg(feature = "cache")] cache: Cache) -> ProjectContext<WithCache> {
         ProjectContext {
             config: self.config,
             apps: self.apps,
@@ -1908,7 +1908,7 @@ impl<S: BootstrapPhase<AuthBackend = Arc<dyn AuthBackend>>> ProjectContext<S> {
 }
 
 #[cfg(feature = "cache")]
-impl<S: BootstrapPhase<Cache = Arc<Cache>>> ProjectContext<S> {
+impl<S: BootstrapPhase<Cache = Cache>> ProjectContext<S> {
     /// Returns the cache for the project.
     ///
     /// # Examples
@@ -1925,7 +1925,7 @@ impl<S: BootstrapPhase<Cache = Arc<Cache>>> ProjectContext<S> {
     /// ```
     #[must_use]
     #[cfg(feature = "cache")]
-    pub fn cache(&self) -> &Arc<Cache> {
+    pub fn cache(&self) -> &Cache {
         &self.cache
     }
 }
@@ -2521,11 +2521,11 @@ mod tests {
 
     #[cot::test]
     async fn default_auth_backend() {
-        let cache_memory = Arc::new(Cache::new(
+        let cache_memory = Cache::new(
             cache::store::memory::Memory::new(),
             None,
             Timeout::default(),
-        ));
+        );
 
         let context = ProjectContext::new()
             .with_config(

--- a/cot/src/test.rs
+++ b/cot/src/test.rs
@@ -233,7 +233,7 @@ pub struct TestRequestBuilder {
     json_data: Option<String>,
     static_files: Vec<StaticFile>,
     #[cfg(feature = "cache")]
-    cache: Option<Arc<Cache>>,
+    cache: Option<Cache>,
 }
 
 /// A wrapper over an auth backend that is cloneable.
@@ -774,7 +774,7 @@ impl TestRequestBuilder {
             #[cfg(feature = "cache")]
             self.cache
                 .clone()
-                .unwrap_or_else(|| Arc::new(Cache::new(Memory::new(), None, Timeout::default()))),
+                .unwrap_or_else(|| Cache::new(Memory::new(), None, Timeout::default())),
         );
         prepare_request(&mut request, Arc::new(context));
 
@@ -1776,17 +1776,14 @@ enum CacheKind {
 #[cfg(feature = "cache")]
 #[derive(Debug, Clone)]
 pub struct TestCache {
-    cache: Arc<Cache>,
+    cache: Cache,
     kind: CacheKind,
 }
 
 #[cfg(feature = "cache")]
 impl TestCache {
     fn new(cache: Cache, kind: CacheKind) -> Self {
-        Self {
-            cache: Arc::new(cache),
-            kind,
-        }
+        Self { cache, kind }
     }
 
     /// Create a new in-memory test cache.
@@ -1905,7 +1902,7 @@ impl TestCache {
     /// # }
     /// ```
     #[must_use]
-    pub fn cache(&self) -> Arc<Cache> {
+    pub fn cache(&self) -> Cache {
         self.cache.clone()
     }
 


### PR DESCRIPTION
Similarly to #432, this drops the `Arc` from `Arc<Cache>` in public APIs to make the interfaces more ergonomic and easier to use for the users.