### PR TITLE
feat: improve error printing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,6 +1006,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "indexmap",
+ "insta",
  "schemars",
  "serde",
  "serde_html_form",

--- a/cot-core/Cargo.toml
+++ b/cot-core/Cargo.toml
@@ -45,6 +45,7 @@ async-stream.workspace = true
 # When publishing, path dependencies are dropped, removing the cycle.
 cot = { path = "../cot", features = ["test"] }
 futures.workspace = true
+insta.workspace = true
 tokio.workspace = true
 
 [features]

--- a/cot-core/src/error/error_impl.rs
+++ b/cot-core/src/error/error_impl.rs
@@ -171,7 +171,26 @@ impl Error {
 
 impl Debug for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Debug::fmt(&self.repr, f)
+        // If the alternate (`{:#?}`) formatting has been specified, print out the
+        // `Debug` formatting normally. If not, (which is the case when using
+        // `Result::unwrap()` or `Result::expect()`) pretty print the error.
+        if f.alternate() {
+            Debug::fmt(&self.repr, f)
+        } else {
+            Display::fmt(&self.repr.inner, f)?;
+
+            writeln!(f)?;
+            writeln!(f)?;
+            writeln!(f, "caused by:")?;
+            let mut source = self.source();
+            while let Some(e) = source {
+                writeln!(f, "    {e}")?;
+
+                source = e.source();
+            }
+
+            Ok(())
+        }
     }
 }
 

--- a/cot-core/src/error/error_impl.rs
+++ b/cot-core/src/error/error_impl.rs
@@ -186,10 +186,7 @@ impl Debug for Error {
                 writeln!(f, "caused by:")?;
                 let mut source = Some(source);
                 let mut i = 0;
-                while let Some(mut e) = source {
-                    if let Some(ekurwa) = e.downcast_ref::<Self>() {
-                        e = ekurwa.inner();
-                    }
+                while let Some(e) = source {
                     writeln!(f, "{i:4}: {e}")?;
 
                     source = e.source();

--- a/cot-core/src/error/error_impl.rs
+++ b/cot-core/src/error/error_impl.rs
@@ -441,7 +441,9 @@ mod tests {
         #[error("wrapper error")]
         struct WrapperError(#[source] OuterError);
 
-        let err = Error::internal(WrapperError(OuterError(std::io::Error::other("inner io error"))));
+        let err = Error::internal(WrapperError(OuterError(std::io::Error::other(
+            "inner io error",
+        ))));
 
         assert_snapshot!(format!("{err:?}"), @"
         wrapper error

--- a/cot-core/src/error/error_impl.rs
+++ b/cot-core/src/error/error_impl.rs
@@ -177,16 +177,21 @@ impl Debug for Error {
         if f.alternate() {
             Debug::fmt(&self.repr, f)
         } else {
-            Display::fmt(&self.repr.inner, f)?;
+            let error = self.inner();
+            Display::fmt(error, f)?;
 
-            writeln!(f)?;
-            writeln!(f)?;
-            writeln!(f, "caused by:")?;
-            let mut source = self.source();
-            while let Some(e) = source {
-                writeln!(f, "    {e}")?;
+            if let Some(source) = error.source() {
+                writeln!(f)?;
+                writeln!(f)?;
+                writeln!(f, "caused by:")?;
+                let mut source = Some(source);
+                let mut i = 0;
+                while let Some(e) = source {
+                    writeln!(f, "{i:4}: {e}")?;
 
-                source = e.source();
+                    source = e.source();
+                    i += 1;
+                }
             }
 
             Ok(())
@@ -288,6 +293,7 @@ impl From<tower_sessions::session::Error> for Error {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
     use serde::ser::Error as _;
 
     use super::*;
@@ -382,5 +388,47 @@ mod tests {
                 .to_string()
                 .contains("error while accessing the session object")
         );
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "unsupported operation: extern static `pidfd_spawnp` is not supported by Miri"
+    )]
+    fn error_debug_printing() {
+        #[derive(::core::fmt::Debug, thiserror::Error)]
+        #[error("outer error")]
+        struct OuterError(#[source] std::io::Error);
+
+        let err = Error::internal("root error");
+        assert_snapshot!(format!("{err:?}"), @"root error");
+
+        let err = Error::with_status("root error", StatusCode::BAD_REQUEST);
+        assert_snapshot!(format!("{err:?}"), @"root error");
+
+        let err = Error::wrap(std::io::Error::other("io error"));
+        assert_snapshot!(format!("{err:?}"), @"io error");
+
+        let io_err = std::io::Error::other("inner io error");
+        let err = Error::wrap(OuterError(io_err));
+        assert_snapshot!(format!("{err:?}"), @r###"
+        outer error
+
+        caused by:
+           0: inner io error
+        "###);
+
+        let err = Error::with_status(
+            OuterError(std::io::Error::other("inner io error")),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        );
+        assert_snapshot!(format!("{err:?}"), @r###"
+        outer error
+
+        caused by:
+           0: inner io error
+        "###);
+
+        assert_snapshot!(format!("{err}"), @"outer error");
     }
 }

--- a/cot-core/src/error/error_impl.rs
+++ b/cot-core/src/error/error_impl.rs
@@ -293,10 +293,15 @@ impl From<tower_sessions::session::Error> for Error {
 
 #[cfg(test)]
 mod tests {
+    use derive_more::with_trait::Debug;
     use insta::assert_snapshot;
     use serde::ser::Error as _;
 
     use super::*;
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("outer error")]
+    struct OuterError(#[source] std::io::Error);
 
     #[test]
     fn error_new() {
@@ -396,10 +401,6 @@ mod tests {
         ignore = "unsupported operation: extern static `pidfd_spawnp` is not supported by Miri"
     )]
     fn error_debug_printing() {
-        #[derive(::core::fmt::Debug, thiserror::Error)]
-        #[error("outer error")]
-        struct OuterError(#[source] std::io::Error);
-
         let err = Error::internal("root error");
         assert_snapshot!(format!("{err:?}"), @"root error");
 
@@ -418,17 +419,67 @@ mod tests {
            0: inner io error
         "###);
 
-        let err = Error::with_status(
-            OuterError(std::io::Error::other("inner io error")),
-            StatusCode::INTERNAL_SERVER_ERROR,
-        );
+        let err = Error::internal(OuterError(std::io::Error::other("inner io error")));
         assert_snapshot!(format!("{err:?}"), @r###"
         outer error
 
         caused by:
            0: inner io error
         "###);
+    }
 
-        assert_snapshot!(format!("{err}"), @"outer error");
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "unsupported operation: extern static `pidfd_spawnp` is not supported by Miri"
+    )]
+    fn error_debug_printing_chain() {
+        #[derive(Debug, thiserror::Error)]
+        #[error("wrapper error")]
+        struct WrapperError(#[source] Error);
+
+        let err = Error::internal(OuterError(std::io::Error::other("inner io error")));
+        let err = Error::internal(WrapperError(err));
+
+        assert_snapshot!(format!("{err:?}"), @"
+        wrapper error
+
+        caused by:
+           0: outer error
+           1: outer error
+           2: inner io error
+        ");
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "unsupported operation: extern static `pidfd_spawnp` is not supported by Miri"
+    )]
+    fn error_debug_printing_alternate() {
+        let err = Error::with_status(
+            OuterError(std::io::Error::other("inner io error")),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        );
+        assert_snapshot!(format!("{err:#?}"), @r#"
+        ErrorImpl {
+            inner: WithStatusCode(
+                ErrorImpl {
+                    inner: OuterError(
+                        Custom {
+                            kind: Other,
+                            error: "inner io error",
+                        },
+                    ),
+                    status_code: Some(
+                        500,
+                    ),
+                    ..
+                },
+            ),
+            status_code: None,
+            ..
+        }
+        "#);
     }
 }

--- a/cot-core/src/error/error_impl.rs
+++ b/cot-core/src/error/error_impl.rs
@@ -186,7 +186,10 @@ impl Debug for Error {
                 writeln!(f, "caused by:")?;
                 let mut source = Some(source);
                 let mut i = 0;
-                while let Some(e) = source {
+                while let Some(mut e) = source {
+                    if let Some(ekurwa) = e.downcast_ref::<Self>() {
+                        e = ekurwa.inner();
+                    }
                     writeln!(f, "{i:4}: {e}")?;
 
                     source = e.source();
@@ -436,18 +439,16 @@ mod tests {
     fn error_debug_printing_chain() {
         #[derive(Debug, thiserror::Error)]
         #[error("wrapper error")]
-        struct WrapperError(#[source] Error);
+        struct WrapperError(#[source] OuterError);
 
-        let err = Error::internal(OuterError(std::io::Error::other("inner io error")));
-        let err = Error::internal(WrapperError(err));
+        let err = Error::internal(WrapperError(OuterError(std::io::Error::other("inner io error"))));
 
         assert_snapshot!(format!("{err:?}"), @"
         wrapper error
 
         caused by:
            0: outer error
-           1: outer error
-           2: inner io error
+           1: inner io error
         ");
     }
 


### PR DESCRIPTION
When using `Result::expect()`, (e.g. in the default `cot::main`) errors are printed using `Debug` printer. This causes very ugly errors to be produced. Instead, when the alternate mode is not being used, just format the error nicely, along with the error source chain.

This roughly duplicates the `anyhow::Error` error printing logic: https://docs.rs/anyhow/latest/anyhow/struct.Error.html#method.chain

The change turns this:
<img width="3040" height="217" alt="before" src="https://github.com/user-attachments/assets/0934973a-d7a0-4744-8bbf-60e741b81c63" />

into this:
<img width="1668" height="895" alt="after" src="https://github.com/user-attachments/assets/fff3f40a-4898-4dcf-bf29-81d038e5fc24" />
