### PR TITLE
feat: add FileStore implementation for cache (#427)

### DIFF
--- a/.cargo/deny.toml
+++ b/.cargo/deny.toml
@@ -25,4 +25,5 @@ allow = [
     "MIT",
     "Unicode-3.0",
     "Zlib",
+    "BSD-2-Clause",
 ]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,7 +66,7 @@ jobs:
           - rust: nightly
             version: *rust_nightly
           - rust: MSRV
-            version: "1.88" # MSRV
+            version: "1.89" # MSRV
 
     name: Build & test
     runs-on: ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,6 +898,7 @@ dependencies = [
  "fake",
  "fantoccini",
  "form_urlencoded",
+ "fs4",
  "futures-core",
  "futures-util",
  "grass_compiler",
@@ -1681,6 +1682,17 @@ name = "fragile"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+
+[[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix",
+ "tokio",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "futures"
@@ -5116,6 +5128,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.89"
 license = "MIT OR Apache-2.0"
 homepage = "https://cot.rs"
 repository = "https://github.com/cot-rs/cot"
@@ -94,6 +94,7 @@ email_address = "0.2.9"
 fake = "5"
 fantoccini = "0.22"
 form_urlencoded = "1"
+fs4 = { version = "0.13.1", features = ["tokio", "sync"] }
 futures = { version = "0.3", default-features = false }
 futures-core = { version = "0.3", default-features = false }
 futures-util = { version = "0.3", default-features = false }

--- a/cot-macros/src/cache.rs
+++ b/cot-macros/src/cache.rs
@@ -6,6 +6,7 @@ pub(super) fn fn_to_cache_test(test_fn: &ItemFn) -> TokenStream {
     let test_fn_name = &test_fn.sig.ident;
     let memory_ident = format_ident!("{}_memory", test_fn_name);
     let redis_ident = format_ident!("{}_redis", test_fn_name);
+    let file_ident = format_ident!("{}_file", test_fn_name);
 
     let result = quote! {
         #[::cot::test]
@@ -28,7 +29,17 @@ pub(super) fn fn_to_cache_test(test_fn: &ItemFn) -> TokenStream {
             cache.cleanup().await.unwrap_or_else(|err| panic!("Failed to cleanup: {err:?}"));
 
             #test_fn
-    }
+        }
+
+        #[::cot::test]
+        async fn #file_ident() {
+            let mut cache = cot::test::TestCache::new_file().unwrap();
+            #test_fn_name(&mut cache).await;
+
+             cache.cleanup().await.unwrap_or_else(|err| panic!("Failed to cleanup file cache: {err:?}"));
+
+             #test_fn
+         }
     };
     result
 }

--- a/cot/Cargo.toml
+++ b/cot/Cargo.toml
@@ -33,6 +33,7 @@ derive_more = { workspace = true, features = ["debug", "deref", "display", "from
 email_address.workspace = true
 fake = { workspace = true, optional = true, features = ["derive", "chrono"] }
 form_urlencoded.workspace = true
+fs4 = { workspace = true, optional = true }
 futures-core.workspace = true
 futures-util.workspace = true
 hex.workspace = true
@@ -111,7 +112,7 @@ json = ["dep:serde_json", "cot_core/json"]
 openapi = ["json", "cot_core/schemars", "dep:aide", "dep:schemars"]
 swagger-ui = ["openapi", "dep:swagger-ui-redist"]
 live-reload = ["dep:tower-livereload"]
-cache = ["json"]
+cache = ["json", "fs4"]
 test = []
 
 [lib]

--- a/cot/src/cache.rs
+++ b/cot/src/cache.rs
@@ -122,6 +122,7 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use thiserror::Error;
 
+use crate::cache::store::file::{FileStore, FileStorePoolConfig};
 use crate::cache::store::memory::Memory;
 #[cfg(feature = "redis")]
 use crate::cache::store::redis::Redis;
@@ -786,9 +787,24 @@ impl Cache {
                     let redis_store = Redis::new(url, pool_size)?;
                     Self::new(redis_store, config.prefix.clone(), config.timeout)
                 }
-                _ => {
-                    unimplemented!();
+                CacheStoreTypeConfig::File {
+                    ref path,
+                    worker_count,
+                    queue_size,
+                    acquisition_timeout_ms,
+                } => {
+                    let file_store = FileStore::new(
+                        path.clone(),
+                        FileStorePoolConfig::builder()
+                            .worker_count(worker_count)
+                            .queue_size(queue_size)
+                            .acquisition_timeout_ms(acquisition_timeout_ms)
+                            .build(),
+                    )?;
+                    Self::new(file_store, config.prefix.clone(), config.timeout)
                 }
+                #[expect(unused)]
+                _ => unimplemented!(),
             }
         };
 
@@ -980,5 +996,43 @@ mod tests {
 
         let result = Cache::from_config(&config).await;
         assert!(result.is_ok());
+    }
+
+    #[cot::test]
+    async fn test_cache_from_config_file() {
+        use std::env;
+
+        use crate::config::{CacheConfig, CacheStoreConfig};
+
+        let temp_path =
+            env::temp_dir().join(format!("test_cot_cache_file_store_{}", std::process::id()));
+        let cloned_path = temp_path.clone();
+        let default_file_store_pool_config = FileStorePoolConfig::default();
+
+        let config = CacheConfig::builder()
+            .store(CacheStoreConfig {
+                store_type: CacheStoreTypeConfig::File {
+                    path: temp_path,
+                    worker_count: default_file_store_pool_config.worker_count(),
+                    queue_size: default_file_store_pool_config.queue_size(),
+                    acquisition_timeout_ms: default_file_store_pool_config.acquisition_timeout_ms(),
+                },
+            })
+            .prefix("test_file")
+            .timeout(Timeout::After(Duration::from_secs(60)))
+            .build();
+
+        let cache = Cache::from_config(&config)
+            .await
+            .expect("Failed to create cache from config");
+
+        cache
+            .insert("test_key", "test_value".to_string())
+            .await
+            .unwrap();
+        let retrieved = cache.get("test_key").await.unwrap();
+        assert_eq!(retrieved, Some("test_value".to_string()));
+
+        let _ = tokio::fs::remove_dir_all(&cloned_path).await;
     }
 }

--- a/cot/src/cache.rs
+++ b/cot/src/cache.rs
@@ -792,6 +792,7 @@ impl Cache {
                     worker_count,
                     queue_size,
                     acquisition_timeout_ms,
+                    waiting_timeout_ms,
                 } => {
                     let file_store = FileStore::new(
                         path.clone(),
@@ -799,6 +800,7 @@ impl Cache {
                             .worker_count(worker_count)
                             .queue_size(queue_size)
                             .acquisition_timeout_ms(acquisition_timeout_ms)
+                            .waiting_timeout_ms(waiting_timeout_ms)
                             .build(),
                     )?;
                     Self::new(file_store, config.prefix.clone(), config.timeout)
@@ -1016,6 +1018,7 @@ mod tests {
                     worker_count: default_file_store_pool_config.worker_count(),
                     queue_size: default_file_store_pool_config.queue_size(),
                     acquisition_timeout_ms: default_file_store_pool_config.acquisition_timeout_ms(),
+                    waiting_timeout_ms: default_file_store_pool_config.waiting_timeout_ms(),
                 },
             })
             .prefix("test_file")

--- a/cot/src/cache/store.rs
+++ b/cot/src/cache/store.rs
@@ -5,6 +5,7 @@
 //! provide a simple asynchronous interface for storing, retrieving, and
 //! managing cached values, optionally with expiration policies.
 
+pub mod file;
 pub mod memory;
 #[cfg(feature = "redis")]
 pub mod redis;

--- a/cot/src/cache/store/file.rs
+++ b/cot/src/cache/store/file.rs
@@ -6,7 +6,7 @@
 //!
 //! # Examples
 //!
-//! ```no_run
+//! ```
 //! # use cot::cache::store::file::{FileStore, FileStorePoolConfig};
 //! # use cot::cache::store::CacheStore;
 //! # use cot::config::Timeout;
@@ -15,10 +15,11 @@
 //! # async fn main() {
 //!
 //! let path = PathBuf::from("./cache_data");
-//! let store = FileStore::new(path, FileStorePoolConfig::builder()
+//! let store = FileStore::new(path.clone(), FileStorePoolConfig::builder()
 //!     .worker_count(8)
 //!     .queue_size(128)
 //!     .acquisition_timeout_ms(2000)
+//!     .waiting_timeout_ms(4000)
 //!     .build()
 //! )
 //! .expect("Failed to initialize store");
@@ -30,6 +31,8 @@
 //!
 //! let retrieved = store.get(&key).await.unwrap();
 //! assert_eq!(retrieved, Some(value));
+//!
+//! # let _ = tokio::fs::remove_dir_all(&path).await;
 //! # }
 //! ```
 //!
@@ -49,6 +52,7 @@
 //! | Expiry header | 0           | 7         | i64 (8 bytes)  |
 //! | Cache data    | 8           | EOF       | length of data |
 use std::borrow::Cow;
+use std::fs::TryLockError;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -70,20 +74,18 @@ const TEMPFILE_SUFFIX: &str = "tmp";
 
 // Custom error messages for implementation related
 // failure modes
-const PERMISSION_ERROR_OR_BUSY: &str = "file-system busy or permission error";
+const FILE_SYSTEM_BUSY: &str = "file-system too busy to carry out normal operation";
 const POOL_QUEUE_FULL: &str = "file-store pool queue full";
 const POOL_BUSY: &str = "file-store pool busy";
 // Use this for cases that should not happen under normal
 // operating conditions, e.g., runtime quirks.
 const UNEXPECTED_ERROR: &str = "unexpected error";
+const TIMEOUT_REACHED: &str = "file-store pool took to long to respond";
 
 // This is a retry limit for edge-cases where a file has been
 // created but failed to be locked immediately, where such case
 // happens multiple times.
 const INTERNAL_MAX_RETRIES: i32 = 5;
-
-// The timeout is set to 2000ms to allow the queue to drain efficiently
-// while giving requests a reasonable window to acquire a file lock.
 
 // This header offset skips exactly one i64 integer,
 // which is the basis of our current expiry timestamp
@@ -147,12 +149,14 @@ struct FileStorePool {
 /// The `new()` method will provide default values for  `FileStorePoolConfig`
 ///
 /// #  Examples
-/// ```no_run
+/// ```
 /// use std::path::PathBuf;
 ///
-/// use crate::cot::cache::store::file::{FileStore, FileStorePoolConfig};
+/// use cot::cache::store::file::{FileStore, FileStorePoolConfig};
 ///
-/// let store_path = PathBuf::from("./cache");
+/// # #[tokio::main]
+/// # async fn main() {
+/// let store_path = PathBuf::from("cache");
 ///
 /// // Using default values
 /// let default_config = FileStorePoolConfig::builder().build();
@@ -160,6 +164,7 @@ struct FileStorePool {
 /// assert_eq!(default_config.worker_count(), 10);
 /// assert_eq!(default_config.queue_size(), 128);
 /// assert_eq!(default_config.acquisition_timeout_ms(), 2000);
+/// assert_eq!(default_config.waiting_timeout_ms(), 4000);
 /// let store_default = FileStore::new(store_path.clone(), default_config).unwrap();
 ///
 /// // Specifying values
@@ -167,12 +172,16 @@ struct FileStorePool {
 ///     .worker_count(4)
 ///     .queue_size(100)
 ///     .acquisition_timeout_ms(1000)
+///     .waiting_timeout_ms(2000)
 ///     .build();
 ///
 /// assert_eq!(specified_config.worker_count(), 4);
 /// assert_eq!(specified_config.queue_size(), 100);
 /// assert_eq!(specified_config.acquisition_timeout_ms(), 1000);
-/// let store_custom = FileStore::new(store_path, specified_config).unwrap();
+/// assert_eq!(specified_config.waiting_timeout_ms(), 2000);
+/// let store_custom = FileStore::new(store_path.clone(), specified_config).unwrap();
+/// # let _ = tokio::fs::remove_dir_all(&store_path).await;
+/// # }
 /// ```
 #[derive(Debug, Clone, Copy, Default)]
 pub struct FileStorePoolConfigBuilder {
@@ -222,12 +231,27 @@ impl FileStorePoolConfigBuilder {
         self.file_store_pool_config.acquisition_timeout_ms = acquisition_timeout_ms;
         self
     }
+    /// Sets the maximum duration (in milliseconds) for requests to wait until
+    /// it can be processed.
+    ///
+    /// This only accounts for the time spent waiting in the queue.
+    /// When the timeout is reached before the request gets the file,
+    /// the request would get dropped and returns error.
+    #[must_use]
+    pub fn waiting_timeout_ms(mut self, waiting_timeout_ms: u64) -> Self {
+        self.file_store_pool_config.waiting_timeout_ms = waiting_timeout_ms;
+        self
+    }
+
     /// Consumes this struct and builds the `FileStorePoolConfig`
     ///
     /// # Panics
     ///
-    /// This method will panic if a value > `usize::MAX >> 3`
-    /// was provided in the `worker_count()` and `queue_size()` setters.
+    /// This method will panic if
+    /// *  a value > `usize::MAX >> 3`was provided in the `worker_count()` and `queue_size()` setters.
+    /// * `worker_count` == 0 with  `queue_size`!= 0 and vice-versa.
+    /// * `waiting_timeout_ms` < `acquisition_timeout_ms`.
+    ///
     #[must_use]
     pub fn build(self) -> FileStorePoolConfig {
         assert!(
@@ -237,6 +261,16 @@ impl FileStorePoolConfigBuilder {
         assert!(
             self.file_store_pool_config.queue_size <= usize::MAX >> 3,
             "the provided `queue_size` must not be bigger than usize::MAX >> 3"
+        );
+        assert!(
+            (self.file_store_pool_config.worker_count == 0)
+                == (self.file_store_pool_config.queue_size == 0),
+            "`queue_size` must be 0 when `worker_count` is 0 and vice versa"
+        );
+        assert!(
+            self.file_store_pool_config.waiting_timeout_ms
+                >= self.file_store_pool_config.acquisition_timeout_ms,
+            "`waiting_timeout_ms` must be greater or equal to `acquisition_timeout_ms`"
         );
 
         self.file_store_pool_config
@@ -257,6 +291,7 @@ pub struct FileStorePoolConfig {
     worker_count: usize,
     queue_size: usize,
     acquisition_timeout_ms: u64,
+    waiting_timeout_ms: u64,
 }
 
 impl FileStorePoolConfig {
@@ -266,7 +301,7 @@ impl FileStorePoolConfig {
     /// default values.
     ///
     /// # Examples
-    /// ```no_run
+    /// ```
     /// use crate::cot::cache::store::file::{FileStore, FileStorePoolConfig};
     ///
     /// let default_config = FileStorePoolConfig::default();
@@ -302,6 +337,16 @@ impl FileStorePoolConfig {
     pub fn acquisition_timeout_ms(&self) -> u64 {
         self.acquisition_timeout_ms
     }
+    /// Returns the maximum duration (in milliseconds) for requests to wait
+    /// until it can be processed.
+    ///
+    /// This only accounts for the time spent waiting in the queue.
+    /// When the timeout is reached before the request gets the file,
+    /// the request would get dropped and returns error.
+    #[must_use]
+    pub fn waiting_timeout_ms(&self) -> u64 {
+        self.waiting_timeout_ms
+    }
 }
 
 impl Default for FileStorePoolConfig {
@@ -310,6 +355,7 @@ impl Default for FileStorePoolConfig {
             worker_count: crate::config::DEFAULT_FILE_STORE_WORKER_COUNT,
             queue_size: crate::config::DEFAULT_FILE_STORE_QUEUE_SIZE,
             acquisition_timeout_ms: crate::config::DEFAULT_FILE_STORE_ACQUISITION_TIMEOUT_MS,
+            waiting_timeout_ms: crate::config::DEFAULT_FILE_STORE_WAITING_TIMEOUT_MS,
         }
     }
 }
@@ -333,11 +379,13 @@ impl FileStorePool {
     async fn run(&mut self) {
         while let Some(data) = self.work_receiver.recv().await {
             let permits = self.permits.clone();
-            let tx = data.file_handle_sender;
+            let mut tx = data.file_handle_sender;
 
             let acquire_permit_result = tokio::select! {
                 r = permits.acquire_owned() => Ok(r),
                 _r = tokio::time::sleep(self.acquisiton_timeout_duration) => Err(FileCacheStoreError::TempFileCreation(POOL_BUSY.into())),
+                _r = tx.closed() => {
+                     Err(FileCacheStoreError::TempFileCreation(UNEXPECTED_ERROR.into()))},
             };
 
             match acquire_permit_result {
@@ -346,10 +394,9 @@ impl FileStorePool {
 
                     // We spawn the task here since
                     // 1. We don't want to spawn tasks just to wait on semaphore
-                    // 2. We don't want the spawn_blocking await to block
-                    // the main loop
+                    // 2. We don't want the spawn_blocking await to block the main loop
                     tokio::spawn(async move {
-                        if let Ok(file_acquisition_result) = spawn_blocking(move || {
+                        let task = spawn_blocking(move || {
                             let file_handle = std::fs::OpenOptions::new()
                                 .write(true)
                                 .read(true)
@@ -362,18 +409,12 @@ impl FileStorePool {
                                 .lock()
                                 .map_err(|e| FileCacheStoreError::TempFileCreation(Box::new(e)))?;
 
-                            file_handle
-                                .set_len(0)
-                                .map_err(|e| FileCacheStoreError::TempFileCreation(Box::new(e)))?;
-
                             drop(acquired_permit);
                             Ok(tokio::fs::File::from_std(file_handle))
-                        })
-                        .await
-                        {
+                        });
+                        if let Ok(file_acquisition_result) = task.await {
                             // No-op on error because we can't really notify the consumers if the
                             // request was aborted.
-
                             let _ = tx.send(file_acquisition_result);
                         } else {
                             let _ = tx.send(Err(FileCacheStoreError::TempFileCreation(
@@ -401,13 +442,15 @@ impl FileStorePool {
 /// This store uses the local file system for caching.
 ///
 /// # Examples
-/// ```no_run
+/// ```
 /// use std::path::Path;
 ///
 /// use cot::cache::store::file::{FileStore, FileStorePoolConfig};
 ///
+/// # #[tokio::main]
+/// # async fn main() {
 /// let store = FileStore::new(
-///     Path::new("./cache_dir"),
+///     Path::new("cache_dir"),
 ///     FileStorePoolConfig::builder()
 ///         .worker_count(10)
 ///         .queue_size(128)
@@ -415,11 +458,14 @@ impl FileStorePool {
 ///         .build(),
 /// )
 /// .unwrap();
+/// # let _ = tokio::fs::remove_dir_all("cache_dir").await;
+/// # }
 /// ```
 #[derive(Debug, Clone)]
 pub struct FileStore {
     dir_path: Cow<'static, Path>,
     file_path_sender: tokio::sync::mpsc::Sender<FileAcquisitionWork>,
+    waiting_timeout_duration: tokio::time::Duration,
 }
 
 impl FileStore {
@@ -435,13 +481,15 @@ impl FileStore {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use std::path::PathBuf;
     ///
     /// use cot::cache::store::file::{FileStore, FileStorePoolConfig};
     ///
+    /// # #[tokio::main]
+    /// # async fn main() {
     /// // Using a string slice
-    /// let path = PathBuf::from("./cache");
+    /// let path = PathBuf::from("cache");
     /// let store = FileStore::new(
     ///     path,
     ///     FileStorePoolConfig::builder()
@@ -453,8 +501,11 @@ impl FileStore {
     /// .unwrap();
     ///
     /// // Using a PathBuf
-    /// let path = PathBuf::from("/var/lib/myapp/cache");
+    /// let path = PathBuf::from("cache_lib");
     /// let store = FileStore::new(path, FileStorePoolConfig::builder().build()).unwrap();
+    /// # let _ = tokio::fs::remove_dir_all("cache").await;
+    /// # let _ = tokio::fs::remove_dir_all("cache_lib").await;
+    /// # }
     /// ```
     pub fn new(
         dir: impl Into<Cow<'static, Path>>,
@@ -466,6 +517,7 @@ impl FileStore {
         let store = Self {
             dir_path,
             file_path_sender: tx,
+            waiting_timeout_duration: tokio::time::Duration::from_millis(config.waiting_timeout_ms),
         };
 
         store.create_dir_root_sync()?;
@@ -480,21 +532,30 @@ impl FileStore {
         std::fs::create_dir_all(&self.dir_path)
             .map_err(|e| FileCacheStoreError::DirCreation(Box::new(e)))?;
 
-        // When a crash happens mid-flight, we'll may have some .tmp files
+        // When a crash happens mid-flight, we may have some .tmp files
         // This ensures that we have no .tmp files lingering around on startup
         if let Ok(entries) = std::fs::read_dir(&self.dir_path) {
             for entry in entries.flatten() {
                 let path = entry.path();
 
-                if path.extension().is_some_and(|ext| ext == TEMPFILE_SUFFIX)
-                    && let Ok(file) = std::fs::OpenOptions::new()
+                if path.extension().is_some_and(|ext| ext == TEMPFILE_SUFFIX) {
+                    let file = std::fs::OpenOptions::new()
                         .write(true)
-                        .create(true)
                         .truncate(false)
                         .open(&path)
-                    && file.try_lock().is_ok()
-                {
-                    let _ = std::fs::remove_file(path);
+                        .map_err(|e| FileCacheStoreError::Io(Box::new(e)))?;
+                    match file.try_lock() {
+                        Ok(()) => {
+                            let _ = std::fs::remove_file(path);
+                        }
+                        // No-op on this since the file is currently used.
+                        // This process is intented to only clean orphaned .tmp files.
+                        // Therefore, we don't steal the files here.
+                        Err(TryLockError::WouldBlock) => {}
+                        Err(TryLockError::Error(e)) => {
+                            return Err(FileCacheStoreError::Io(Box::new(e)))?;
+                        }
+                    }
                 }
             }
         }
@@ -513,49 +574,49 @@ impl FileStore {
     async fn write(&self, key: String, value: Value, expiry: Timeout) -> CacheStoreResult<()> {
         let key_hash = FileStore::create_key_hash(&key);
         let (mut file, file_path) = self.create_file_temp(&key_hash).await?;
+        file.set_len(0)
+            .await
+            .map_err(|e| FileCacheStoreError::Serialize(Box::new(e)))?;
 
         self.serialize_data(value, expiry, &mut file, &file_path)
             .await?;
 
-        // Here's the flow:
-        // We sync the data after writing to it. This ensures that we get the correctly
-        // written data even if the later ops fail. We unlock first to let
-        // progress move. This is free when there are no concurrent accessor. If we
-        // rename then unlock, the final file gets locked instead when subsequent
-        // readers progress, defeating the purpose of this method. We create a
-        // new file handle to see whether the file still exists or not. If it doesn't
-        // exist, we move on. It's most likely has been deleted by
-        // `create_dir_root_sync` or `clear`. Finally, we rename only if the
-        // thread reasonably hold the "last" lock to the .tmp. This doesn't
-        // guarantee that no .tmp file will be renamed by another thread, but it pushes
-        // the guarantees towards "writers write and hold in .tmp file, not contesting
-        // the final file"
+        // Sync data to synchronize content to the disk
         file.sync_data()
             .await
             .map_err(|e| FileCacheStoreError::Io(Box::new(e)))?;
 
+        // Unlock the file to ensure that the locked file is not
+        // the switched file
         file.unlock_async()
             .await
             .map_err(|e| FileCacheStoreError::Io(Box::new(e)))?;
 
         // The return `Ok(())`on these two methods
-        // are to anticipate the "unlocked file" window mentioned in
+        // is to anticipate the "unlocked file" window mentioned in
         // `create_file_temp()`.
-
         let new_file_handle = match OpenOptions::new().read(true).open(&file_path).await {
             Ok(handle) => handle,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
             Err(e) => return Err(FileCacheStoreError::Io(Box::new(e)))?,
         };
 
-        if new_file_handle.try_lock_shared().is_ok_and(|lock| lock)
-            && let Err(e) = tokio::fs::rename(&file_path, self.dir_path.join(&key_hash)).await
-        {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                return Ok(());
+        // Try to lock one last time, but for shared so that it won't block readers
+        // If `rename()` fails, we check the error result. NotFound means someone stole
+        // the file. Other errors would otherwise be propagated as legitimate
+        // errors.
+        match new_file_handle.try_lock_shared() {
+            Ok(true) => {
+                if let Err(e) = tokio::fs::rename(&file_path, self.dir_path.join(&key_hash)).await {
+                    if e.kind() == std::io::ErrorKind::NotFound {
+                        return Ok(());
+                    }
+                    return Err(FileCacheStoreError::Io(Box::new(e)))?;
+                }
             }
-
-            return Err(FileCacheStoreError::Io(Box::new(e)))?;
+            // Other task is currently holding the file locked
+            Ok(false) => return Ok(()),
+            Err(e) => return Err(FileCacheStoreError::Io(Box::new(e)))?,
         }
 
         Ok(())
@@ -611,10 +672,8 @@ impl FileStore {
         result
     }
 
-    // Check expiry also removes the file
-    // when expired. This makes the read
-    // process more efficient with less
-    // error propagation
+    // Check expiry also removes expired files.
+    // This makes the read process more efficient with less error propagation
     async fn check_expiry(
         &self,
         file: &mut tokio::fs::File,
@@ -663,15 +722,15 @@ impl FileStore {
             return Ok(None);
         }
 
+        // In supported platforms, this would be succesful. Consequently, when a
+        // platform does not support this operation, it would always fail and we
+        // handle it as unexpected error
+        let expiry_offset = u64::try_from(EXPIRY_HEADER_OFFSET)
+            .map_err(|_| FileCacheStoreError::Deserialize(UNEXPECTED_ERROR.into()))?;
         let mut buffer = Vec::new();
 
         // Advances cursor by the expiry header offset
-        // EXPIRY_HEADER_OFFSET is a usize that stores
-        // the size of i64. It is unlikely that this will
-        // overflow.
-        // This direct cast currently works without any other
-        // wrapping addition or fallback conversion
-        file.seek(SeekFrom::Start(EXPIRY_HEADER_OFFSET as u64))
+        file.seek(SeekFrom::Start(expiry_offset))
             .await
             .map_err(|e| FileCacheStoreError::Io(Box::new(e)))?;
         file.read_to_end(&mut buffer)
@@ -719,24 +778,22 @@ impl FileStore {
                 .write(true)
                 .read(true)
                 .create_new(true)
-                .truncate(true)
+                .truncate(false)
                 .open(&temp_path)
                 .await
             {
                 Ok(handle) => {
-                    if let Ok(lock_acquired) = handle.try_lock_exclusive()
-                        && lock_acquired
-                    {
-                        break handle;
-                    }
-
-                    // We try again when we can't lock maybe due to external processes.
-                    // However, if failure keeps happening here, we must abort.
-                    retry_count += 1;
-                    if retry_count > INTERNAL_MAX_RETRIES {
-                        return Err(FileCacheStoreError::TempFileCreation(
-                            PERMISSION_ERROR_OR_BUSY.into(),
-                        ))?;
+                    match handle.try_lock_exclusive() {
+                        Ok(true) => break handle,
+                        Ok(false) => {
+                            retry_count += 1;
+                            if retry_count > INTERNAL_MAX_RETRIES {
+                                return Err(FileCacheStoreError::TempFileCreation(
+                                    FILE_SYSTEM_BUSY.into(),
+                                ))?;
+                            }
+                        }
+                        Err(e) => return Err(FileCacheStoreError::TempFileCreation(Box::new(e)))?,
                     }
                     continue;
                 }
@@ -749,13 +806,17 @@ impl FileStore {
                         file_handle_sender: tx,
                     }) {
                         Ok(()) => {
-                            let Ok(new_temp_file) = rx.await else {
-                                // This shouldn't happen because the rx is created here
-                                return Err(FileCacheStoreError::TempFileCreation(
-                                    POOL_BUSY.into(),
-                                ))?;
-                            };
-                            break new_temp_file?;
+                            let rx_result = tokio::time::timeout(self.waiting_timeout_duration, rx)
+                                .await
+                                .map_err(|_| {
+                                    FileCacheStoreError::TempFileCreation(TIMEOUT_REACHED.into())
+                                })?;
+
+                            let new_file_temp = rx_result.map_err(|_| {
+                                FileCacheStoreError::TempFileCreation(UNEXPECTED_ERROR.into())
+                            })?;
+
+                            break new_file_temp?;
                         }
                         Err(_) => {
                             return Err(FileCacheStoreError::TempFileCreation(
@@ -825,16 +886,23 @@ impl CacheStore for FileStore {
             return Ok(());
         }
 
-        if let Ok(entries) = std::fs::read_dir(&self.dir_path) {
-            for entry in entries.flatten() {
+        if let Ok(mut entries) = tokio::fs::read_dir(&self.dir_path).await {
+            while let Ok(Some(entry)) = entries.next_entry().await {
                 let path = entry.path();
                 if let Ok(file) = std::fs::OpenOptions::new()
                     .write(true)
                     .truncate(false)
                     .open(&path)
-                    && file.try_lock().is_ok()
                 {
-                    let _ = std::fs::remove_file(&path);
+                    match file.try_lock() {
+                        // We can steal the .tmp files to prevent ghost files
+                        Ok(()) | Err(TryLockError::WouldBlock) => {
+                            let _ = tokio::fs::remove_file(&path).await;
+                        }
+                        Err(TryLockError::Error(e)) => {
+                            return Err(FileCacheStoreError::Io(Box::new(e)))?;
+                        }
+                    }
                 }
             }
         }
@@ -885,6 +953,7 @@ mod tests {
 
     use crate::cache::store::file::{
         FileCacheStoreError, FileStore, FileStorePoolConfig, POOL_BUSY, POOL_QUEUE_FULL,
+        TIMEOUT_REACHED,
     };
     use crate::cache::store::{CacheStore, CacheStoreError};
     use crate::config::Timeout;
@@ -1131,18 +1200,21 @@ mod tests {
         let path = make_store_path();
         let store =
             FileStore::new(path.clone(), FileStorePoolConfig::default()).expect("failed to init");
-        let _ = tokio::fs::remove_dir_all(&path).await;
+        let value = serde_json::json!({ "id": 1 });
+        let key = "key";
 
         let mut handles = Vec::new();
         for i in 0..10 {
             let s = store.clone();
+            let v = value.clone();
             handles.push(tokio::spawn(async move {
                 if i % 2 == 0 {
-                    let _ = s
-                        .insert("k".into(), serde_json::json!({"i": i}), Timeout::Never)
-                        .await;
+                    // We currently implement the "aggressive clear."
+                    // This removes the files and directory  at any cycle during write,
+                    // so we can't be sure this does not error
+                    let _ = s.insert(key.into(), v, Timeout::Never).await;
                 } else {
-                    let _ = s.clear().await;
+                    s.clear().await.expect("clear should not fail");
                 }
             }));
         }
@@ -1150,6 +1222,16 @@ mod tests {
         for h in handles {
             h.await.unwrap();
         }
+        let received = store.read(key).await.expect("failed to read from store");
+        if let Some(received_value) = received {
+            assert_eq!(received_value, value);
+        }
+
+        // However, we guarantee that after clear, the system is stable again
+        store
+            .insert(key.into(), value, Timeout::Never)
+            .await
+            .expect("write should not fail");
         let _ = tokio::fs::remove_dir_all(&path).await;
     }
 
@@ -1247,7 +1329,7 @@ mod tests {
 
     #[cfg_attr(miri, ignore)]
     #[cot::test]
-    async fn test_thundering_write_with_timeout_exceeded() {
+    async fn test_thundering_write_with_acquisition_timeout_exceeded() {
         let path = make_store_path();
         let store = FileStore::new(
             path.clone(),
@@ -1273,8 +1355,6 @@ mod tests {
                     let file_store_error = FileCacheStoreError::TempFileCreation(POOL_BUSY.into());
                     let cache_store_error: CacheStoreError = file_store_error.into();
 
-                    println!("timeout error check triggered");
-
                     assert_eq!(e.to_string(), cache_store_error.to_string());
                 });
             }
@@ -1284,6 +1364,58 @@ mod tests {
         assert_eq!(retrieved.unwrap(), value);
 
         let _ = tokio::fs::remove_dir_all(&path).await;
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[cot::test]
+    async fn test_thundering_write_with_waiting_timeout_exceeded() {
+        let path = make_store_path();
+        let store = FileStore::new(
+            path.clone(),
+            FileStorePoolConfig::builder()
+                .worker_count(1)
+                .acquisition_timeout_ms(0)
+                .waiting_timeout_ms(0)
+                .build(),
+        )
+        .expect("failed to init");
+        let value = serde_json::json!({ "id": 1 });
+
+        let tasks: Vec<_> = (0..10)
+            .map(|_| {
+                let s = store.clone();
+                let v = value.clone();
+                tokio::spawn(async move { s.insert("key".into(), v, Timeout::Never).await })
+            })
+            .collect();
+
+        for h in tasks {
+            if let Ok(result) = h.await {
+                let _ = result.map_err(|e| {
+                    let file_store_error =
+                        FileCacheStoreError::TempFileCreation(TIMEOUT_REACHED.into());
+                    let cache_store_error: CacheStoreError = file_store_error.into();
+
+                    assert_eq!(e.to_string(), cache_store_error.to_string());
+                });
+            }
+        }
+
+        // When ALL tasks enter handoff, they are subject to the timeout
+        if let Some(retrieved) = store.read("key").await.expect("failed to read from store") {
+            assert_eq!(retrieved, value);
+        }
+        let _ = tokio::fs::remove_dir_all(&path).await;
+    }
+
+    #[test]
+    #[should_panic(expected = "`queue_size` must be 0")]
+    fn test_invalid_file_store_pool_config_creation() {
+        let _file_store = FileStorePoolConfig::builder()
+            .worker_count(0)
+            .queue_size(10)
+            .acquisition_timeout_ms(2000)
+            .build();
     }
 
     #[cot::test]

--- a/cot/src/cache/store/file.rs
+++ b/cot/src/cache/store/file.rs
@@ -482,7 +482,7 @@ impl FileStore {
     /// # Examples
     ///
     /// ```
-    /// use std::path::{PathBuf, Path};
+    /// use std::path::{Path, PathBuf};
     ///
     /// use cot::cache::store::file::{FileStore, FileStorePoolConfig};
     ///
@@ -509,7 +509,7 @@ impl FileStore {
     ///         .queue_size(128)
     ///         .acquisition_timeout_ms(2000)
     ///         .waiting_timeout_ms(4000)
-    ///         .build()
+    ///         .build(),
     /// )
     /// .unwrap();
     /// # let _ = tokio::fs::remove_dir_all("cache").await;

--- a/cot/src/cache/store/file.rs
+++ b/cot/src/cache/store/file.rs
@@ -1427,6 +1427,15 @@ mod tests {
             .build();
     }
 
+    #[test]
+    #[should_panic(expected = "must be greater or equal to")]
+    fn test_invalid_timeout_file_store_pool_config_creation() {
+        let _file_store = FileStorePoolConfig::builder()
+            .waiting_timeout_ms(1999)
+            .acquisition_timeout_ms(2000)
+            .build();
+    }
+
     #[cot::test]
     async fn test_from_file_cache_store_error_to_cache_store_error() {
         let file_error = FileCacheStoreError::Io(Box::new(std::io::Error::other("disk failure")));

--- a/cot/src/cache/store/file.rs
+++ b/cot/src/cache/store/file.rs
@@ -482,29 +482,38 @@ impl FileStore {
     /// # Examples
     ///
     /// ```
-    /// use std::path::PathBuf;
+    /// use std::path::{PathBuf, Path};
     ///
     /// use cot::cache::store::file::{FileStore, FileStorePoolConfig};
     ///
     /// # #[tokio::main]
     /// # async fn main() {
     /// // Using a string slice
-    /// let path = PathBuf::from("cache");
     /// let store = FileStore::new(
-    ///     path,
+    ///     Path::new("cache"),
     ///     FileStorePoolConfig::builder()
     ///         .worker_count(10)
     ///         .queue_size(128)
     ///         .acquisition_timeout_ms(2000)
+    ///         .waiting_timeout_ms(4000)
     ///         .build(),
     /// )
     /// .unwrap();
     ///
     /// // Using a PathBuf
-    /// let path = PathBuf::from("cache_lib");
-    /// let store = FileStore::new(path, FileStorePoolConfig::builder().build()).unwrap();
+    /// let path_from_pathbuf = PathBuf::from("cache_lib");
+    /// let store = FileStore::new(
+    ///     path_from_pathbuf.clone(),
+    ///     FileStorePoolConfig::builder()
+    ///         .worker_count(10)
+    ///         .queue_size(128)
+    ///         .acquisition_timeout_ms(2000)
+    ///         .waiting_timeout_ms(4000)
+    ///         .build()
+    /// )
+    /// .unwrap();
     /// # let _ = tokio::fs::remove_dir_all("cache").await;
-    /// # let _ = tokio::fs::remove_dir_all("cache_lib").await;
+    /// # let _ = tokio::fs::remove_dir_all(path_from_pathbuf).await;
     /// # }
     /// ```
     pub fn new(

--- a/cot/src/cache/store/file.rs
+++ b/cot/src/cache/store/file.rs
@@ -1,0 +1,1330 @@
+//! File-based cache store implementation.
+//!
+//! This store uses the local file system as the backend for caching. It
+//! provides atomic writes via sync-then-rename and active validation for
+//! TTL-based expiration.
+//!
+//! # Examples
+//!
+//! ```no_run
+//! # use cot::cache::store::file::{FileStore, FileStorePoolConfig};
+//! # use cot::cache::store::CacheStore;
+//! # use cot::config::Timeout;
+//! # use std::path::PathBuf;
+//! # #[tokio::main]
+//! # async fn main() {
+//!
+//! let path = PathBuf::from("./cache_data");
+//! let store = FileStore::new(path, FileStorePoolConfig::builder()
+//!     .worker_count(8)
+//!     .queue_size(128)
+//!     .acquisition_timeout_ms(2000)
+//!     .build()
+//! )
+//! .expect("Failed to initialize store");
+//!
+//! let key = "example_key".to_string();
+//! let value = serde_json::json!({"data": "example_value"});
+//!
+//! store.insert(key.clone(), value.clone(), Timeout::default()).await.unwrap();
+//!
+//! let retrieved = store.get(&key).await.unwrap();
+//! assert_eq!(retrieved, Some(value));
+//! # }
+//! ```
+//!
+//! # Expiration Policy
+//!
+//! Cache files are evicted on `contains_key` and `get`.
+//! No background collector is implemented.
+//!
+//! # Cache File Format
+//!
+//! The cache file consists of a timestamp header, which
+//! currently is as long as the byte representation of
+//! `DateTime`, an i64 integer.
+//!
+//! | Section       | Start-Index | End-Index | Size           |
+//! |---------------|-------------|-----------|----------------|
+//! | Expiry header | 0           | 7         | i64 (8 bytes)  |
+//! | Cache data    | 8           | EOF       | length of data |
+use std::borrow::Cow;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use blake3::hash;
+use chrono::{DateTime, Utc};
+use cot_core::error::impl_into_cot_error;
+use fs4::tokio::AsyncFileExt;
+use serde_json::Value;
+use thiserror::Error;
+use tokio::fs::OpenOptions;
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, SeekFrom};
+use tokio::task::spawn_blocking;
+
+use crate::cache::store::{CacheStore, CacheStoreError, CacheStoreResult};
+use crate::config::Timeout;
+
+const ERROR_PREFIX: &str = "file-based cache store error:";
+const TEMPFILE_SUFFIX: &str = "tmp";
+
+// Custom error messages for implementation related
+// failure modes
+const PERMISSION_ERROR_OR_BUSY: &str = "file-system busy or permission error";
+const POOL_QUEUE_FULL: &str = "file-store pool queue full";
+const POOL_BUSY: &str = "file-store pool busy";
+// Use this for cases that should not happen under normal
+// operating conditions, e.g., runtime quirks.
+const UNEXPECTED_ERROR: &str = "unexpected error";
+
+// This is a retry limit for edge-cases where a file has been
+// created but failed to be locked immediately, where such case
+// happens multiple times.
+const INTERNAL_MAX_RETRIES: i32 = 5;
+
+// The timeout is set to 2000ms to allow the queue to drain efficiently
+// while giving requests a reasonable window to acquire a file lock.
+
+// This header offset skips exactly one i64 integer,
+// which is the basis of our current expiry timestamp
+const EXPIRY_HEADER_OFFSET: usize = size_of::<i64>();
+
+/// Errors specific to the file based cache store.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum FileCacheStoreError {
+    /// An error occured during directory creation
+    #[error("{ERROR_PREFIX} directory creation error: {0}")]
+    DirCreation(Box<dyn std::error::Error + Send + Sync>),
+
+    /// An error occured during temp file creation
+    #[error("{ERROR_PREFIX} temporary file creation error: {0}")]
+    TempFileCreation(Box<dyn std::error::Error + Send + Sync>),
+
+    /// An error occured during write/stream file
+    #[error("{ERROR_PREFIX} I/O error: {0}")]
+    Io(Box<dyn std::error::Error + Send + Sync>),
+
+    /// An error occured during data serialization
+    #[error("{ERROR_PREFIX} serialization error: {0}")]
+    Serialize(Box<dyn std::error::Error + Send + Sync>),
+
+    /// An error occured during data deserialization
+    #[error("{ERROR_PREFIX} deserialization error: {0}")]
+    Deserialize(Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl_into_cot_error!(FileCacheStoreError);
+
+impl From<FileCacheStoreError> for CacheStoreError {
+    fn from(err: FileCacheStoreError) -> Self {
+        let full = err.to_string();
+
+        match err {
+            FileCacheStoreError::Serialize(_) => CacheStoreError::Serialize(full),
+            FileCacheStoreError::Deserialize(_) => CacheStoreError::Deserialize(full),
+            _ => CacheStoreError::Backend(full),
+        }
+    }
+}
+
+struct FileAcquisitionWork {
+    path: PathBuf,
+    file_handle_sender: tokio::sync::oneshot::Sender<Result<tokio::fs::File, FileCacheStoreError>>,
+}
+
+struct FileStorePool {
+    permits: Arc<tokio::sync::Semaphore>,
+    work_receiver: tokio::sync::mpsc::Receiver<FileAcquisitionWork>,
+    acquisiton_timeout_duration: tokio::time::Duration,
+}
+
+/// Config builder for `FileStorePoolConfig`
+///
+/// This provides the config required to instantiate
+/// a `FileStore` instance.
+///
+/// The `new()` method will provide default values for  `FileStorePoolConfig`
+///
+/// #  Examples
+/// ```no_run
+/// use std::path::PathBuf;
+///
+/// use crate::cot::cache::store::file::{FileStore, FileStorePoolConfig};
+///
+/// let store_path = PathBuf::from("./cache");
+///
+/// // Using default values
+/// let default_config = FileStorePoolConfig::builder().build();
+///
+/// assert_eq!(default_config.worker_count(), 10);
+/// assert_eq!(default_config.queue_size(), 128);
+/// assert_eq!(default_config.acquisition_timeout_ms(), 2000);
+/// let store_default = FileStore::new(store_path.clone(), default_config).unwrap();
+///
+/// // Specifying values
+/// let specified_config = FileStorePoolConfig::builder()
+///     .worker_count(4)
+///     .queue_size(100)
+///     .acquisition_timeout_ms(1000)
+///     .build();
+///
+/// assert_eq!(specified_config.worker_count(), 4);
+/// assert_eq!(specified_config.queue_size(), 100);
+/// assert_eq!(specified_config.acquisition_timeout_ms(), 1000);
+/// let store_custom = FileStore::new(store_path, specified_config).unwrap();
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FileStorePoolConfigBuilder {
+    file_store_pool_config: FileStorePoolConfig,
+}
+
+impl FileStorePoolConfigBuilder {
+    /// Sets the maximum number of concurrent blocking tasks permitted for file
+    /// lock acquisition.
+    ///
+    /// When a blocking task is spawned to acquire a file lock, it may remain
+    /// occupied until the underlying operating system returns control to
+    /// the application. If the filesystem becomes unresponsive, these tasks
+    /// will remain allocated and unavailable for further requests until the
+    /// kernel-level operation completes or fails.
+    ///
+    /// Setting this value to `0` opts out of spawning background tasks for
+    /// contested file locks. In this configuration, it is recommended to
+    /// also set `queue_size` to `0` to ensure that requests requiring a
+    /// lock fail immediately rather than entering a pending state that
+    /// cannot be serviced.
+    ///
+    /// If the maximum worker count has been reached and the associated request
+    /// queue is full, any incoming request that requires file locking will
+    /// return an error immediately to prevent further resource contention.
+    #[must_use]
+    pub fn worker_count(mut self, worker_count: usize) -> Self {
+        self.file_store_pool_config.worker_count = worker_count;
+        self
+    }
+    /// Sets the maximum number of waiting insertions allowed in the queue.
+    ///
+    /// Incoming requests that require file locking will return an
+    /// error immediately if this queue is full.
+    #[must_use]
+    pub fn queue_size(mut self, queue_size: usize) -> Self {
+        self.file_store_pool_config.queue_size = queue_size;
+        self
+    }
+    /// Sets the  maximum duration (in milliseconds) to wait for lock
+    /// acquisition.
+    ///
+    /// This does not include time spent waiting in the queue or
+    /// the duration of I/O operations once the lock is acquired.
+    #[must_use]
+    pub fn acquisition_timeout_ms(mut self, acquisition_timeout_ms: u64) -> Self {
+        self.file_store_pool_config.acquisition_timeout_ms = acquisition_timeout_ms;
+        self
+    }
+    /// Consumes this struct and builds the `FileStorePoolConfig`
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if a value > `usize::MAX >> 3`
+    /// was provided in the `worker_count()` and `queue_size()` setters.
+    #[must_use]
+    pub fn build(self) -> FileStorePoolConfig {
+        assert!(
+            self.file_store_pool_config.worker_count <= usize::MAX >> 3,
+            "the provided `worker_count` must not be bigger than usize::MAX >> 3"
+        );
+        assert!(
+            self.file_store_pool_config.queue_size <= usize::MAX >> 3,
+            "the provided `queue_size` must not be bigger than usize::MAX >> 3"
+        );
+
+        self.file_store_pool_config
+    }
+}
+/// Configuration for a file-backed cache store implementation.
+///
+/// This determines the concurrency limits and timeout behavior for
+/// handling cache insertions that encounter file contention.
+///
+/// This configuration can be initialized using `FileStorePoolConfig::default()`
+/// to use the default values.
+///
+/// Alternatively, the `FileStorePoolConfigBuilder` can be used
+/// to provide custom properties.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FileStorePoolConfig {
+    worker_count: usize,
+    queue_size: usize,
+    acquisition_timeout_ms: u64,
+}
+
+impl FileStorePoolConfig {
+    /// Instantiate the `FileStorePoolConfigBuilder` object
+    ///
+    /// This will provide the inner `FileStorePoolConfig` with its
+    /// default values.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// use crate::cot::cache::store::file::{FileStore, FileStorePoolConfig};
+    ///
+    /// let default_config = FileStorePoolConfig::default();
+    /// let default_config_from_builder = FileStorePoolConfig::builder().build();
+    ///
+    /// assert_eq!(default_config, default_config_from_builder);
+    /// assert_eq!(default_config.worker_count(), 10);
+    /// assert_eq!(default_config.queue_size(), 128);
+    /// assert_eq!(default_config.acquisition_timeout_ms(), 2000);
+    /// ```
+    #[must_use]
+    pub fn builder() -> FileStorePoolConfigBuilder {
+        FileStorePoolConfigBuilder::default()
+    }
+    /// Returns the maximum number of concurrent blocking tasks permitted
+    /// for file lock acquisition.
+    #[must_use]
+    pub fn worker_count(&self) -> usize {
+        self.worker_count
+    }
+    /// Returns the maximum number of requests allowed to wait in the
+    /// queue.
+    #[must_use]
+    pub fn queue_size(&self) -> usize {
+        self.queue_size
+    }
+    /// Returns the maximum duration (in milliseconds) a task will wait
+    /// to acquire a file lock.
+    ///
+    /// This represents the timeout for the lock acquisition itself and
+    /// excludes queue wait time and subsequent I/O duration.
+    #[must_use]
+    pub fn acquisition_timeout_ms(&self) -> u64 {
+        self.acquisition_timeout_ms
+    }
+}
+
+impl Default for FileStorePoolConfig {
+    fn default() -> Self {
+        Self {
+            worker_count: crate::config::DEFAULT_FILE_STORE_WORKER_COUNT,
+            queue_size: crate::config::DEFAULT_FILE_STORE_QUEUE_SIZE,
+            acquisition_timeout_ms: crate::config::DEFAULT_FILE_STORE_ACQUISITION_TIMEOUT_MS,
+        }
+    }
+}
+
+impl FileStorePool {
+    fn new(config: FileStorePoolConfig) -> (Self, tokio::sync::mpsc::Sender<FileAcquisitionWork>) {
+        let (tx, rx) = tokio::sync::mpsc::channel(config.queue_size);
+        let semaphore = tokio::sync::Semaphore::new(config.worker_count);
+        (
+            Self {
+                acquisiton_timeout_duration: tokio::time::Duration::from_millis(
+                    config.acquisition_timeout_ms,
+                ),
+                permits: Arc::new(semaphore),
+                work_receiver: rx,
+            },
+            tx,
+        )
+    }
+
+    async fn run(&mut self) {
+        while let Some(data) = self.work_receiver.recv().await {
+            let permits = self.permits.clone();
+            let tx = data.file_handle_sender;
+
+            let acquire_permit_result = tokio::select! {
+                r = permits.acquire_owned() => Ok(r),
+                _r = tokio::time::sleep(self.acquisiton_timeout_duration) => Err(FileCacheStoreError::TempFileCreation(POOL_BUSY.into())),
+            };
+
+            match acquire_permit_result {
+                Ok(Ok(acquired_permit)) => {
+                    let cloned_temp_path = data.path.clone();
+
+                    // We spawn the task here since
+                    // 1. We don't want to spawn tasks just to wait on semaphore
+                    // 2. We don't want the spawn_blocking await to block
+                    // the main loop
+                    tokio::spawn(async move {
+                        if let Ok(file_acquisition_result) = spawn_blocking(move || {
+                            let file_handle = std::fs::OpenOptions::new()
+                                .write(true)
+                                .read(true)
+                                .create(true)
+                                .truncate(false)
+                                .open(cloned_temp_path)
+                                .map_err(|e| FileCacheStoreError::TempFileCreation(Box::new(e)))?;
+
+                            file_handle
+                                .lock()
+                                .map_err(|e| FileCacheStoreError::TempFileCreation(Box::new(e)))?;
+
+                            file_handle
+                                .set_len(0)
+                                .map_err(|e| FileCacheStoreError::TempFileCreation(Box::new(e)))?;
+
+                            drop(acquired_permit);
+                            Ok(tokio::fs::File::from_std(file_handle))
+                        })
+                        .await
+                        {
+                            // No-op on error because we can't really notify the consumers if the
+                            // request was aborted.
+
+                            let _ = tx.send(file_acquisition_result);
+                        } else {
+                            let _ = tx.send(Err(FileCacheStoreError::TempFileCreation(
+                                UNEXPECTED_ERROR.into(),
+                            )));
+                        }
+                    });
+                }
+                Ok(Err(_)) => {
+                    // This should not trigger under normal condition
+                    let _ = tx.send(Err(FileCacheStoreError::TempFileCreation(
+                        UNEXPECTED_ERROR.into(),
+                    )));
+                }
+                Err(e) => {
+                    let _ = tx.send(Err(e));
+                }
+            }
+        }
+    }
+}
+
+/// A file-backed cache store implementation.
+///
+/// This store uses the local file system for caching.
+///
+/// # Examples
+/// ```no_run
+/// use std::path::Path;
+///
+/// use cot::cache::store::file::{FileStore, FileStorePoolConfig};
+///
+/// let store = FileStore::new(
+///     Path::new("./cache_dir"),
+///     FileStorePoolConfig::builder()
+///         .worker_count(10)
+///         .queue_size(128)
+///         .acquisition_timeout_ms(2000)
+///         .build(),
+/// )
+/// .unwrap();
+/// ```
+#[derive(Debug, Clone)]
+pub struct FileStore {
+    dir_path: Cow<'static, Path>,
+    file_path_sender: tokio::sync::mpsc::Sender<FileAcquisitionWork>,
+}
+
+impl FileStore {
+    /// Creates a new `FileStore` at the specified directory.
+    ///
+    /// This will attempt to create the directory and its parents if they do not
+    /// exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FileCacheStoreError::DirCreation`] if the directory cannot be
+    /// created due to permissions or other I/O issues.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::path::PathBuf;
+    ///
+    /// use cot::cache::store::file::{FileStore, FileStorePoolConfig};
+    ///
+    /// // Using a string slice
+    /// let path = PathBuf::from("./cache");
+    /// let store = FileStore::new(
+    ///     path,
+    ///     FileStorePoolConfig::builder()
+    ///         .worker_count(10)
+    ///         .queue_size(128)
+    ///         .acquisition_timeout_ms(2000)
+    ///         .build(),
+    /// )
+    /// .unwrap();
+    ///
+    /// // Using a PathBuf
+    /// let path = PathBuf::from("/var/lib/myapp/cache");
+    /// let store = FileStore::new(path, FileStorePoolConfig::builder().build()).unwrap();
+    /// ```
+    pub fn new(
+        dir: impl Into<Cow<'static, Path>>,
+        config: FileStorePoolConfig,
+    ) -> CacheStoreResult<Self> {
+        let dir_path = dir.into();
+
+        let (mut pool, tx) = FileStorePool::new(config);
+        let store = Self {
+            dir_path,
+            file_path_sender: tx,
+        };
+
+        store.create_dir_root_sync()?;
+        tokio::spawn(async move {
+            pool.run().await;
+        });
+
+        Ok(store)
+    }
+
+    fn create_dir_root_sync(&self) -> CacheStoreResult<()> {
+        std::fs::create_dir_all(&self.dir_path)
+            .map_err(|e| FileCacheStoreError::DirCreation(Box::new(e)))?;
+
+        // When a crash happens mid-flight, we'll may have some .tmp files
+        // This ensures that we have no .tmp files lingering around on startup
+        if let Ok(entries) = std::fs::read_dir(&self.dir_path) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+
+                if path.extension().is_some_and(|ext| ext == TEMPFILE_SUFFIX)
+                    && let Ok(file) = std::fs::OpenOptions::new()
+                        .write(true)
+                        .create(true)
+                        .truncate(false)
+                        .open(&path)
+                    && file.try_lock().is_ok()
+                {
+                    let _ = std::fs::remove_file(path);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn create_dir_root(&self) -> CacheStoreResult<()> {
+        tokio::fs::create_dir_all(&self.dir_path)
+            .await
+            .map_err(|e| FileCacheStoreError::DirCreation(Box::new(e)))?;
+
+        Ok(())
+    }
+
+    async fn write(&self, key: String, value: Value, expiry: Timeout) -> CacheStoreResult<()> {
+        let key_hash = FileStore::create_key_hash(&key);
+        let (mut file, file_path) = self.create_file_temp(&key_hash).await?;
+
+        self.serialize_data(value, expiry, &mut file, &file_path)
+            .await?;
+
+        // Here's the flow:
+        // We sync the data after writing to it. This ensures that we get the correctly
+        // written data even if the later ops fail. We unlock first to let
+        // progress move. This is free when there are no concurrent accessor. If we
+        // rename then unlock, the final file gets locked instead when subsequent
+        // readers progress, defeating the purpose of this method. We create a
+        // new file handle to see whether the file still exists or not. If it doesn't
+        // exist, we move on. It's most likely has been deleted by
+        // `create_dir_root_sync` or `clear`. Finally, we rename only if the
+        // thread reasonably hold the "last" lock to the .tmp. This doesn't
+        // guarantee that no .tmp file will be renamed by another thread, but it pushes
+        // the guarantees towards "writers write and hold in .tmp file, not contesting
+        // the final file"
+        file.sync_data()
+            .await
+            .map_err(|e| FileCacheStoreError::Io(Box::new(e)))?;
+
+        file.unlock_async()
+            .await
+            .map_err(|e| FileCacheStoreError::Io(Box::new(e)))?;
+
+        // The return `Ok(())`on these two methods
+        // are to anticipate the "unlocked file" window mentioned in
+        // `create_file_temp()`.
+
+        let new_file_handle = match OpenOptions::new().read(true).open(&file_path).await {
+            Ok(handle) => handle,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => return Err(FileCacheStoreError::Io(Box::new(e)))?,
+        };
+
+        if new_file_handle.try_lock_shared().is_ok_and(|lock| lock)
+            && let Err(e) = tokio::fs::rename(&file_path, self.dir_path.join(&key_hash)).await
+        {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                return Ok(());
+            }
+
+            return Err(FileCacheStoreError::Io(Box::new(e)))?;
+        }
+
+        Ok(())
+    }
+
+    async fn read(&self, key: &str) -> CacheStoreResult<Option<Value>> {
+        let Some((mut file, file_path)) = self.open_file_for_reading(key).await? else {
+            return Ok(None);
+        };
+
+        self.deserialize_data(&mut file, &file_path).await
+    }
+
+    fn create_key_hash(key: &str) -> String {
+        let key_hash_hex = hash(key.as_bytes());
+        format!("{key_hash_hex}")
+    }
+
+    async fn serialize_data(
+        &self,
+        value: Value,
+        expiry: Timeout,
+        file: &mut tokio::fs::File,
+        file_path: &Path,
+    ) -> CacheStoreResult<()> {
+        let result = async {
+            let timeout = expiry.canonicalize();
+            let seconds: i64 = match timeout {
+                Timeout::Never => i64::MAX,
+                Timeout::AtDateTime(date_time) => date_time.timestamp(),
+                Timeout::After(_) => unreachable!("should've been converted by canonicalize"),
+            };
+
+            let data = serde_json::to_vec(&value)
+                .map_err(|e| FileCacheStoreError::Serialize(Box::new(e)))?;
+
+            file.write_all(&seconds.to_le_bytes())
+                .await
+                .map_err(|e| FileCacheStoreError::Io(Box::new(e)))?;
+
+            file.write_all(&data)
+                .await
+                .map_err(|e| FileCacheStoreError::Io(Box::new(e)))?;
+
+            Ok(())
+        }
+        .await;
+
+        if result.is_err() {
+            let _ = tokio::fs::remove_file(file_path).await;
+        }
+
+        result
+    }
+
+    // Check expiry also removes the file
+    // when expired. This makes the read
+    // process more efficient with less
+    // error propagation
+    async fn check_expiry(
+        &self,
+        file: &mut tokio::fs::File,
+        file_path: &Path,
+    ) -> CacheStoreResult<bool> {
+        let mut header: [u8; EXPIRY_HEADER_OFFSET] = [0; EXPIRY_HEADER_OFFSET];
+
+        let _ = file
+            .read_exact(&mut header)
+            .await
+            .map_err(|e| FileCacheStoreError::Deserialize(Box::new(e)))?;
+        let seconds = i64::from_le_bytes(header);
+        // This may look inefficient, but this ensures portability
+        // By making this method reset its own cursor,
+        // the logic is reusable without the risk of forgetting to reset cursor
+        file.seek(SeekFrom::Start(0))
+            .await
+            .map_err(|e| FileCacheStoreError::Io(Box::new(e)))?;
+
+        let expiry = if seconds == i64::MAX {
+            Timeout::Never
+        } else {
+            let date_time = DateTime::from_timestamp(seconds, 0)
+                .ok_or_else(|| FileCacheStoreError::Deserialize("date time corrupted".into()))?
+                .with_timezone(&Utc)
+                .fixed_offset();
+            Timeout::AtDateTime(date_time)
+        };
+
+        if expiry.is_expired(None) {
+            tokio::fs::remove_file(file_path)
+                .await
+                .map_err(|e| FileCacheStoreError::Io(Box::new(e)))?;
+            return Ok(false);
+        }
+
+        Ok(true)
+    }
+
+    async fn deserialize_data(
+        &self,
+        file: &mut tokio::fs::File,
+        file_path: &Path,
+    ) -> CacheStoreResult<Option<Value>> {
+        if !self.check_expiry(file, file_path).await? {
+            return Ok(None);
+        }
+
+        let mut buffer = Vec::new();
+
+        // Advances cursor by the expiry header offset
+        // EXPIRY_HEADER_OFFSET is a usize that stores
+        // the size of i64. It is unlikely that this will
+        // overflow.
+        // This direct cast currently works without any other
+        // wrapping addition or fallback conversion
+        file.seek(SeekFrom::Start(EXPIRY_HEADER_OFFSET as u64))
+            .await
+            .map_err(|e| FileCacheStoreError::Io(Box::new(e)))?;
+        file.read_to_end(&mut buffer)
+            .await
+            .map_err(|e| FileCacheStoreError::Io(Box::new(e)))?;
+
+        let value: Value = serde_json::from_slice(&buffer)
+            .map_err(|e| FileCacheStoreError::Deserialize(Box::new(e)))?;
+
+        Ok(Some(value))
+    }
+
+    async fn create_file_temp(
+        &self,
+        key_hash: &str,
+    ) -> CacheStoreResult<(tokio::fs::File, PathBuf)> {
+        let temp_path = self.dir_path.join(format!("{key_hash}.{TEMPFILE_SUFFIX}"));
+
+        // We must let the loop to propagate upwards to catch sudden
+        // missing cache directory.
+        //
+        // Then, it would be easier for us to wait for file creation
+        // where we offload one lock check into the OS by using `create_new()`
+        //
+        // Therefore, the flow looks like this,
+        // 1. `create_new()` -> fail, we check if the error is AlreadyExists.
+        // 2. In a condition where (1) is triggered, we park the task into a
+        // blocking thread managed by `FileStorePool`. The request waits on the
+        // result using a oneshot channel for at most `acquisition_timeout_ms`
+        // + I/O processing duration.
+        // 3. The blocking thread will only wait for the existing file in
+        // the temp_path
+        //
+        // This approach was chosen because we can't possibly (at least for now)
+        // to create a file AND lock that file atomically.
+        //
+        // A window where the existing file may get renamed or deleted
+        // is expected.
+        //
+        // Therefore, the blocking task is a pessimistic write.
+
+        let mut retry_count = 0;
+        let temp_file = loop {
+            match OpenOptions::new()
+                .write(true)
+                .read(true)
+                .create_new(true)
+                .truncate(true)
+                .open(&temp_path)
+                .await
+            {
+                Ok(handle) => {
+                    if let Ok(lock_acquired) = handle.try_lock_exclusive()
+                        && lock_acquired
+                    {
+                        break handle;
+                    }
+
+                    // We try again when we can't lock maybe due to external processes.
+                    // However, if failure keeps happening here, we must abort.
+                    retry_count += 1;
+                    if retry_count > INTERNAL_MAX_RETRIES {
+                        return Err(FileCacheStoreError::TempFileCreation(
+                            PERMISSION_ERROR_OR_BUSY.into(),
+                        ))?;
+                    }
+                    continue;
+                }
+                // Trigger to enter the task handoff
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    let cloned_temp_path = temp_path.clone();
+                    let (tx, rx) = tokio::sync::oneshot::channel();
+                    match self.file_path_sender.try_send(FileAcquisitionWork {
+                        path: cloned_temp_path,
+                        file_handle_sender: tx,
+                    }) {
+                        Ok(()) => {
+                            let Ok(new_temp_file) = rx.await else {
+                                // This shouldn't happen because the rx is created here
+                                return Err(FileCacheStoreError::TempFileCreation(
+                                    POOL_BUSY.into(),
+                                ))?;
+                            };
+                            break new_temp_file?;
+                        }
+                        Err(_) => {
+                            return Err(FileCacheStoreError::TempFileCreation(
+                                POOL_QUEUE_FULL.into(),
+                            ))?;
+                        }
+                    }
+                }
+                // Trigger to create the new directory
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => self
+                    .create_dir_root()
+                    .await
+                    .map_err(|e| FileCacheStoreError::DirCreation(Box::new(e)))?,
+                Err(e) => {
+                    return Err(FileCacheStoreError::TempFileCreation(Box::new(e)))?;
+                }
+            }
+        };
+
+        Ok((temp_file, temp_path))
+    }
+
+    async fn open_file_for_reading(
+        &self,
+        key: &str,
+    ) -> CacheStoreResult<Option<(tokio::fs::File, PathBuf)>> {
+        let key_hash = FileStore::create_key_hash(key);
+        let path = self.dir_path.join(&key_hash);
+        match OpenOptions::new().read(true).open(&path).await {
+            Ok(f) => Ok(Some((f, path))),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(FileCacheStoreError::Io(Box::new(e)).into()),
+        }
+    }
+}
+
+impl CacheStore for FileStore {
+    async fn get(&self, key: &str) -> CacheStoreResult<Option<Value>> {
+        match self.read(key).await? {
+            Some(value) => Ok(Some(value)),
+            None => Ok(None),
+        }
+    }
+
+    async fn insert(&self, key: String, value: Value, expiry: Timeout) -> CacheStoreResult<()> {
+        self.write(key, value, expiry).await?;
+        Ok(())
+    }
+
+    async fn remove(&self, key: &str) -> CacheStoreResult<()> {
+        if let Some((_file, file_path)) = self.open_file_for_reading(key).await? {
+            tokio::fs::remove_file(file_path)
+                .await
+                .map_err(|e| FileCacheStoreError::Io(Box::new(e)))?;
+        }
+
+        Ok(())
+    }
+
+    async fn clear(&self) -> CacheStoreResult<()> {
+        // First, try to remove the whole thing.
+        // If failure happens, we fallback to iterative removal
+        if tokio::fs::remove_dir_all(&self.dir_path).await.is_ok() {
+            tokio::fs::create_dir_all(&self.dir_path)
+                .await
+                .map_err(|e| FileCacheStoreError::DirCreation(Box::new(e)))?;
+            return Ok(());
+        }
+
+        if let Ok(entries) = std::fs::read_dir(&self.dir_path) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if let Ok(file) = std::fs::OpenOptions::new()
+                    .write(true)
+                    .truncate(false)
+                    .open(&path)
+                    && file.try_lock().is_ok()
+                {
+                    let _ = std::fs::remove_file(&path);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn approx_size(&self) -> CacheStoreResult<usize> {
+        let mut entries = match tokio::fs::read_dir(&self.dir_path).await {
+            Ok(e) => e,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+            Err(e) => return Err(FileCacheStoreError::Io(Box::new(e)).into()),
+        };
+
+        let mut total_size: usize = 0;
+
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let path = entry.path();
+            let is_temp = path.extension().is_some_and(|ext| ext == TEMPFILE_SUFFIX);
+
+            if let Ok(meta) = entry.metadata().await
+                && meta.is_file()
+                && !is_temp
+            {
+                total_size += 1;
+            }
+        }
+
+        Ok(total_size)
+    }
+
+    async fn contains_key(&self, key: &str) -> CacheStoreResult<bool> {
+        let Ok(Some((mut file, file_path))) = self.open_file_for_reading(key).await else {
+            return Ok(false);
+        };
+
+        // Cache eviction on contains_key() based on TTL
+        self.check_expiry(&mut file, &file_path).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use chrono::Utc;
+    use tempfile::tempdir;
+
+    use crate::cache::store::file::{
+        FileCacheStoreError, FileStore, FileStorePoolConfig, POOL_BUSY, POOL_QUEUE_FULL,
+    };
+    use crate::cache::store::{CacheStore, CacheStoreError};
+    use crate::config::Timeout;
+
+    fn make_store_path() -> std::path::PathBuf {
+        tempdir().expect("failed to create dir").keep()
+    }
+
+    #[cot::test]
+    async fn test_create_dir() {
+        let path = make_store_path();
+        let _ = FileStore::new(path.clone(), FileStorePoolConfig::default())
+            .expect("failed to init store");
+
+        assert!(path.exists());
+        assert!(path.is_dir());
+
+        tokio::fs::remove_dir_all(path)
+            .await
+            .expect("failed to cleanup tempdir");
+    }
+
+    #[cot::test]
+    async fn test_create_dir_on_existing() {
+        let path = make_store_path();
+        let _ = FileStore::new(path.clone(), FileStorePoolConfig::default())
+            .expect("failed to init store");
+        let _ = FileStore::new(path.clone(), FileStorePoolConfig::default())
+            .expect("failed to init second store");
+
+        assert!(path.exists());
+        assert!(path.is_dir());
+
+        tokio::fs::remove_dir_all(path)
+            .await
+            .expect("failed to cleanup tempdir");
+    }
+
+    #[cot::test]
+    async fn test_insert_and_read_single() {
+        let path = make_store_path();
+
+        let store = FileStore::new(path.clone(), FileStorePoolConfig::default())
+            .expect("failed to init store");
+        let key = "test_key".to_string();
+        let value = serde_json::json!({ "id": 1, "message": "hello world" });
+
+        store
+            .insert(key.clone(), value.clone(), Timeout::Never)
+            .await
+            .expect("failed to insert data to store");
+
+        let retrieved = store.read(&key).await.expect("failed to read from store");
+
+        assert!(retrieved.is_some(), "retrieved value should not be None");
+        assert_eq!(
+            retrieved.unwrap(),
+            value,
+            "retrieved value does not match inserted value"
+        );
+
+        let _ = tokio::fs::remove_dir_all(&path).await;
+    }
+
+    #[cot::test]
+    async fn test_insert_and_read_after_delete_single() {
+        let path = make_store_path();
+
+        let store = FileStore::new(path.clone(), FileStorePoolConfig::default())
+            .expect("failed to init store");
+        let key = "test_key".to_string();
+        let value = serde_json::json!({ "id": 1, "message": "hello world" });
+
+        store
+            .insert(key.clone(), value.clone(), Timeout::Never)
+            .await
+            .expect("failed to insert data to store");
+
+        store.remove(&key).await.expect("failed to delete entry");
+
+        let retrieved = store.read(&key).await.expect("failed to read from store");
+        assert!(retrieved.is_none(), "retrieved value should not be Some");
+
+        let _ = tokio::fs::remove_dir_all(&path).await;
+    }
+
+    #[cot::test]
+    async fn test_clear_double_free() {
+        let path = make_store_path();
+
+        let store = FileStore::new(path.clone(), FileStorePoolConfig::default())
+            .expect("failed to init store");
+        let key = "test_key".to_string();
+        let value = serde_json::json!({ "id": 1, "message": "hello world" });
+
+        store
+            .insert(key.clone(), value.clone(), Timeout::Never)
+            .await
+            .expect("failed to insert data to store");
+
+        store.clear().await.expect("failed to clear");
+        store
+            .clear()
+            .await
+            .expect("failed to clear the second time");
+
+        let retrieved = store.read(&key).await.expect("failed to read from store");
+
+        assert!(path.is_dir(), "path must be dir");
+        assert!(retrieved.is_none(), "retrieved value should not be Some");
+
+        let _ = tokio::fs::remove_dir_all(&path).await;
+    }
+
+    #[cot::test]
+    async fn test_approx_size() {
+        let path = make_store_path();
+
+        let store = FileStore::new(path.clone(), FileStorePoolConfig::default())
+            .expect("failed to init store");
+        let key = "test_key".to_string();
+        let key_2 = "test_key_2".to_string();
+
+        let value = serde_json::json!({ "id": 1, "message": "hello world" });
+
+        store
+            .insert(key.clone(), value.clone(), Timeout::Never)
+            .await
+            .expect("failed to insert data to store");
+        store
+            .insert(key.clone(), value.clone(), Timeout::Never)
+            .await
+            .expect("failed to insert data to store");
+        store
+            .insert(key_2.clone(), value.clone(), Timeout::Never)
+            .await
+            .expect("failed to insert data to store");
+
+        let data_length: usize = 2;
+
+        let entry_length = store
+            .approx_size()
+            .await
+            .expect("failed to get approx file");
+
+        assert_eq!(data_length, entry_length);
+
+        let _ = tokio::fs::remove_dir_all(&path).await;
+    }
+
+    #[cot::test]
+    async fn test_contains_key() {
+        let path = make_store_path();
+
+        let store = FileStore::new(path.clone(), FileStorePoolConfig::default())
+            .expect("failed to init store");
+        let key = "test_key".to_string();
+        let value = serde_json::json!({ "id": 1, "message": "hello world" });
+
+        store
+            .insert(key.clone(), value.clone(), Timeout::Never)
+            .await
+            .expect("failed to insert data to store");
+
+        let exist = store
+            .contains_key(&key)
+            .await
+            .expect("failed to check key existence");
+
+        assert!(exist);
+
+        let _ = tokio::fs::remove_dir_all(&path).await;
+    }
+
+    #[cot::test]
+    async fn test_expiration_integrity() {
+        let path = make_store_path();
+
+        let store = FileStore::new(path.clone(), FileStorePoolConfig::default())
+            .expect("failed to init store");
+        let key = "test_key".to_string();
+        let value = serde_json::json!({ "id": 1, "message": "hello world" });
+
+        let past = Utc::now() - Duration::from_secs(1);
+        let past_fixed = past.fixed_offset();
+        let expiry = Timeout::AtDateTime(past_fixed);
+
+        store
+            .insert(key.clone(), value.clone(), expiry)
+            .await
+            .expect("failed to insert data to store");
+
+        // test file is None
+        let retrieved = store.get(&key).await.expect("failed to read from store");
+        assert!(retrieved.is_none());
+
+        // test file doesn't exist
+        let exist = store
+            .contains_key(&key)
+            .await
+            .expect("failed to check key existence");
+        assert!(!exist);
+
+        // test size is 0
+        let size = store.approx_size().await.expect("failed to check size");
+        assert_eq!(size, 0);
+
+        let _ = tokio::fs::remove_dir_all(&path).await;
+    }
+
+    // Ignored in miri since it currently doesn't support
+    // blocking lock operation
+    #[cfg_attr(miri, ignore)]
+    #[cot::test]
+    async fn test_interference_during_write() {
+        let path = make_store_path();
+        let store =
+            FileStore::new(path.clone(), FileStorePoolConfig::default()).expect("failed to init");
+        let key = "test_key".to_string();
+        let value = serde_json::json!({ "id": 1 });
+
+        let handles: Vec<_> = (0..10)
+            .map(|_| {
+                let (s, k, v) = (store.clone(), key.clone(), value.clone());
+                tokio::spawn(async move { s.insert(k, v, Timeout::Never).await })
+            })
+            .collect();
+
+        let _store_2 = FileStore::new(path.clone(), FileStorePoolConfig::default())
+            .expect("failed to init interference");
+
+        for h in handles {
+            h.await.unwrap().expect("insert failed");
+        }
+
+        let res = store.read(&key).await.expect("read failed");
+        assert_eq!(res.unwrap(), value);
+        let _ = tokio::fs::remove_dir_all(&path).await;
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[cot::test]
+    async fn test_clear_during_write() {
+        let path = make_store_path();
+        let store =
+            FileStore::new(path.clone(), FileStorePoolConfig::default()).expect("failed to init");
+        let _ = tokio::fs::remove_dir_all(&path).await;
+
+        let mut handles = Vec::new();
+        for i in 0..10 {
+            let s = store.clone();
+            handles.push(tokio::spawn(async move {
+                if i % 2 == 0 {
+                    let _ = s
+                        .insert("k".into(), serde_json::json!({"i": i}), Timeout::Never)
+                        .await;
+                } else {
+                    let _ = s.clear().await;
+                }
+            }));
+        }
+
+        for h in handles {
+            h.await.unwrap();
+        }
+        let _ = tokio::fs::remove_dir_all(&path).await;
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[cot::test]
+    async fn test_thundering_write() {
+        let path = make_store_path();
+        let store =
+            FileStore::new(path.clone(), FileStorePoolConfig::default()).expect("failed to init");
+        let value = serde_json::json!({ "id": 1 });
+
+        let tasks: Vec<_> = (0..10)
+            .map(|_| {
+                let s = store.clone();
+                let v = value.clone();
+                tokio::spawn(async move { s.insert("key".into(), v, Timeout::Never).await })
+            })
+            .collect();
+
+        for h in tasks {
+            h.await.unwrap().expect("task panicked");
+        }
+
+        let retrieved = store.read("key").await.expect("failed to read from store");
+        assert_eq!(retrieved.unwrap(), value);
+
+        let _ = tokio::fs::remove_dir_all(&path).await;
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[cot::test]
+    async fn test_thundering_write_with_semaphore_congestion() {
+        let path = make_store_path();
+        let store = FileStore::new(
+            path.clone(),
+            FileStorePoolConfig::builder().worker_count(1).build(),
+        )
+        .expect("failed to init");
+        let value = serde_json::json!({ "id": 1 });
+
+        let tasks: Vec<_> = (0..10)
+            .map(|_| {
+                let s = store.clone();
+                let v = value.clone();
+                tokio::spawn(async move { s.insert("key".into(), v, Timeout::Never).await })
+            })
+            .collect();
+
+        for h in tasks {
+            h.await.unwrap().expect("task panicked");
+        }
+
+        let retrieved = store.read("key").await.expect("failed to read from store");
+        assert_eq!(retrieved.unwrap(), value);
+
+        let _ = tokio::fs::remove_dir_all(&path).await;
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[cot::test]
+    async fn test_thundering_write_with_queue_full() {
+        let path = make_store_path();
+        let store = FileStore::new(
+            path.clone(),
+            FileStorePoolConfig::builder().queue_size(1).build(),
+        )
+        .expect("failed to init");
+        let value = serde_json::json!({ "id": 1 });
+
+        let tasks: Vec<_> = (0..10)
+            .map(|_| {
+                let s = store.clone();
+                let v = value.clone();
+                tokio::spawn(async move { s.insert("key".into(), v, Timeout::Never).await })
+            })
+            .collect();
+
+        for h in tasks {
+            if let Ok(result) = h.await {
+                let _ = result.map_err(|e| {
+                    let file_store_error =
+                        FileCacheStoreError::TempFileCreation(POOL_QUEUE_FULL.into());
+                    let cache_store_error: CacheStoreError = file_store_error.into();
+
+                    assert_eq!(e.to_string(), cache_store_error.to_string());
+                });
+            }
+        }
+
+        let retrieved = store.read("key").await.expect("failed to read from store");
+        assert_eq!(retrieved.unwrap(), value);
+
+        let _ = tokio::fs::remove_dir_all(&path).await;
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[cot::test]
+    async fn test_thundering_write_with_timeout_exceeded() {
+        let path = make_store_path();
+        let store = FileStore::new(
+            path.clone(),
+            FileStorePoolConfig::builder()
+                .worker_count(1)
+                .acquisition_timeout_ms(0)
+                .build(),
+        )
+        .expect("failed to init");
+        let value = serde_json::json!({ "id": 1 });
+
+        let tasks: Vec<_> = (0..10)
+            .map(|_| {
+                let s = store.clone();
+                let v = value.clone();
+                tokio::spawn(async move { s.insert("key".into(), v, Timeout::Never).await })
+            })
+            .collect();
+
+        for h in tasks {
+            if let Ok(result) = h.await {
+                let _ = result.map_err(|e| {
+                    let file_store_error = FileCacheStoreError::TempFileCreation(POOL_BUSY.into());
+                    let cache_store_error: CacheStoreError = file_store_error.into();
+
+                    println!("timeout error check triggered");
+
+                    assert_eq!(e.to_string(), cache_store_error.to_string());
+                });
+            }
+        }
+
+        let retrieved = store.read("key").await.expect("failed to read from store");
+        assert_eq!(retrieved.unwrap(), value);
+
+        let _ = tokio::fs::remove_dir_all(&path).await;
+    }
+
+    #[cot::test]
+    async fn test_from_file_cache_store_error_to_cache_store_error() {
+        let file_error = FileCacheStoreError::Io(Box::new(std::io::Error::other("disk failure")));
+        let cache_error: CacheStoreError = file_error.into();
+        assert_eq!(
+            cache_error.to_string(),
+            "cache store error: backend error: file-based cache store error: I/O error: disk failure"
+        );
+
+        let file_error =
+            FileCacheStoreError::Serialize(Box::new(std::io::Error::other("json fail")));
+        let cache_error: CacheStoreError = file_error.into();
+        assert_eq!(
+            cache_error.to_string(),
+            "cache store error: serialization error: file-based cache store error: serialization error: json fail"
+        );
+
+        let file_error =
+            FileCacheStoreError::Deserialize(Box::new(std::io::Error::other("corrupt header")));
+        let cache_error: CacheStoreError = file_error.into();
+        assert_eq!(
+            cache_error.to_string(),
+            "cache store error: deserialization error: file-based cache store error: deserialization error: corrupt header"
+        );
+
+        let file_error =
+            FileCacheStoreError::DirCreation(Box::new(std::io::Error::other("permission denied")));
+        let cache_error: CacheStoreError = file_error.into();
+        assert_eq!(
+            cache_error.to_string(),
+            "cache store error: backend error: file-based cache store error: directory creation error: permission denied"
+        );
+
+        let file_error =
+            FileCacheStoreError::TempFileCreation(Box::new(std::io::Error::other("no space left")));
+        let cache_error: CacheStoreError = file_error.into();
+        assert_eq!(
+            cache_error.to_string(),
+            "cache store error: backend error: file-based cache store error: temporary file creation error: no space left"
+        );
+    }
+}

--- a/cot/src/cache/store/file.rs
+++ b/cot/src/cache/store/file.rs
@@ -248,10 +248,10 @@ impl FileStorePoolConfigBuilder {
     /// # Panics
     ///
     /// This method will panic if
-    /// *  a value > `usize::MAX >> 3`was provided in the `worker_count()` and `queue_size()` setters.
+    /// * a value > `usize::MAX >> 3`was provided in the `worker_count()` and
+    ///   `queue_size()` setters.
     /// * `worker_count` == 0 with  `queue_size`!= 0 and vice-versa.
     /// * `waiting_timeout_ms` < `acquisition_timeout_ms`.
-    ///
     #[must_use]
     pub fn build(self) -> FileStorePoolConfig {
         assert!(

--- a/cot/src/cache/store/file.rs
+++ b/cot/src/cache/store/file.rs
@@ -967,7 +967,6 @@ mod tests {
     use std::time::Duration;
 
     use chrono::Utc;
-    use tempfile::tempdir;
 
     use crate::cache::store::file::{
         FileCacheStoreError, FileStore, FileStorePoolConfig, POOL_BUSY, POOL_QUEUE_FULL,
@@ -977,7 +976,10 @@ mod tests {
     use crate::config::Timeout;
 
     fn make_store_path() -> std::path::PathBuf {
-        tempdir().expect("failed to create dir").keep()
+        let base_env = std::env::temp_dir();
+        let this_runner = std::thread::current().id();
+        let this_test_dir = format!("cache-store-file-unit-test-{this_runner:#?}");
+        base_env.join(this_test_dir)
     }
 
     #[cot::test]

--- a/cot/src/cache/store/file.rs
+++ b/cot/src/cache/store/file.rs
@@ -978,9 +978,11 @@ mod tests {
     fn make_store_path(test_name: &str) -> std::path::PathBuf {
         let base_env = std::env::temp_dir();
         let thread_id = std::thread::current().id();
+        let tid_num = format!("{thread_id:?}").replace(|c: char| !c.is_ascii_digit(), "");
+
         let pid = std::process::id();
 
-        let this_test_dir = format!("cache-store-{test_name}-{pid}-{thread_id:#?}");
+        let this_test_dir = format!("cache-store-{test_name}-{pid}-{tid_num}");
 
         base_env.join(this_test_dir)
     }

--- a/cot/src/cache/store/file.rs
+++ b/cot/src/cache/store/file.rs
@@ -975,16 +975,19 @@ mod tests {
     use crate::cache::store::{CacheStore, CacheStoreError};
     use crate::config::Timeout;
 
-    fn make_store_path() -> std::path::PathBuf {
+    fn make_store_path(test_name: &str) -> std::path::PathBuf {
         let base_env = std::env::temp_dir();
-        let this_runner = std::thread::current().id();
-        let this_test_dir = format!("cache-store-file-unit-test-{this_runner:#?}");
+        let thread_id = std::thread::current().id();
+        let pid = std::process::id();
+
+        let this_test_dir = format!("cache-store-{test_name}-{pid}-{thread_id:#?}");
+
         base_env.join(this_test_dir)
     }
 
     #[cot::test]
     async fn test_create_dir() {
-        let path = make_store_path();
+        let path = make_store_path("test_create_dir");
         let _ = FileStore::new(path.clone(), FileStorePoolConfig::default())
             .expect("failed to init store");
 
@@ -998,7 +1001,7 @@ mod tests {
 
     #[cot::test]
     async fn test_create_dir_on_existing() {
-        let path = make_store_path();
+        let path = make_store_path("test_create_dir_on_existing");
         let _ = FileStore::new(path.clone(), FileStorePoolConfig::default())
             .expect("failed to init store");
         let _ = FileStore::new(path.clone(), FileStorePoolConfig::default())
@@ -1014,7 +1017,7 @@ mod tests {
 
     #[cot::test]
     async fn test_insert_and_read_single() {
-        let path = make_store_path();
+        let path = make_store_path("test_insert_and_read_single");
 
         let store = FileStore::new(path.clone(), FileStorePoolConfig::default())
             .expect("failed to init store");
@@ -1040,7 +1043,7 @@ mod tests {
 
     #[cot::test]
     async fn test_insert_and_read_after_delete_single() {
-        let path = make_store_path();
+        let path = make_store_path("test_insert_and_read_after_delete_single");
 
         let store = FileStore::new(path.clone(), FileStorePoolConfig::default())
             .expect("failed to init store");
@@ -1062,7 +1065,7 @@ mod tests {
 
     #[cot::test]
     async fn test_clear_double_free() {
-        let path = make_store_path();
+        let path = make_store_path("test_clear_double_free");
 
         let store = FileStore::new(path.clone(), FileStorePoolConfig::default())
             .expect("failed to init store");
@@ -1090,7 +1093,7 @@ mod tests {
 
     #[cot::test]
     async fn test_approx_size() {
-        let path = make_store_path();
+        let path = make_store_path("test_approx_size");
 
         let store = FileStore::new(path.clone(), FileStorePoolConfig::default())
             .expect("failed to init store");
@@ -1126,7 +1129,7 @@ mod tests {
 
     #[cot::test]
     async fn test_contains_key() {
-        let path = make_store_path();
+        let path = make_store_path("test_contains_key");
 
         let store = FileStore::new(path.clone(), FileStorePoolConfig::default())
             .expect("failed to init store");
@@ -1150,7 +1153,7 @@ mod tests {
 
     #[cot::test]
     async fn test_expiration_integrity() {
-        let path = make_store_path();
+        let path = make_store_path("test_expiration_integrity");
 
         let store = FileStore::new(path.clone(), FileStorePoolConfig::default())
             .expect("failed to init store");
@@ -1189,7 +1192,8 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     #[cot::test]
     async fn test_interference_during_write() {
-        let path = make_store_path();
+        let path = make_store_path("test_interference_during_write");
+
         let store =
             FileStore::new(path.clone(), FileStorePoolConfig::default()).expect("failed to init");
         let key = "test_key".to_string();
@@ -1217,7 +1221,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     #[cot::test]
     async fn test_clear_during_write() {
-        let path = make_store_path();
+        let path = make_store_path("test_clear_during_write");
         let store =
             FileStore::new(path.clone(), FileStorePoolConfig::default()).expect("failed to init");
         let value = serde_json::json!({ "id": 1 });
@@ -1258,7 +1262,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     #[cot::test]
     async fn test_thundering_write() {
-        let path = make_store_path();
+        let path = make_store_path("test_thundering_write");
         let store =
             FileStore::new(path.clone(), FileStorePoolConfig::default()).expect("failed to init");
         let value = serde_json::json!({ "id": 1 });
@@ -1284,7 +1288,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     #[cot::test]
     async fn test_thundering_write_with_semaphore_congestion() {
-        let path = make_store_path();
+        let path = make_store_path("test_thundering_write_with_semaphore_congestion");
         let store = FileStore::new(
             path.clone(),
             FileStorePoolConfig::builder().worker_count(1).build(),
@@ -1313,7 +1317,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     #[cot::test]
     async fn test_thundering_write_with_queue_full() {
-        let path = make_store_path();
+        let path = make_store_path("test_thundering_write_with_queue_full");
         let store = FileStore::new(
             path.clone(),
             FileStorePoolConfig::builder().queue_size(1).build(),
@@ -1350,7 +1354,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     #[cot::test]
     async fn test_does_not_panic_on_opt_out_queue_empty() {
-        let path = make_store_path();
+        let path = make_store_path("test_does_not_panic_on_opt_out_queue_empty");
         let _store = FileStore::new(
             path.clone(),
             FileStorePoolConfig::builder().queue_size(0).build(),
@@ -1363,7 +1367,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     #[cot::test]
     async fn test_does_not_panic_on_opt_out_worker_count_empty() {
-        let path = make_store_path();
+        let path = make_store_path("test_does_not_panic_on_opt_out_worker_count_empty");
         let _store = FileStore::new(
             path.clone(),
             FileStorePoolConfig::builder().worker_count(0).build(),
@@ -1376,7 +1380,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     #[cot::test]
     async fn test_opt_out_behavior() {
-        let path = make_store_path();
+        let path = make_store_path("test_opt_out_behavior");
         let store = FileStore::new(
             path.clone(),
             FileStorePoolConfig::builder().worker_count(0).build(),
@@ -1423,7 +1427,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     #[cot::test]
     async fn test_thundering_write_with_acquisition_timeout_exceeded() {
-        let path = make_store_path();
+        let path = make_store_path("test_thundering_write_with_acquisition_timeout_exceeded");
         let store = FileStore::new(
             path.clone(),
             FileStorePoolConfig::builder()
@@ -1462,7 +1466,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     #[cot::test]
     async fn test_thundering_write_with_waiting_timeout_exceeded() {
-        let path = make_store_path();
+        let path = make_store_path("test_thundering_write_with_waiting_timeout_exceeded");
         let store = FileStore::new(
             path.clone(),
             FileStorePoolConfig::builder()

--- a/cot/src/cache/store/file.rs
+++ b/cot/src/cache/store/file.rs
@@ -198,15 +198,13 @@ impl FileStorePoolConfigBuilder {
     /// will remain allocated and unavailable for further requests until the
     /// kernel-level operation completes or fails.
     ///
-    /// Setting this value to `0` opts out of spawning background tasks for
-    /// contested file locks. In this configuration, it is recommended to
-    /// also set `queue_size` to `0` to ensure that requests requiring a
-    /// lock fail immediately rather than entering a pending state that
-    /// cannot be serviced.
-    ///
     /// If the maximum worker count has been reached and the associated request
     /// queue is full, any incoming request that requires file locking will
     /// return an error immediately to prevent further resource contention.
+    ///
+    /// Setting this value to `0` opts out of spawning background tasks for
+    /// contested file locks, similar to the behavior for providing `0` to
+    /// `queue_size`.
     #[must_use]
     pub fn worker_count(mut self, worker_count: usize) -> Self {
         self.file_store_pool_config.worker_count = worker_count;
@@ -216,6 +214,10 @@ impl FileStorePoolConfigBuilder {
     ///
     /// Incoming requests that require file locking will return an
     /// error immediately if this queue is full.
+    ///
+    /// Setting this value to `0` opts out of spawning background tasks for
+    /// contested file locks, similar to the behavior for providing `0` to
+    /// `worker_count`.
     #[must_use]
     pub fn queue_size(mut self, queue_size: usize) -> Self {
         self.file_store_pool_config.queue_size = queue_size;
@@ -250,7 +252,6 @@ impl FileStorePoolConfigBuilder {
     /// This method will panic if
     /// * a value > `usize::MAX >> 3`was provided in the `worker_count()` and
     ///   `queue_size()` setters.
-    /// * `worker_count` == 0 with  `queue_size`!= 0 and vice-versa.
     /// * `waiting_timeout_ms` < `acquisition_timeout_ms`.
     #[must_use]
     pub fn build(self) -> FileStorePoolConfig {
@@ -261,11 +262,6 @@ impl FileStorePoolConfigBuilder {
         assert!(
             self.file_store_pool_config.queue_size <= usize::MAX >> 3,
             "the provided `queue_size` must not be bigger than usize::MAX >> 3"
-        );
-        assert!(
-            (self.file_store_pool_config.worker_count == 0)
-                == (self.file_store_pool_config.queue_size == 0),
-            "`queue_size` must be 0 when `worker_count` is 0 and vice versa"
         );
         assert!(
             self.file_store_pool_config.waiting_timeout_ms
@@ -362,8 +358,15 @@ impl Default for FileStorePoolConfig {
 
 impl FileStorePool {
     fn new(config: FileStorePoolConfig) -> (Self, tokio::sync::mpsc::Sender<FileAcquisitionWork>) {
-        let (tx, rx) = tokio::sync::mpsc::channel(config.queue_size);
-        let semaphore = tokio::sync::Semaphore::new(config.worker_count);
+        let (resolve_queue_size, resolve_worker_count) =
+            if config.worker_count == 0 || config.queue_size == 0 {
+                (1, 0)
+            } else {
+                (config.queue_size, config.worker_count)
+            };
+
+        let (tx, rx) = tokio::sync::mpsc::channel(resolve_queue_size);
+        let semaphore = tokio::sync::Semaphore::new(resolve_worker_count);
         (
             Self {
                 acquisiton_timeout_duration: tokio::time::Duration::from_millis(
@@ -522,11 +525,17 @@ impl FileStore {
     ) -> CacheStoreResult<Self> {
         let dir_path = dir.into();
 
+        let resolved_waiting_timeout = if config.worker_count == 0 || config.queue_size == 0 {
+            0
+        } else {
+            config.waiting_timeout_ms
+        };
+
         let (mut pool, tx) = FileStorePool::new(config);
         let store = Self {
             dir_path,
             file_path_sender: tx,
-            waiting_timeout_duration: tokio::time::Duration::from_millis(config.waiting_timeout_ms),
+            waiting_timeout_duration: tokio::time::Duration::from_millis(resolved_waiting_timeout),
         };
 
         store.create_dir_root_sync()?;
@@ -1338,6 +1347,79 @@ mod tests {
 
     #[cfg_attr(miri, ignore)]
     #[cot::test]
+    async fn test_does_not_panic_on_opt_out_queue_empty() {
+        let path = make_store_path();
+        let _store = FileStore::new(
+            path.clone(),
+            FileStorePoolConfig::builder().queue_size(0).build(),
+        )
+        .expect("failed to init");
+
+        let _ = tokio::fs::remove_dir_all(&path).await;
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[cot::test]
+    async fn test_does_not_panic_on_opt_out_worker_count_empty() {
+        let path = make_store_path();
+        let _store = FileStore::new(
+            path.clone(),
+            FileStorePoolConfig::builder().worker_count(0).build(),
+        )
+        .expect("failed to init");
+
+        let _ = tokio::fs::remove_dir_all(&path).await;
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[cot::test]
+    async fn test_opt_out_behavior() {
+        let path = make_store_path();
+        let store = FileStore::new(
+            path.clone(),
+            FileStorePoolConfig::builder().worker_count(0).build(),
+        )
+        .expect("failed to init");
+        let value = serde_json::json!({ "id": 1 });
+
+        let tasks: Vec<_> = (0..10)
+            .map(|_| {
+                let s = store.clone();
+                let v = value.clone();
+                tokio::spawn(async move { s.insert("key".into(), v, Timeout::Never).await })
+            })
+            .collect();
+
+        for h in tasks {
+            if let Ok(result) = h.await {
+                let _ = result.map_err(|e| {
+                    let first_store_error =
+                        FileCacheStoreError::TempFileCreation(POOL_QUEUE_FULL.into());
+                    let then_store_error =
+                        FileCacheStoreError::TempFileCreation(TIMEOUT_REACHED.into());
+
+                    let first_cache_store_error: CacheStoreError = first_store_error.into();
+
+                    let then_cache_store_error: CacheStoreError = then_store_error.into();
+
+                    assert!(
+                        e.to_string() == then_cache_store_error.to_string()
+                            || e.to_string() == first_cache_store_error.to_string()
+                    );
+                });
+            }
+        }
+
+        // When ALL tasks enter handoff, they are subject to the timeout
+        if let Some(retrieved) = store.read("key").await.expect("failed to read from store") {
+            assert_eq!(retrieved, value);
+        }
+
+        let _ = tokio::fs::remove_dir_all(&path).await;
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[cot::test]
     async fn test_thundering_write_with_acquisition_timeout_exceeded() {
         let path = make_store_path();
         let store = FileStore::new(
@@ -1415,16 +1497,6 @@ mod tests {
             assert_eq!(retrieved, value);
         }
         let _ = tokio::fs::remove_dir_all(&path).await;
-    }
-
-    #[test]
-    #[should_panic(expected = "`queue_size` must be 0")]
-    fn test_invalid_file_store_pool_config_creation() {
-        let _file_store = FileStorePoolConfig::builder()
-            .worker_count(0)
-            .queue_size(10)
-            .acquisition_timeout_ms(2000)
-            .build();
     }
 
     #[test]

--- a/cot/src/config.rs
+++ b/cot/src/config.rs
@@ -3089,7 +3089,7 @@ mod tests {
             [cache]
 
             [cache.store]
-            type = "file" 
+            type = "file"
         "#;
 
         let _config = ProjectConfig::from_toml(toml_content).unwrap();

--- a/cot/src/config.rs
+++ b/cot/src/config.rs
@@ -875,29 +875,53 @@ impl CacheStoreConfigBuilder {
     }
 }
 
+// The default values for `FileStorePoolConfig`
+// These are reasonable guesses for approaching the behavior
+// of `FileStorePool` and the `FileStore`
+//
+// `worker_count` represent the `Semaphore` in the loop dispatcher.
+// This number determines how many `spawn_blocking` is allowed to acquire a
+// lock. The default is small because these workers are ultimately allocated to
+// park on OS processes.
 #[cfg(feature = "cache")]
-pub(crate) const DEFAULT_FILE_STORE_WORKER_COUNT: usize = default_file_store_pool_worker_count();
+pub(crate) const DEFAULT_FILE_STORE_WORKER_COUNT: usize = 10;
 
+// `queue_size` determines how many queued requests go into the `FileStorePool`
+// This should be larger than the `worker_count` itself.
 #[cfg(feature = "cache")]
-pub(crate) const DEFAULT_FILE_STORE_QUEUE_SIZE: usize = default_file_store_pool_queue_size();
+pub(crate) const DEFAULT_FILE_STORE_QUEUE_SIZE: usize = 128;
 
+// This value relates to how long the dispatcher would wait for a worker to be
+// available. The timeout is set to 2000ms to allow the queue to drain
+// efficiently while giving requests a reasonable window to acquire a file lock.
 #[cfg(feature = "cache")]
-pub(crate) const DEFAULT_FILE_STORE_ACQUISITION_TIMEOUT_MS: u64 =
-    default_file_store_pool_acquisition_timeout_ms();
+pub(crate) const DEFAULT_FILE_STORE_ACQUISITION_TIMEOUT_MS: u64 = 2000;
+
+// This value relates to how long a request would wait during
+// `create_file_temp`. It should be slightly longer than
+// `acquisition_timeout_ms` to give time for the `FileStorePool` to free up the
+// workers if they were occupied.
+#[cfg(feature = "cache")]
+pub(crate) const DEFAULT_FILE_STORE_WAITING_TIMEOUT_MS: u64 = 4000;
 
 #[cfg(feature = "cache")]
 const fn default_file_store_pool_worker_count() -> usize {
-    10
+    DEFAULT_FILE_STORE_WORKER_COUNT
 }
 
 #[cfg(feature = "cache")]
 const fn default_file_store_pool_queue_size() -> usize {
-    128
+    DEFAULT_FILE_STORE_QUEUE_SIZE
 }
 
 #[cfg(feature = "cache")]
 const fn default_file_store_pool_acquisition_timeout_ms() -> u64 {
-    2000
+    DEFAULT_FILE_STORE_ACQUISITION_TIMEOUT_MS
+}
+
+#[cfg(feature = "cache")]
+const fn default_file_store_pool_waiting_timeout_ms() -> u64 {
+    DEFAULT_FILE_STORE_WAITING_TIMEOUT_MS
 }
 
 #[cfg(feature = "cache")]
@@ -980,6 +1004,8 @@ pub enum CacheStoreTypeConfig {
     /// This stores cache data in files on the local filesystem. The path to
     /// the directory where the cache files will be stored must be specified.
     File {
+        /// The path to the directory where cache files will be stored.
+        ///
         /// # Examples
         ///
         /// ```
@@ -992,9 +1018,9 @@ pub enum CacheStoreTypeConfig {
         ///     worker_count: 10,
         ///     queue_size: 100,
         ///     acquisition_timeout_ms: 2000,
+        ///     waiting_timeout_ms: 4000,
         /// };
         /// ```
-        /// The path to the directory where cache files will be stored.
         path: PathBuf,
 
         /// Specifies the maximum number of concurrent blocking tasks permitted
@@ -1006,17 +1032,6 @@ pub enum CacheStoreTypeConfig {
         /// becomes unresponsive, these tasks will remain allocated and
         /// unavailable for further requests until the kernel-level operation
         /// completes or fails.
-        ///
-        /// Setting this value to `0` opts out of spawning background tasks for
-        /// contested file locks. In this configuration, it is
-        /// recommended to also set `queue_size` to `0` to ensure that
-        /// requests requiring a lock fail immediately rather than
-        /// entering a pending state that cannot be serviced.
-        ///
-        /// If the maximum worker count has been reached and the associated
-        /// request queue is full, any incoming request that requires
-        /// file locking will return an error immediately to prevent
-        /// further resource contention.
         #[serde(default = "default_file_store_pool_worker_count")]
         worker_count: usize,
 
@@ -1028,13 +1043,22 @@ pub enum CacheStoreTypeConfig {
         #[serde(default = "default_file_store_pool_queue_size")]
         queue_size: usize,
 
-        /// Sets the  maximum duration (in milliseconds) to wait for lock
+        /// Specifies the maximum duration (in milliseconds) to wait for lock
         /// acquisition.
         ///
         /// This does not include time spent waiting in the queue or
         /// the duration of I/O operations once the lock is acquired.
         #[serde(default = "default_file_store_pool_acquisition_timeout_ms")]
         acquisition_timeout_ms: u64,
+
+        /// Specifies the maximum duration (in milliseconds) for requests to
+        /// wait until it can be processed.
+        ///
+        /// This only accounts for the time spent waiting in the queue.
+        /// When the timeout is reached before the request gets the file,
+        /// the request would get dropped and returns error.
+        #[serde(default = "default_file_store_pool_waiting_timeout_ms")]
+        waiting_timeout_ms: u64,
     },
 }
 
@@ -2997,6 +3021,7 @@ mod tests {
             worker_count = 8
             queue_size = 100
             acquisition_timeout_ms = 4000
+            waiting_timeout_ms = 5000
         "#;
 
         let config = ProjectConfig::from_toml(toml_content).unwrap();
@@ -3013,13 +3038,61 @@ mod tests {
             worker_count,
             queue_size,
             acquisition_timeout_ms,
+            waiting_timeout_ms,
         } = &config.cache.store.store_type
         {
             assert_eq!(path, &PathBuf::from("/tmp/cache"));
             assert_eq!(worker_count, &8usize);
             assert_eq!(queue_size, &100usize);
             assert_eq!(acquisition_timeout_ms, &4000u64);
+            assert_eq!(waiting_timeout_ms, &5000u64);
         }
+    }
+
+    #[test]
+    #[cfg(feature = "cache")]
+    fn cache_config_defaults_file() {
+        let toml_content = r#"
+            [cache]
+
+            [cache.store]
+            type = "file"
+            path = "tmp/cache"
+        "#;
+
+        let config = ProjectConfig::from_toml(toml_content).unwrap();
+
+        if let CacheStoreTypeConfig::File {
+            path,
+            worker_count,
+            queue_size,
+            acquisition_timeout_ms,
+            waiting_timeout_ms,
+        } = &config.cache.store.store_type
+        {
+            assert_eq!(path, "tmp/cache");
+            assert_eq!(worker_count, &DEFAULT_FILE_STORE_WORKER_COUNT);
+            assert_eq!(queue_size, &DEFAULT_FILE_STORE_QUEUE_SIZE);
+            assert_eq!(
+                acquisition_timeout_ms,
+                &DEFAULT_FILE_STORE_ACQUISITION_TIMEOUT_MS
+            );
+            assert_eq!(waiting_timeout_ms, &DEFAULT_FILE_STORE_WAITING_TIMEOUT_MS);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "missing field `path`")]
+    #[cfg(feature = "cache")]
+    fn cache_config_missing_path_file() {
+        let toml_content = r#"
+            [cache]
+
+            [cache.store]
+            type = "file" 
+        "#;
+
+        let _config = ProjectConfig::from_toml(toml_content).unwrap();
     }
 
     #[test]

--- a/cot/src/config.rs
+++ b/cot/src/config.rs
@@ -876,6 +876,31 @@ impl CacheStoreConfigBuilder {
 }
 
 #[cfg(feature = "cache")]
+pub(crate) const DEFAULT_FILE_STORE_WORKER_COUNT: usize = default_file_store_pool_worker_count();
+
+#[cfg(feature = "cache")]
+pub(crate) const DEFAULT_FILE_STORE_QUEUE_SIZE: usize = default_file_store_pool_queue_size();
+
+#[cfg(feature = "cache")]
+pub(crate) const DEFAULT_FILE_STORE_ACQUISITION_TIMEOUT_MS: u64 =
+    default_file_store_pool_acquisition_timeout_ms();
+
+#[cfg(feature = "cache")]
+const fn default_file_store_pool_worker_count() -> usize {
+    10
+}
+
+#[cfg(feature = "cache")]
+const fn default_file_store_pool_queue_size() -> usize {
+    128
+}
+
+#[cfg(feature = "cache")]
+const fn default_file_store_pool_acquisition_timeout_ms() -> u64 {
+    2000
+}
+
+#[cfg(feature = "cache")]
 pub(crate) const DEFAULT_REDIS_POOL_SIZE: usize = default_redis_pool_size();
 
 #[cfg(feature = "cache")]
@@ -951,7 +976,7 @@ pub enum CacheStoreTypeConfig {
         pool_size: usize,
     },
     /// File-based cache store.
-
+    ///
     /// This stores cache data in files on the local filesystem. The path to
     /// the directory where the cache files will be stored must be specified.
     File {
@@ -964,10 +989,52 @@ pub enum CacheStoreTypeConfig {
         ///
         /// let config = CacheStoreTypeConfig::File {
         ///     path: PathBuf::from("/tmp/cache"),
+        ///     worker_count: 10,
+        ///     queue_size: 100,
+        ///     acquisition_timeout_ms: 2000,
         /// };
         /// ```
         /// The path to the directory where cache files will be stored.
         path: PathBuf,
+
+        /// Specifies the maximum number of concurrent blocking tasks permitted
+        /// for file lock acquisition.
+        ///
+        /// When a blocking task is spawned to acquire a file lock, it may
+        /// remain occupied until the underlying operating system
+        /// returns control to the application. If the filesystem
+        /// becomes unresponsive, these tasks will remain allocated and
+        /// unavailable for further requests until the kernel-level operation
+        /// completes or fails.
+        ///
+        /// Setting this value to `0` opts out of spawning background tasks for
+        /// contested file locks. In this configuration, it is
+        /// recommended to also set `queue_size` to `0` to ensure that
+        /// requests requiring a lock fail immediately rather than
+        /// entering a pending state that cannot be serviced.
+        ///
+        /// If the maximum worker count has been reached and the associated
+        /// request queue is full, any incoming request that requires
+        /// file locking will return an error immediately to prevent
+        /// further resource contention.
+        #[serde(default = "default_file_store_pool_worker_count")]
+        worker_count: usize,
+
+        /// Specifies the maximum number of waiting insertions allowed in the
+        /// queue.
+        ///
+        /// Incoming requests that require file locking will return an
+        /// error immediately if this queue is full.
+        #[serde(default = "default_file_store_pool_queue_size")]
+        queue_size: usize,
+
+        /// Sets the  maximum duration (in milliseconds) to wait for lock
+        /// acquisition.
+        ///
+        /// This does not include time spent waiting in the queue or
+        /// the duration of I/O operations once the lock is acquired.
+        #[serde(default = "default_file_store_pool_acquisition_timeout_ms")]
+        acquisition_timeout_ms: u64,
     },
 }
 
@@ -2927,6 +2994,9 @@ mod tests {
             [cache.store]
             type = "file"
             path = "/tmp/cache"
+            worker_count = 8
+            queue_size = 100
+            acquisition_timeout_ms = 4000
         "#;
 
         let config = ProjectConfig::from_toml(toml_content).unwrap();
@@ -2938,8 +3008,17 @@ mod tests {
         );
         assert_eq!(config.cache.prefix, Some("dev".to_string()));
 
-        if let CacheStoreTypeConfig::File { path } = &config.cache.store.store_type {
+        if let CacheStoreTypeConfig::File {
+            path,
+            worker_count,
+            queue_size,
+            acquisition_timeout_ms,
+        } = &config.cache.store.store_type
+        {
             assert_eq!(path, &PathBuf::from("/tmp/cache"));
+            assert_eq!(worker_count, &8usize);
+            assert_eq!(queue_size, &100usize);
+            assert_eq!(acquisition_timeout_ms, &4000u64);
         }
     }
 

--- a/cot/src/config.rs
+++ b/cot/src/config.rs
@@ -3070,7 +3070,7 @@ mod tests {
             waiting_timeout_ms,
         } = &config.cache.store.store_type
         {
-            assert_eq!(path, "tmp/cache");
+            assert_eq!(path, &PathBuf::from("tmp/cache"));
             assert_eq!(worker_count, &DEFAULT_FILE_STORE_WORKER_COUNT);
             assert_eq!(queue_size, &DEFAULT_FILE_STORE_QUEUE_SIZE);
             assert_eq!(

--- a/cot/src/config.rs
+++ b/cot/src/config.rs
@@ -1032,6 +1032,10 @@ pub enum CacheStoreTypeConfig {
         /// becomes unresponsive, these tasks will remain allocated and
         /// unavailable for further requests until the kernel-level operation
         /// completes or fails.
+        ///
+        /// Setting this value to `0` opts out of spawning background tasks for
+        /// contested file locks, similar to the behavior for providing `0` to
+        /// `queue_size`.
         #[serde(default = "default_file_store_pool_worker_count")]
         worker_count: usize,
 
@@ -1040,6 +1044,10 @@ pub enum CacheStoreTypeConfig {
         ///
         /// Incoming requests that require file locking will return an
         /// error immediately if this queue is full.
+        ///
+        /// Setting this value to `0` opts out of spawning background tasks for
+        /// contested file locks, similar to the behavior for providing `0` to
+        /// `worker_count`.
         #[serde(default = "default_file_store_pool_queue_size")]
         queue_size: usize,
 

--- a/cot/src/lib.rs
+++ b/cot/src/lib.rs
@@ -84,7 +84,6 @@ pub(crate) mod utils;
 
 #[cfg(feature = "openapi")]
 pub use aide;
-pub use bytes;
 /// A wrapper around a handler that's used in [`Bootstrapper`].
 ///
 /// It is returned by [`Bootstrapper::finish`]. Typically, you don't need to
@@ -182,7 +181,6 @@ pub use cot_macros::e2e_test;
 /// ```
 pub use cot_macros::main;
 pub use cot_macros::test;
-pub use http;
 #[cfg(feature = "openapi")]
 pub use schemars;
 pub use toml;

--- a/cot/src/lib.rs
+++ b/cot/src/lib.rs
@@ -84,7 +84,6 @@ pub(crate) mod utils;
 
 #[cfg(feature = "openapi")]
 pub use aide;
-pub use bytes;
 /// A wrapper around a handler that's used in [`Bootstrapper`].
 ///
 /// It is returned by [`Bootstrapper::finish`]. Typically, you don't need to
@@ -182,10 +181,9 @@ pub use cot_macros::e2e_test;
 /// ```
 pub use cot_macros::main;
 pub use cot_macros::test;
-pub use http;
 #[cfg(feature = "openapi")]
 pub use schemars;
-pub use toml;
+pub use {bytes, http, toml};
 
 pub use crate::__private::askama::{Template, filter_fn};
 pub use crate::project::{

--- a/cot/src/lib.rs
+++ b/cot/src/lib.rs
@@ -84,6 +84,7 @@ pub(crate) mod utils;
 
 #[cfg(feature = "openapi")]
 pub use aide;
+pub use bytes;
 /// A wrapper around a handler that's used in [`Bootstrapper`].
 ///
 /// It is returned by [`Bootstrapper::finish`]. Typically, you don't need to
@@ -181,6 +182,7 @@ pub use cot_macros::e2e_test;
 /// ```
 pub use cot_macros::main;
 pub use cot_macros::test;
+pub use http;
 #[cfg(feature = "openapi")]
 pub use schemars;
 pub use toml;

--- a/cot/src/lib.rs
+++ b/cot/src/lib.rs
@@ -84,6 +84,7 @@ pub(crate) mod utils;
 
 #[cfg(feature = "openapi")]
 pub use aide;
+pub use bytes;
 /// A wrapper around a handler that's used in [`Bootstrapper`].
 ///
 /// It is returned by [`Bootstrapper::finish`]. Typically, you don't need to
@@ -181,9 +182,10 @@ pub use cot_macros::e2e_test;
 /// ```
 pub use cot_macros::main;
 pub use cot_macros::test;
+pub use http;
 #[cfg(feature = "openapi")]
 pub use schemars;
-pub use {bytes, http, toml};
+pub use toml;
 
 pub use crate::__private::askama::{Template, filter_fn};
 pub use crate::project::{

--- a/cot/src/test.rs
+++ b/cot/src/test.rs
@@ -4,6 +4,8 @@ use std::any::Any;
 use std::future::poll_fn;
 use std::marker::PhantomData;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+#[cfg(feature = "cache")]
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -26,6 +28,10 @@ use crate::auth::db::DatabaseUserBackend;
 use crate::auth::{Auth, AuthBackend, NoAuthBackend, User, UserId};
 #[cfg(feature = "cache")]
 use crate::cache::Cache;
+#[cfg(feature = "cache")]
+use crate::cache::store::file::FileCacheStoreError;
+#[cfg(feature = "cache")]
+use crate::cache::store::file::FileStore;
 #[cfg(feature = "cache")]
 use crate::cache::store::memory::Memory;
 #[cfg(feature = "redis")]
@@ -1763,6 +1769,9 @@ enum CacheKind {
         #[expect(unused)]
         allocator: RedisDbAllocator,
     },
+    File {
+        path: PathBuf,
+    },
 }
 
 /// A test cache.
@@ -1897,6 +1906,75 @@ impl TestCache {
         Ok(this)
     }
 
+    /// Create a new file store test cache
+    ///
+    /// This will create a new directory for the test cache instance
+    /// in  `{tmp_dir}/cot_test_cache_run_{i}` where `tmp_dir` is
+    /// the path returned by `std::env::temp_dir()` and `i` is the
+    /// instance number of the directory. The constructor will iterate
+    /// over the base path before committing the directory where the
+    /// cache directory will be created.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use cot::test::TestCache;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> cot::Result<()> {
+    /// let test_cache = TestCache::new_file()?;
+    /// let cache = test_cache.cache();
+    ///
+    /// // do something with the cache
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns error if the cache directory could not be created
+    pub fn new_file() -> Result<Self> {
+        use crate::cache::store::file::FileStorePoolConfig;
+        use crate::config::{
+            DEFAULT_FILE_STORE_ACQUISITION_TIMEOUT_MS, DEFAULT_FILE_STORE_QUEUE_SIZE,
+            DEFAULT_FILE_STORE_WORKER_COUNT,
+        };
+
+        let base_path = std::env::temp_dir().join(format!("cot_test_cache_{}", std::process::id()));
+
+        let _ = std::fs::create_dir_all(&base_path);
+
+        let mut i = 0;
+        let path = loop {
+            let candidate = base_path.join(format!("run_{i}"));
+
+            match std::fs::create_dir(&candidate) {
+                Ok(()) => break candidate,
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    i += 1;
+                }
+                Err(e) => return Err(FileCacheStoreError::DirCreation(Box::new(e)))?,
+            }
+        };
+
+        let default_worker_count = DEFAULT_FILE_STORE_WORKER_COUNT;
+        let default_queue_size = DEFAULT_FILE_STORE_QUEUE_SIZE;
+        let default_acquisition_timeout_ms = DEFAULT_FILE_STORE_ACQUISITION_TIMEOUT_MS;
+        let file_store = FileStore::new(
+            path.clone(),
+            FileStorePoolConfig::builder()
+                .worker_count(default_worker_count)
+                .queue_size(default_queue_size)
+                .acquisition_timeout_ms(default_acquisition_timeout_ms)
+                .build(),
+        )?;
+
+        let cache = Cache::new(file_store, Some("dev_test".to_string()), Timeout::default());
+
+        Ok(Self::new(cache, CacheKind::File { path }))
+    }
+
     /// Get the cache.
     ///
     /// # Examples
@@ -1945,6 +2023,9 @@ impl TestCache {
         #[cfg(feature = "redis")]
         if let CacheKind::Redis { allocator: _ } = &self.kind {
             self.cache.clear().await?;
+        }
+        if let CacheKind::File { path } = &self.kind {
+            let _ = tokio::fs::remove_dir_all(path).await;
         }
         Ok(())
     }

--- a/cot/src/test.rs
+++ b/cot/src/test.rs
@@ -1909,13 +1909,13 @@ impl TestCache {
     /// Create a new file store test cache
     ///
     /// This will create a new directory for the test cache instance
-    /// in  `{tmp_dir}/cot_test_cache_run_{i}` where `tmp_dir` is
-    /// the path returned by `std::env::temp_dir()` and `i` is the
-    /// instance number of the directory. The constructor will iterate
-    /// over the base path before committing the directory where the
-    /// cache directory will be created.
+    /// in `{tmp_dir}/cot_test_cache_{process_id}/run_{i}` where `tmp_dir` is
+    /// the path returned by `std::env::temp_dir()`, `process_id` is the current
+    /// process id,  and `i` is the entry number of the directory.
     ///
-    /// # Examples
+    /// The constructor will try to create an entry based on current count base
+    /// path entries. If collision happens, it will increment the `i` until
+    /// a directory is created. # Examples
     ///
     /// ```no_run
     /// use cot::test::TestCache;
@@ -1934,6 +1934,13 @@ impl TestCache {
     /// # Errors
     ///
     /// Returns error if the cache directory could not be created
+    ///
+    /// # Panics
+    ///
+    /// Panics if:
+    /// * The path `{tmp_dir}/cot_test_cache_{process_id}/` doesn't exist
+    /// * The process lacks the permission to read the directory
+    /// * The path `{tmp_dir}/cot_test_cache_{process_id}/` is not a directory
     pub fn new_file() -> Result<Self> {
         use crate::cache::store::file::FileStorePoolConfig;
         use crate::config::{
@@ -1945,14 +1952,14 @@ impl TestCache {
 
         let _ = std::fs::create_dir_all(&base_path);
 
-        let mut i = 0;
+        let mut dir_length = std::fs::read_dir(&base_path).unwrap().count() + 1;
         let path = loop {
-            let candidate = base_path.join(format!("run_{i}"));
+            let candidate = base_path.join(format!("run_{dir_length}"));
 
             match std::fs::create_dir(&candidate) {
                 Ok(()) => break candidate,
                 Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                    i += 1;
+                    dir_length += 1;
                 }
                 Err(e) => return Err(FileCacheStoreError::DirCreation(Box::new(e)))?,
             }


### PR DESCRIPTION
Pull Request to Issue #427 

Key info:
* CAS-based registry
* Hashed using md-5 (which is already an existing dependency from sqlx)
* Eviction on get and contains key (similar to memory cache)

Note:
* Uses DateTime to parse serialized expiry into Timeout (this can be improved by implementing From<u64> in Timeout)
* No retry policy implemented
* No entry cap implemented