### PR TITLE
feat: derive `Ord` and `PartialOrd` for `Auto`

### DIFF
--- a/cot/src/db.rs
+++ b/cot/src/db.rs
@@ -1808,7 +1808,7 @@ pub struct RowsNum(pub u64);
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default, Ord, PartialOrd)]
 pub enum Auto<T> {
     /// A fixed value.
     Fixed(T),


### PR DESCRIPTION
## Description

<!-- What does this PR do and why? -->

This allows us to do this:

```rust
#[model]
#[derive(Debug, Clone)]
struct Foo{
   id: Auto<i64>
}

...

let _ = query!(Foo, $id > 1).all(&db).await.unwrap();

```


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Other (describe above)

## Checklist

- [ ] I've read the [contributing guide](CONTRIBUTING.md)
- [ ] Tests pass locally (`just test-all`)
- [ ] Code passes clippy (`just clippy`)
- [ ] Code is properly formatted (`cargo fmt`)
- [ ] New tests added (regression test for bugs, coverage for new features)
- [ ] Documentation (both code and site) updated (if applicable)

<!-- Please mark the PR as in progress if you haven't completed the checklist -->
