### PR TITLE
refactor!: fix includes for `#[derive(Template)]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,13 +180,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba5e7259a1580c61571e3116ebaaa01e3c001b2132b17c4cc5c70780ca3e994"
 dependencies = [
  "askama_parser",
- "basic-toml",
  "memchr",
  "proc-macro2",
  "quote",
  "rustc-hash",
- "serde",
- "serde_derive",
  "syn",
 ]
 
@@ -206,8 +203,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c63392767bb2df6aa65a6e1e3b80fd89bb7af6d58359b924c0695620f1512e"
 dependencies = [
  "rustc-hash",
- "serde",
- "serde_derive",
  "unicode-ident",
  "winnow",
 ]
@@ -503,15 +498,6 @@ name = "base64ct"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
-
-[[package]]
-name = "basic-toml"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitflags"
@@ -994,6 +980,7 @@ dependencies = [
 name = "cot_macros"
 version = "0.4.0"
 dependencies = [
+ "askama_derive",
  "cot",
  "cot_codegen",
  "darling 0.23.0",
@@ -1463,7 +1450,6 @@ dependencies = [
 name = "example-admin"
 version = "0.1.0"
 dependencies = [
- "askama",
  "async-trait",
  "cot",
 ]
@@ -1472,7 +1458,6 @@ dependencies = [
 name = "example-custom-error-pages"
 version = "0.1.0"
 dependencies = [
- "askama",
  "cot",
 ]
 
@@ -1489,7 +1474,6 @@ dependencies = [
 name = "example-file-upload"
 version = "0.1.0"
 dependencies = [
- "askama",
  "base64",
  "cot",
 ]
@@ -1514,7 +1498,6 @@ dependencies = [
 name = "example-send-email"
 version = "0.1.0"
 dependencies = [
- "askama",
  "cot",
  "serde",
 ]
@@ -1523,7 +1506,6 @@ dependencies = [
 name = "example-sessions"
 version = "0.1.0"
 dependencies = [
- "askama",
  "cot",
 ]
 
@@ -1531,7 +1513,6 @@ dependencies = [
 name = "example-todo-list"
 version = "0.1.0"
 dependencies = [
- "askama",
  "cot",
 ]
 
@@ -1641,7 +1622,6 @@ dependencies = [
 name = "forms"
 version = "0.1.0"
 dependencies = [
- "askama",
  "chrono",
  "chrono-tz",
  "cot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ aide = { version = "0.15", default-features = false }
 anstyle = "1.0.13"
 anyhow = "1.0.100"
 askama = { version = "0.15.1", default-features = false }
+askama_derive = { version = "0.15.1", default-features = false, features = ["external-sources", "proc-macro"] }
 assert_cmd = "2"
 async-stream = "0.3"
 async-trait = "0.1"

--- a/cot-cli/src/project_template/src/main.rs
+++ b/cot-cli/src/project_template/src/main.rs
@@ -1,6 +1,5 @@
 mod migrations;
 
-use askama::Template;
 use cot::auth::db::DatabaseUserApp;
 use cot::cli::CliMetadata;
 use cot::db::migrations::SyncDynMigration;
@@ -11,7 +10,7 @@ use cot::request::extractors::StaticFiles;
 use cot::router::{Route, Router};
 use cot::static_files::{StaticFile, StaticFilesMiddleware};
 use cot::session::db::SessionApp;
-use cot::{App, AppBuilder, Project, static_files};
+use cot::{App, AppBuilder, Project, static_files, Template};
 
 #[derive(Debug, Template)]
 #[template(path = "index.html")]

--- a/cot-macros/Cargo.toml
+++ b/cot-macros/Cargo.toml
@@ -21,8 +21,9 @@ path = "tests/compile_tests.rs"
 workspace = true
 
 [dependencies]
-darling.workspace = true
+askama_derive.workspace = true
 cot_codegen.workspace = true
+darling.workspace = true
 heck.workspace = true
 proc-macro-crate.workspace = true
 proc-macro2 = { workspace = true, features = ["proc-macro"] }

--- a/cot-macros/src/lib.rs
+++ b/cot-macros/src/lib.rs
@@ -240,3 +240,26 @@ pub fn derive_api_operation_response(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     impl_api_operation_response_for_enum(&ast).into()
 }
+
+/// The `Template` derive macro and its `template()` attribute.
+///
+/// Please see our [template guide](https://cot.rs/guide/latest/templates/) and [askama's book](
+/// https://askama.readthedocs.io/en/stable/creating_templates.html) for more information.
+#[proc_macro_derive(Template, attributes(template))]
+pub fn derive_template(input: TokenStream) -> TokenStream {
+    askama_derive::derive_template(input.into(), import_askama).into()
+}
+
+/// A macro attribute to write custom filters for askama templates.
+///
+/// Please see [askama's book](https://askama.readthedocs.io/en/stable/filters.html#custom-filters)
+/// for more information.
+#[proc_macro_attribute]
+pub fn filter_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
+    askama_derive::derive_filter_fn(attr.into(), item.into(), import_askama).into()
+}
+
+fn import_askama() -> proc_macro2::TokenStream {
+    let cot = cot_ident();
+    quote!(use #cot::__private::askama;)
+}

--- a/cot/Cargo.toml
+++ b/cot/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 aide = { workspace = true, optional = true }
-askama = { workspace = true, features = ["derive", "std"] }
+askama = { workspace = true, features = ["std"] }
 async-trait.workspace = true
 axum = { workspace = true, features = ["http1", "tokio"] }
 backtrace.workspace = true

--- a/cot/src/admin.rs
+++ b/cot/src/admin.rs
@@ -6,7 +6,6 @@
 use std::any::Any;
 use std::marker::PhantomData;
 
-use askama::Template;
 use async_trait::async_trait;
 use bytes::Bytes;
 /// Implements the [`AdminModel`] trait for a struct.
@@ -32,7 +31,7 @@ use crate::request::{Request, RequestExt, RequestHead};
 use crate::response::{IntoResponse, Response};
 use crate::router::{Router, Urls};
 use crate::static_files::StaticFile;
-use crate::{App, Error, Method, RequestHandler, reverse_redirect};
+use crate::{App, Error, Method, RequestHandler, Template, reverse_redirect};
 
 struct AdminAuthenticated<T, H: Send + Sync>(H, PhantomData<fn() -> T>);
 

--- a/cot/src/common_types.rs
+++ b/cot/src/common_types.rs
@@ -699,9 +699,8 @@ impl Display for Email {
 mod tests {
     use std::convert::TryFrom;
 
-    use askama::Template;
-
     use super::*;
+    use crate::Template;
 
     #[test]
     fn url_new() {

--- a/cot/src/error_page.rs
+++ b/cot/src/error_page.rs
@@ -2,14 +2,13 @@ use std::any::Any;
 use std::panic::PanicHookInfo;
 use std::sync::Arc;
 
-use askama::Template;
 use tracing::{Level, error, warn};
 
 use crate::config::ProjectConfig;
 use crate::error::NotFound;
 use crate::error::backtrace::{__cot_create_backtrace, Backtrace};
 use crate::router::Router;
-use crate::{Error, Result, StatusCode};
+use crate::{Error, Result, StatusCode, Template};
 
 #[derive(Debug)]
 pub(super) struct Diagnostics {

--- a/cot/src/lib.rs
+++ b/cot/src/lib.rs
@@ -161,11 +161,12 @@ pub use cot_macros::e2e_test;
 /// ```
 pub use cot_macros::main;
 pub use cot_macros::test;
-pub use error::error_impl::Error;
 #[cfg(feature = "openapi")]
 pub use schemars;
 pub use {bytes, http};
 
+pub use crate::__private::askama::{Template, filter_fn};
+pub use crate::error::error_impl::Error;
 pub use crate::handler::{BoxedHandler, RequestHandler};
 pub use crate::project::{
     App, AppBuilder, Bootstrapper, Project, ProjectContext, run, run_at, run_cli,

--- a/cot/src/private.rs
+++ b/cot/src/private.rs
@@ -8,14 +8,15 @@
 
 #[cfg(feature = "openapi")]
 pub use aide::openapi::{Operation, RequestBody, Response as OpenApiResponse, StatusCode};
-/// Askama's macros don't work when Askama is re-exported, so there's no point
-/// in re-exporting it publicly. However, we need to re-export it here so that
-/// our macros can implement traits from Askama.
-pub use askama;
 pub use async_trait::async_trait;
 pub use bytes::Bytes;
 pub use cot_macros::ModelHelper;
 pub use tokio;
+
+pub mod askama {
+    pub use askama::*;
+    pub use cot_macros::{Template, filter_fn};
+}
 
 // used in the CLI
 #[cfg(feature = "db")]

--- a/cot/src/project.rs
+++ b/cot/src/project.rs
@@ -25,9 +25,9 @@ use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use askama::Template;
 use async_trait::async_trait;
 use axum::handler::HandlerWithoutStateExt;
+use cot::Template;
 use derive_more::with_trait::Debug;
 use futures_util::FutureExt;
 use thiserror::Error;

--- a/examples/admin/Cargo.toml
+++ b/examples/admin/Cargo.toml
@@ -8,5 +8,4 @@ edition = "2024"
 
 [dependencies]
 async-trait = "0.1"
-askama = "0.15"
 cot = { path = "../../cot", features = ["live-reload"] }

--- a/examples/admin/src/main.rs
+++ b/examples/admin/src/main.rs
@@ -3,7 +3,6 @@ mod migrations;
 use std::fmt::{Display, Formatter};
 use std::time::Duration;
 
-use askama::Template;
 use async_trait::async_trait;
 use cot::admin::{AdminApp, AdminModel, AdminModelManager, DefaultAdminModelManager};
 use cot::auth::db::{DatabaseUser, DatabaseUserApp};
@@ -20,7 +19,7 @@ use cot::middleware::{AuthMiddleware, LiveReloadMiddleware, SessionMiddleware};
 use cot::project::{MiddlewareContext, RegisterAppsContext, RootHandler};
 use cot::router::{Route, Router, Urls};
 use cot::static_files::StaticFilesMiddleware;
-use cot::{App, AppBuilder, Project, ProjectContext};
+use cot::{App, AppBuilder, Project, ProjectContext, Template};
 
 #[derive(Debug, Clone, Form, AdminModel)]
 #[model]

--- a/examples/custom-error-pages/Cargo.toml
+++ b/examples/custom-error-pages/Cargo.toml
@@ -7,5 +7,4 @@ license = "MIT OR Apache-2.0"
 edition = "2024"
 
 [dependencies]
-askama = "0.15"
 cot = { path = "../../cot" }

--- a/examples/custom-error-pages/src/main.rs
+++ b/examples/custom-error-pages/src/main.rs
@@ -1,4 +1,3 @@
-use askama::Template;
 use cot::cli::CliMetadata;
 use cot::config::ProjectConfig;
 use cot::error::handler::{DynErrorPageHandler, RequestError};
@@ -6,7 +5,7 @@ use cot::html::Html;
 use cot::project::RegisterAppsContext;
 use cot::response::{IntoResponse, Response};
 use cot::router::{Route, Router};
-use cot::{App, AppBuilder, Project};
+use cot::{App, AppBuilder, Project, Template};
 
 async fn return_hello() -> cot::Result<Response> {
     panic!()

--- a/examples/file-upload/Cargo.toml
+++ b/examples/file-upload/Cargo.toml
@@ -7,6 +7,5 @@ license = "MIT OR Apache-2.0"
 edition = "2024"
 
 [dependencies]
-askama = "0.15"
 base64 = "0.22"
 cot = { path = "../../cot" }

--- a/examples/file-upload/src/main.rs
+++ b/examples/file-upload/src/main.rs
@@ -1,4 +1,3 @@
-use askama::Template;
 use base64::Engine;
 use cot::cli::CliMetadata;
 use cot::config::ProjectConfig;
@@ -9,7 +8,7 @@ use cot::project::{MiddlewareContext, RegisterAppsContext, RootHandler};
 use cot::request::extractors::RequestForm;
 use cot::router::{Route, Router, Urls};
 use cot::static_files::StaticFilesMiddleware;
-use cot::{App, AppBuilder, Project};
+use cot::{App, AppBuilder, Project, Template};
 
 #[derive(Debug, Template)]
 #[template(path = "index.html")]

--- a/examples/forms/Cargo.toml
+++ b/examples/forms/Cargo.toml
@@ -6,7 +6,6 @@ license = "MIT OR Apache-2.0"
 edition = "2024"
 
 [dependencies]
-askama = "0.15"
 cot = { path = "../../cot" , features = ["full"]}
 chrono = "0.4.42"
 chrono-tz = "0.10.4"

--- a/examples/forms/src/main.rs
+++ b/examples/forms/src/main.rs
@@ -1,6 +1,5 @@
 mod migrations;
 
-use askama::Template;
 use chrono::{DateTime, Duration, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime};
 use chrono_tz::Tz;
 use cot::cli::CliMetadata;
@@ -17,7 +16,7 @@ use cot::request::extractors::{RequestForm, StaticFiles};
 use cot::response::Response;
 use cot::router::{Route, Router, Urls};
 use cot::static_files::{StaticFile, StaticFilesMiddleware};
-use cot::{App, AppBuilder, Project, reverse_redirect, static_files};
+use cot::{App, AppBuilder, Project, Template, reverse_redirect, static_files};
 
 #[derive(Debug, Clone)]
 #[model]

--- a/examples/send-email/Cargo.toml
+++ b/examples/send-email/Cargo.toml
@@ -8,5 +8,4 @@ edition = "2024"
 
 [dependencies]
 cot = { path = "../../cot", features = ["email", "live-reload"] }
-askama = "0.15"
 serde = { version = "1", features = ["derive"] }

--- a/examples/send-email/src/main.rs
+++ b/examples/send-email/src/main.rs
@@ -1,4 +1,3 @@
-use askama::Template;
 use cot::cli::CliMetadata;
 use cot::common_types::Email;
 use cot::config::{EmailConfig, EmailTransportConfig, EmailTransportTypeConfig, ProjectConfig};
@@ -12,7 +11,7 @@ use cot::request::{Request, RequestExt};
 use cot::response::Response;
 use cot::router::{Route, Router, Urls};
 use cot::static_files::{StaticFile, StaticFilesMiddleware};
-use cot::{App, AppBuilder, Project, reverse_redirect, static_files};
+use cot::{App, AppBuilder, Project, Template, reverse_redirect, static_files};
 use serde::{Deserialize, Serialize};
 
 struct EmailApp;

--- a/examples/sessions/Cargo.toml
+++ b/examples/sessions/Cargo.toml
@@ -7,5 +7,4 @@ license = "MIT OR Apache-2.0"
 edition = "2024"
 
 [dependencies]
-askama = "0.15"
 cot = { path = "../../cot" }

--- a/examples/sessions/src/main.rs
+++ b/examples/sessions/src/main.rs
@@ -1,4 +1,3 @@
-use askama::Template;
 use cot::cli::CliMetadata;
 use cot::config::{
     DatabaseConfig, MiddlewareConfig, ProjectConfig, SessionMiddlewareConfig, SessionStoreConfig,
@@ -13,7 +12,7 @@ use cot::response::{IntoResponse, Response};
 use cot::router::{Route, Router, Urls};
 use cot::session::Session;
 use cot::session::db::SessionApp;
-use cot::{App, AppBuilder, Project, reverse_redirect};
+use cot::{App, AppBuilder, Project, Template, reverse_redirect};
 
 #[derive(Debug, Template)]
 #[template(path = "index.html")]

--- a/examples/todo-list/Cargo.toml
+++ b/examples/todo-list/Cargo.toml
@@ -7,5 +7,4 @@ license = "MIT OR Apache-2.0"
 edition = "2024"
 
 [dependencies]
-askama = "0.15"
 cot = { path = "../../cot" }

--- a/examples/todo-list/src/main.rs
+++ b/examples/todo-list/src/main.rs
@@ -1,6 +1,5 @@
 mod migrations;
 
-use askama::Template;
 use cot::auth::db::DatabaseUserApp;
 use cot::cli::CliMetadata;
 use cot::config::{DatabaseConfig, ProjectConfig};
@@ -13,7 +12,7 @@ use cot::request::extractors::{Path, RequestForm};
 use cot::response::Response;
 use cot::router::{Route, Router, Urls};
 use cot::static_files::StaticFilesMiddleware;
-use cot::{App, AppBuilder, Project, reverse_redirect};
+use cot::{App, AppBuilder, Project, Template, reverse_redirect};
 
 #[derive(Debug, Clone)]
 #[model]


### PR DESCRIPTION
This PR makes `cot_macros` implement `Template` and `filter_fn` instead of transcluding the macros from `askama_macros`. This way users of `cot` don't need to depend on `askama` in their project, but can simply use the exported trait and derive_macro from `cot`.