### PR TITLE
fix: place correct contributing guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ manager might not be the latest one, so we recommend just using the official pac
 
 ## Development
 
-If you want to contribute to Cot, please read the [contributing guide](https://cot.rs/guide/latest/contributing). It will guide you through the process of setting up your development environment and making contributions.
+If you want to contribute to Cot, please read the [contributing guide](https://github.com/cot-rs/cot/blob/master/CONTRIBUTING.md). It will guide you through the process of setting up your development environment and making contributions.
 
 Thanks in advance for your contributions — every contribution is appreciated!
 


### PR DESCRIPTION
## Related issue or discussion

Fixes https://github.com/cot-rs/cot/issues/556

## Description
Previously linked https://cot.rs/guide/latest/contributing in README.md shows "Not Found. The page you are looking for was not found."
Actual contributing guide is in https://github.com/cot-rs/cot/blob/master/CONTRIBUTING.md
Minor change but makes life easier for new contributors by pointing to the right guide rightaway.

<img width="1543" height="727" alt="Screenshot 2026-04-22 at 11-38-56 Error Cot" src="https://github.com/user-attachments/assets/adbbb3a2-463f-4bce-a21a-9b0dec0d9680" />


## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Documentation
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Other (describe above)

## Checklist

- [X] I've read the [contributing guide](CONTRIBUTING.md)
- [X] Tests pass locally (`just test-all`) `(Although N/A cause this is only a docs change)`
- [X] Code passes clippy (`just clippy`)  `(Although N/A cause this is only a docs change)`
- [X] Code is properly formatted (`cargo fmt`)  `(Although N/A cause this is only a docs change)`
- [ ] New tests added (regression test for bugs, coverage for new features)  `(Although N/A cause this is only a docs change)`
- [X] Documentation (both code and site) updated (if applicable)

<!-- Please mark the PR as in progress if you haven't completed the checklist -->
