### PR TITLE
feat: Implement `From<DbFieldValue>` for  Non primitive types

### DIFF
--- a/cot/src/auth.rs
+++ b/cot/src/auth.rs
@@ -685,6 +685,50 @@ impl ToDbValue for PasswordHash {
     }
 }
 
+#[cfg(feature = "db")]
+impl FromDbValue for Option<PasswordHash> {
+    #[cfg(feature = "sqlite")]
+    fn from_sqlite(value: crate::db::impl_sqlite::SqliteValueRef<'_>) -> cot::db::Result<Self> {
+        value
+            .get::<Option<String>>()
+            .map(|op_str| op_str.map(PasswordHash::new))?
+            .transpose()
+            .map_err(cot::db::DatabaseError::value_decode)
+    }
+
+    #[cfg(feature = "postgres")]
+    fn from_postgres(
+        value: crate::db::impl_postgres::PostgresValueRef<'_>,
+    ) -> cot::db::Result<Self> {
+        value
+            .get::<Option<String>>()
+            .map(|op_str| op_str.map(PasswordHash::new))?
+            .transpose()
+            .map_err(cot::db::DatabaseError::value_decode)
+    }
+
+    #[cfg(feature = "mysql")]
+    fn from_mysql(value: crate::db::impl_mysql::MySqlValueRef<'_>) -> crate::db::Result<Self>
+    where
+        Self: Sized,
+    {
+        value
+            .get::<Option<String>>()
+            .map(|op_str| op_str.map(PasswordHash::new))?
+            .transpose()
+            .map_err(cot::db::DatabaseError::value_decode)
+    }
+}
+
+impl ToDbValue for Option<PasswordHash> {
+    fn to_db_value(&self) -> DbValue {
+        match self {
+            Some(hash) => hash.to_db_value(),
+            None => <Option<String>>::None.to_db_value(),
+        }
+    }
+}
+
 /// Authentication helper structure.
 ///
 /// This is an object that provides methods to sign users in and out, by using

--- a/cot/src/auth.rs
+++ b/cot/src/auth.rs
@@ -720,6 +720,7 @@ impl FromDbValue for Option<PasswordHash> {
     }
 }
 
+#[cfg(feature = "db")]
 impl ToDbValue for Option<PasswordHash> {
     fn to_db_value(&self) -> DbValue {
         match self {

--- a/cot/src/common_types.rs
+++ b/cot/src/common_types.rs
@@ -430,7 +430,7 @@ impl FromDbValue for Option<Url> {
 
 impl ToDbValue for Option<Url> {
     fn to_db_value(&self) -> DbValue {
-        self.clone().map(|url| url.into_string()).into()
+        self.clone().map(Url::into_string).into()
     }
 }
 

--- a/cot/src/common_types.rs
+++ b/cot/src/common_types.rs
@@ -393,6 +393,47 @@ impl FromDbValue for Url {
     }
 }
 
+impl FromDbValue for Option<Url> {
+    fn from_sqlite(value: SqliteValueRef<'_>) -> cot::db::Result<Self>
+    where
+        Self: Sized,
+    {
+        value
+            .get::<Option<String>>()
+            .map(|opt_str| opt_str.map(Url::new))?
+            .transpose()
+            .map_err(cot::db::DatabaseError::value_decode)
+    }
+
+    fn from_postgres(value: PostgresValueRef<'_>) -> cot::db::Result<Self>
+    where
+        Self: Sized,
+    {
+        value
+            .get::<Option<String>>()
+            .map(|opt_str| opt_str.map(Url::new))?
+            .transpose()
+            .map_err(cot::db::DatabaseError::value_decode)
+    }
+
+    fn from_mysql(value: MySqlValueRef<'_>) -> cot::db::Result<Self>
+    where
+        Self: Sized,
+    {
+        value
+            .get::<Option<String>>()
+            .map(|opt_str| opt_str.map(Url::new))?
+            .transpose()
+            .map_err(cot::db::DatabaseError::value_decode)
+    }
+}
+
+impl ToDbValue for Option<Url> {
+    fn to_db_value(&self) -> DbValue {
+        self.clone().map(|url| url.into_string()).into()
+    }
+}
+
 #[cfg(feature = "db")]
 impl DatabaseField for Url {
     const TYPE: ColumnType = ColumnType::Text;
@@ -680,6 +721,49 @@ impl FromDbValue for Email {
         Self: Sized,
     {
         Email::new(value.get::<String>()?).map_err(cot::db::DatabaseError::value_decode)
+    }
+}
+
+#[cfg(feature = "db")]
+impl ToDbValue for Option<Email> {
+    fn to_db_value(&self) -> DbValue {
+        self.clone().map(|email| email.email()).into()
+    }
+}
+
+#[cfg(feature = "db")]
+impl FromDbValue for Option<Email> {
+    fn from_sqlite(value: SqliteValueRef<'_>) -> cot::db::Result<Self>
+    where
+        Self: Sized,
+    {
+        value
+            .get::<Option<String>>()
+            .map(|opt_str| opt_str.map(Email::new))?
+            .transpose()
+            .map_err(cot::db::DatabaseError::value_decode)
+    }
+
+    fn from_postgres(value: PostgresValueRef<'_>) -> cot::db::Result<Self>
+    where
+        Self: Sized,
+    {
+        value
+            .get::<Option<String>>()
+            .map(|opt_str| opt_str.map(Email::new))?
+            .transpose()
+            .map_err(cot::db::DatabaseError::value_decode)
+    }
+
+    fn from_mysql(value: MySqlValueRef<'_>) -> cot::db::Result<Self>
+    where
+        Self: Sized,
+    {
+        value
+            .get::<Option<String>>()
+            .map(|opt_str| opt_str.map(Email::new))?
+            .transpose()
+            .map_err(cot::db::DatabaseError::value_decode)
     }
 }
 

--- a/cot/src/common_types.rs
+++ b/cot/src/common_types.rs
@@ -393,7 +393,9 @@ impl FromDbValue for Url {
     }
 }
 
+#[cfg(feature = "db")]
 impl FromDbValue for Option<Url> {
+    #[cfg(feature = "sqlite")]
     fn from_sqlite(value: SqliteValueRef<'_>) -> cot::db::Result<Self>
     where
         Self: Sized,
@@ -405,6 +407,7 @@ impl FromDbValue for Option<Url> {
             .map_err(cot::db::DatabaseError::value_decode)
     }
 
+    #[cfg(feature = "postgres")]
     fn from_postgres(value: PostgresValueRef<'_>) -> cot::db::Result<Self>
     where
         Self: Sized,
@@ -416,6 +419,7 @@ impl FromDbValue for Option<Url> {
             .map_err(cot::db::DatabaseError::value_decode)
     }
 
+    #[cfg(feature = "mysql")]
     fn from_mysql(value: MySqlValueRef<'_>) -> cot::db::Result<Self>
     where
         Self: Sized,
@@ -428,6 +432,7 @@ impl FromDbValue for Option<Url> {
     }
 }
 
+#[cfg(feature = "db")]
 impl ToDbValue for Option<Url> {
     fn to_db_value(&self) -> DbValue {
         self.clone().map(Url::into_string).into()

--- a/cot/src/common_types.rs
+++ b/cot/src/common_types.rs
@@ -738,6 +738,7 @@ impl ToDbValue for Option<Email> {
 
 #[cfg(feature = "db")]
 impl FromDbValue for Option<Email> {
+    #[cfg(feature = "sqlite")]
     fn from_sqlite(value: SqliteValueRef<'_>) -> cot::db::Result<Self>
     where
         Self: Sized,
@@ -749,6 +750,7 @@ impl FromDbValue for Option<Email> {
             .map_err(cot::db::DatabaseError::value_decode)
     }
 
+    #[cfg(feature = "postgres")]
     fn from_postgres(value: PostgresValueRef<'_>) -> cot::db::Result<Self>
     where
         Self: Sized,
@@ -760,6 +762,7 @@ impl FromDbValue for Option<Email> {
             .map_err(cot::db::DatabaseError::value_decode)
     }
 
+    #[cfg(feature = "mysql")]
     fn from_mysql(value: MySqlValueRef<'_>) -> cot::db::Result<Self>
     where
         Self: Sized,

--- a/cot/src/db/fields.rs
+++ b/cot/src/db/fields.rs
@@ -499,7 +499,9 @@ mod tests {
 
     #[test]
     fn option_limited_string_is_nullable_string_field() {
-        assert!(<Option<LimitedString<255>> as DatabaseField>::NULLABLE);
+        const {
+            assert!(<Option<LimitedString<255>> as DatabaseField>::NULLABLE);
+        }
         assert_eq!(
             <Option<LimitedString<255>> as DatabaseField>::TYPE,
             ColumnType::String(255),

--- a/cot/src/db/fields.rs
+++ b/cot/src/db/fields.rs
@@ -300,6 +300,35 @@ impl<const LIMIT: u32> ToDbValue for Option<LimitedString<LIMIT>> {
     }
 }
 
+impl<const LIMIT: u32> FromDbValue for Option<LimitedString<LIMIT>> {
+    #[cfg(feature = "sqlite")]
+    fn from_sqlite(value: SqliteValueRef<'_>) -> Result<Self> {
+        value
+            .get::<Option<String>>()
+            .map(|opt_str| opt_str.map(LimitedString::new))?
+            .transpose()
+            .map_err(DatabaseError::value_decode)
+    }
+
+    #[cfg(feature = "postgres")]
+    fn from_postgres(value: PostgresValueRef<'_>) -> Result<Self> {
+        value
+            .get::<Option<String>>()
+            .map(|opt_str| opt_str.map(LimitedString::new))?
+            .transpose()
+            .map_err(DatabaseError::value_decode)
+    }
+
+    #[cfg(feature = "mysql")]
+    fn from_mysql(value: MySqlValueRef<'_>) -> Result<Self> {
+        value
+            .get::<Option<String>>()
+            .map(|opt_str| opt_str.map(LimitedString::new))?
+            .transpose()
+            .map_err(DatabaseError::value_decode)
+    }
+}
+
 impl<T: Model + Send + Sync> DatabaseField for ForeignKey<T> {
     const NULLABLE: bool = T::PrimaryKey::NULLABLE;
     const TYPE: ColumnType = T::PrimaryKey::TYPE;

--- a/cot/src/db/fields.rs
+++ b/cot/src/db/fields.rs
@@ -481,30 +481,3 @@ impl PrimaryKey for u32 {}
 impl PrimaryKey for u64 {}
 
 impl PrimaryKey for String {}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn assert_from_db_value<T: FromDbValue>() {}
-    fn assert_to_db_field_value<T: ToDbFieldValue>() {}
-    fn assert_database_field<T: DatabaseField>() {}
-
-    #[test]
-    fn option_limited_string_implements_field_traits() {
-        assert_from_db_value::<Option<LimitedString<255>>>();
-        assert_to_db_field_value::<Option<LimitedString<255>>>();
-        assert_database_field::<Option<LimitedString<255>>>();
-    }
-
-    #[test]
-    fn option_limited_string_is_nullable_string_field() {
-        const {
-            assert!(<Option<LimitedString<255>> as DatabaseField>::NULLABLE);
-        }
-        assert_eq!(
-            <Option<LimitedString<255>> as DatabaseField>::TYPE,
-            ColumnType::String(255),
-        );
-    }
-}

--- a/cot/src/db/fields.rs
+++ b/cot/src/db/fields.rs
@@ -481,3 +481,28 @@ impl PrimaryKey for u32 {}
 impl PrimaryKey for u64 {}
 
 impl PrimaryKey for String {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_from_db_value<T: FromDbValue>() {}
+    fn assert_to_db_field_value<T: ToDbFieldValue>() {}
+    fn assert_database_field<T: DatabaseField>() {}
+
+    #[test]
+    fn option_limited_string_implements_field_traits() {
+        assert_from_db_value::<Option<LimitedString<255>>>();
+        assert_to_db_field_value::<Option<LimitedString<255>>>();
+        assert_database_field::<Option<LimitedString<255>>>();
+    }
+
+    #[test]
+    fn option_limited_string_is_nullable_string_field() {
+        assert!(<Option<LimitedString<255>> as DatabaseField>::NULLABLE);
+        assert_eq!(
+            <Option<LimitedString<255>> as DatabaseField>::TYPE,
+            ColumnType::String(255),
+        );
+    }
+}

--- a/cot/tests/db.rs
+++ b/cot/tests/db.rs
@@ -383,9 +383,12 @@ async fn password_hash_field(db: &TestDatabase) {
 
     run_migrations!(db, CREATE_OPTIONAL_PASSWORD_HASH_MODEL);
 
+    let generated_password: String = Faker.fake_with_rng(&mut StdRng::from_os_rng());
     let mut with_password = OptionPasswordHashModel {
         id: Auto::auto(),
-        password: Some(PasswordHash::from_password(&Password::new("password123"))),
+        password: Some(PasswordHash::from_password(&Password::new(
+            &generated_password,
+        ))),
     };
     with_password.save(&**db).await.unwrap();
 

--- a/cot/tests/db.rs
+++ b/cot/tests/db.rs
@@ -51,18 +51,18 @@ impl Dummy<EmailFaker> for Email {
         let domain: String = (0..10)
             .map(|_| (0x61u8 + (rng.next_u32() % 26) as u8) as char)
             .collect();
-        Email::new(format!("{}@{}.com", username, domain)).expect("Generated email should be valid")
+        Email::new(format!("{username}@{domain}.com")).expect("Generated email should be valid")
     }
 }
 
 struct UrlFaker;
 
 impl Dummy<UrlFaker> for Url {
-    fn dummy_with_rng<R: RngExt + ?Sized>(config: &UrlFaker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_config: &UrlFaker, rng: &mut R) -> Self {
         let domain: String = (0..10)
             .map(|_| (0x61u8 + (rng.next_u32() % 26) as u8) as char)
             .collect();
-        Url::new(format!("https://{}.com", domain)).expect("Generated URL should be valid")
+        Url::new(format!("https://{domain}.com")).expect("Generated URL should be valid")
     }
 }
 

--- a/cot/tests/db.rs
+++ b/cot/tests/db.rs
@@ -363,6 +363,23 @@ async fn option_limited_string_field(db: &mut TestDatabase) {
     assert_eq!(models.len(), 2);
     assert!(models.contains(&with_name));
     assert!(models.contains(&without_name));
+
+    let with_name_from_db = query!(OptionalLimitedStringModel, $id == with_name.id)
+        .get(&**db)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        with_name_from_db.name,
+        Some(LimitedString::new("named").unwrap())
+    );
+
+    let without_name_from_db = query!(OptionalLimitedStringModel, $id == without_name.id)
+        .get(&**db)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(without_name_from_db.name, None);
 }
 
 #[cot_macros::dbtest]

--- a/cot/tests/db.rs
+++ b/cot/tests/db.rs
@@ -221,6 +221,7 @@ struct AllFieldsModel {
     field_blob: Vec<u8>,
     field_option: Option<String>,
     field_limited_string: LimitedString<10>,
+    field_option_limited_string: Option<LimitedString<10>>,
     #[dummy(faker = "WeekdaySetFaker")]
     field_weekday_set: chrono::WeekdaySet,
 }
@@ -254,6 +255,7 @@ const CREATE_ALL_FIELDS_MODEL: Operation = Operation::create_model()
         all_fields_migration_field!(blob, Vec<u8>),
         all_fields_migration_field!(option, Option<String>),
         all_fields_migration_field!(limited_string, LimitedString<10>),
+        all_fields_migration_field!(option_limited_string, Option<LimitedString<10>>),
         all_fields_migration_field!(weekday_set, chrono::WeekdaySet),
     ])
     .build();
@@ -313,6 +315,54 @@ macro_rules! run_migrations {
             .await
             .unwrap();
     };
+}
+
+#[cot_macros::dbtest]
+async fn option_limited_string_field(db: &mut TestDatabase) {
+    #[derive(Debug, Clone, PartialEq)]
+    #[model]
+    struct OptionalLimitedStringModel {
+        #[model(primary_key)]
+        id: Auto<i32>,
+        name: Option<LimitedString<10>>,
+    }
+
+    const CREATE_OPTIONAL_LIMITED_STRING_MODEL: Operation = Operation::create_model()
+        .table_name(Identifier::new("cot__optional_limited_string_model"))
+        .fields(&[
+            Field::new(Identifier::new("id"), <Auto<i32> as DatabaseField>::TYPE)
+                .primary_key()
+                .auto(),
+            Field::new(
+                Identifier::new("name"),
+                <Option<LimitedString<10>> as DatabaseField>::TYPE,
+            )
+            .set_null(<Option<LimitedString<10>> as DatabaseField>::NULLABLE),
+        ])
+        .build();
+
+    run_migrations!(db, CREATE_OPTIONAL_LIMITED_STRING_MODEL);
+
+    let mut with_name = OptionalLimitedStringModel {
+        id: Auto::auto(),
+        name: Some(LimitedString::new("named").unwrap()),
+    };
+    with_name.save(&**db).await.unwrap();
+
+    let mut without_name = OptionalLimitedStringModel {
+        id: Auto::auto(),
+        name: None,
+    };
+    without_name.save(&**db).await.unwrap();
+
+    let models = OptionalLimitedStringModel::objects()
+        .all(&**db)
+        .await
+        .unwrap();
+
+    assert_eq!(models.len(), 2);
+    assert!(models.contains(&with_name));
+    assert!(models.contains(&without_name));
 }
 
 #[cot_macros::dbtest]

--- a/cot/tests/db.rs
+++ b/cot/tests/db.rs
@@ -1,6 +1,8 @@
 #![cfg(feature = "fake")]
 #![cfg_attr(miri, ignore)]
 
+use cot::auth::PasswordHash;
+use cot::common_types::{Email, Password, Url};
 use cot::db::migrations::{Field, Operation};
 use cot::db::query::ExprEq;
 use cot::db::{
@@ -36,6 +38,31 @@ impl Dummy<WeekdaySetFaker> for chrono::WeekdaySet {
         }
 
         set
+    }
+}
+
+struct EmailFaker;
+
+impl Dummy<EmailFaker> for Email {
+    fn dummy_with_rng<R: fake::rand::Rng + ?Sized>(_: &EmailFaker, rng: &mut R) -> Self {
+        let username: String = (0..10)
+            .map(|_| (0x61u8 + (rng.next_u32() % 26) as u8) as char)
+            .collect();
+        let domain: String = (0..10)
+            .map(|_| (0x61u8 + (rng.next_u32() % 26) as u8) as char)
+            .collect();
+        Email::new(format!("{}@{}.com", username, domain)).expect("Generated email should be valid")
+    }
+}
+
+struct UrlFaker;
+
+impl Dummy<UrlFaker> for Url {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &UrlFaker, rng: &mut R) -> Self {
+        let domain: String = (0..10)
+            .map(|_| (0x61u8 + (rng.next_u32() % 26) as u8) as char)
+            .collect();
+        Url::new(format!("https://{}.com", domain)).expect("Generated URL should be valid")
     }
 }
 
@@ -224,6 +251,14 @@ struct AllFieldsModel {
     field_option_limited_string: Option<LimitedString<10>>,
     #[dummy(faker = "WeekdaySetFaker")]
     field_weekday_set: chrono::WeekdaySet,
+    #[dummy(faker = "EmailFaker")]
+    field_email: Email,
+    #[dummy(faker = "EmailFaker")]
+    field_option_email: Option<Email>,
+    #[dummy(faker = "UrlFaker")]
+    field_url: Url,
+    #[dummy(faker = "UrlFaker")]
+    field_option_url: Option<Url>,
 }
 
 async fn migrate_all_fields_model(db: &Database) {
@@ -257,6 +292,11 @@ const CREATE_ALL_FIELDS_MODEL: Operation = Operation::create_model()
         all_fields_migration_field!(limited_string, LimitedString<10>),
         all_fields_migration_field!(option_limited_string, Option<LimitedString<10>>),
         all_fields_migration_field!(weekday_set, chrono::WeekdaySet),
+        all_fields_migration_field!(email, Email),
+        all_fields_migration_field!(option_email, Option<Email>),
+        all_fields_migration_field!(url, Url),
+        all_fields_migration_field!(option_url, Option<Url>),
+        all_fields_migration_field!(option_password_hash, Option<PasswordHash>),
     ])
     .build();
 
@@ -318,68 +358,46 @@ macro_rules! run_migrations {
 }
 
 #[cot_macros::dbtest]
-async fn option_limited_string_field(db: &mut TestDatabase) {
-    #[derive(Debug, Clone, PartialEq)]
+async fn password_hash_field(db: &TestDatabase) {
+    #[derive(Debug, Clone)]
     #[model]
-    struct OptionalLimitedStringModel {
+    struct OptionPasswordHashModel {
         #[model(primary_key)]
         id: Auto<i32>,
-        name: Option<LimitedString<10>>,
+        password: Option<PasswordHash>,
     }
 
-    const CREATE_OPTIONAL_LIMITED_STRING_MODEL: Operation = Operation::create_model()
-        .table_name(Identifier::new("cot__optional_limited_string_model"))
+    const CREATE_OPTIONAL_PASSWORD_HASH_MODEL: Operation = Operation::create_model()
+        .table_name(Identifier::new("cot__option_password_hash_model"))
         .fields(&[
             Field::new(Identifier::new("id"), <Auto<i32> as DatabaseField>::TYPE)
                 .primary_key()
                 .auto(),
             Field::new(
-                Identifier::new("name"),
-                <Option<LimitedString<10>> as DatabaseField>::TYPE,
+                Identifier::new("password"),
+                <Option<PasswordHash> as DatabaseField>::TYPE,
             )
-            .set_null(<Option<LimitedString<10>> as DatabaseField>::NULLABLE),
+            .set_null(<Option<PasswordHash> as DatabaseField>::NULLABLE),
         ])
         .build();
 
-    run_migrations!(db, CREATE_OPTIONAL_LIMITED_STRING_MODEL);
+    run_migrations!(db, CREATE_OPTIONAL_PASSWORD_HASH_MODEL);
 
-    let mut with_name = OptionalLimitedStringModel {
+    let mut with_password = OptionPasswordHashModel {
         id: Auto::auto(),
-        name: Some(LimitedString::new("named").unwrap()),
+        password: Some(PasswordHash::from_password(&Password::new("password123"))),
     };
-    with_name.save(&**db).await.unwrap();
+    with_password.save(&**db).await.unwrap();
 
-    let mut without_name = OptionalLimitedStringModel {
+    let mut without_password = OptionPasswordHashModel {
         id: Auto::auto(),
-        name: None,
+        password: None,
     };
-    without_name.save(&**db).await.unwrap();
+    without_password.save(&**db).await.unwrap();
 
-    let models = OptionalLimitedStringModel::objects()
-        .all(&**db)
-        .await
-        .unwrap();
+    let models = OptionPasswordHashModel::objects().all(&**db).await.unwrap();
 
     assert_eq!(models.len(), 2);
-    assert!(models.contains(&with_name));
-    assert!(models.contains(&without_name));
-
-    let with_name_from_db = query!(OptionalLimitedStringModel, $id == with_name.id)
-        .get(&**db)
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(
-        with_name_from_db.name,
-        Some(LimitedString::new("named").unwrap())
-    );
-
-    let without_name_from_db = query!(OptionalLimitedStringModel, $id == without_name.id)
-        .get(&**db)
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(without_name_from_db.name, None);
 }
 
 #[cot_macros::dbtest]

--- a/cot/tests/db.rs
+++ b/cot/tests/db.rs
@@ -361,14 +361,55 @@ macro_rules! run_migrations {
 async fn password_hash_field(db: &TestDatabase) {
     #[derive(Debug, Clone)]
     #[model]
-    struct OptionPasswordHashModel {
+    struct PasswordHashModel {
+        #[model(primary_key)]
+        id: Auto<i32>,
+        password: PasswordHash,
+    }
+
+    const CREATE_OPTIONAL_PASSWORD_HASH_MODEL: Operation = Operation::create_model()
+        .table_name(Identifier::new("cot__password_hash_model"))
+        .fields(&[
+            Field::new(Identifier::new("id"), <Auto<i32> as DatabaseField>::TYPE)
+                .primary_key()
+                .auto(),
+            Field::new(
+                Identifier::new("password"),
+                <PasswordHash as DatabaseField>::TYPE,
+            ),
+        ])
+        .build();
+
+    run_migrations!(db, CREATE_OPTIONAL_PASSWORD_HASH_MODEL);
+
+    let generated_password: String = Faker.fake();
+    let mut password_model = PasswordHashModel {
+        id: Auto::auto(),
+        password: PasswordHash::from_password(&Password::new(&generated_password)),
+    };
+    password_model.save(&**db).await.unwrap();
+
+    let models = PasswordHashModel::objects().all(&**db).await.unwrap();
+
+    assert_eq!(models.len(), 1);
+    assert_eq!(
+        models[0].password.as_str(),
+        password_model.password.as_str()
+    );
+}
+
+#[cot_macros::dbtest]
+async fn password_hash_option(db: &TestDatabase) {
+    #[derive(Debug, Clone)]
+    #[model]
+    struct PasswordHashModel {
         #[model(primary_key)]
         id: Auto<i32>,
         password: Option<PasswordHash>,
     }
 
     const CREATE_OPTIONAL_PASSWORD_HASH_MODEL: Operation = Operation::create_model()
-        .table_name(Identifier::new("cot__option_password_hash_model"))
+        .table_name(Identifier::new("cot__password_hash_model"))
         .fields(&[
             Field::new(Identifier::new("id"), <Auto<i32> as DatabaseField>::TYPE)
                 .primary_key()
@@ -384,7 +425,7 @@ async fn password_hash_field(db: &TestDatabase) {
     run_migrations!(db, CREATE_OPTIONAL_PASSWORD_HASH_MODEL);
 
     let generated_password: String = Faker.fake();
-    let mut with_password = OptionPasswordHashModel {
+    let mut with_password = PasswordHashModel {
         id: Auto::auto(),
         password: Some(PasswordHash::from_password(&Password::new(
             &generated_password,
@@ -392,15 +433,20 @@ async fn password_hash_field(db: &TestDatabase) {
     };
     with_password.save(&**db).await.unwrap();
 
-    let mut without_password = OptionPasswordHashModel {
+    let mut without_password = PasswordHashModel {
         id: Auto::auto(),
         password: None,
     };
     without_password.save(&**db).await.unwrap();
 
-    let models = OptionPasswordHashModel::objects().all(&**db).await.unwrap();
+    let models = PasswordHashModel::objects().all(&**db).await.unwrap();
 
     assert_eq!(models.len(), 2);
+    assert_eq!(
+        models[0].password.as_ref().unwrap().as_str(),
+        with_password.password.as_ref().unwrap().as_str()
+    );
+    assert!(models[1].password.is_none());
 }
 
 #[cot_macros::dbtest]

--- a/cot/tests/db.rs
+++ b/cot/tests/db.rs
@@ -383,7 +383,7 @@ async fn password_hash_field(db: &TestDatabase) {
 
     run_migrations!(db, CREATE_OPTIONAL_PASSWORD_HASH_MODEL);
 
-    let generated_password: String = Faker.fake_with_rng(&mut StdRng::from_os_rng());
+    let generated_password: String = Faker.fake();
     let mut with_password = OptionPasswordHashModel {
         id: Auto::auto(),
         password: Some(PasswordHash::from_password(&Password::new(


### PR DESCRIPTION
## Description

Fixes the error below as a result of having an `Option<LimitedString<u32>>` in a model:

```rust
#[derive(Debug, Clone)
#[model]
Struct Foo {
    name: Option<LimitedString<255>>
}
```

Error:
```
error[E0277]: the trait bound `std::option::Option<LimitedString<255>>: FromDbValue` is not satisfied
   --> src/main.rs:16:18
    |
  7 | #[model]
    | -------- required by a bound introduced by this call
...
 16 |     name:  Option<LimitedString<255>>,
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromDbValue` is not implemented for `std::option::Option<LimitedString<512>>`
    |
    = help: the following other types implement trait `FromDbValue`:
              std::option::Option<ForeignKey<T>>
              std::option::Option<NaiveDate>
              std::option::Option<NaiveDateTime>
              std::option::Option<NaiveTime>
              std::option::Option<Vec<u8>>
              std::option::Option<WeekdaySet>
              std::option::Option<bool>
              std::option::Option<chrono::DateTime<FixedOffset>>
            and 14 others
note: required by a bound in `Row::get`
   --> /Users/eli/Documents/work/cot/cot/cot/src/db.rs:450:19
    |
450 |     pub fn get<T: FromDbValue>(&self, index: usize) -> Result<T> {
    |                   ^^^^^^^^^^^ required by this bound in `Row::get`

```


## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Other (describe above)

