### PR TITLE
docs: add DeepWiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@
 [![Rust Build Status](https://github.com/cot-rs/cot/workflows/Rust%20CI/badge.svg)](https://github.com/cot-rs/cot/actions/workflows/rust.yml)
 [![codecov](https://codecov.io/gh/cot-rs/cot/branch/master/graph/badge.svg)](https://codecov.io/gh/cot-rs/cot)
 [![crates.io](https://img.shields.io/crates/v/cot.svg)](https://crates.io/crates/cot)
-[![Guide](https://img.shields.io/website?url=https%3A%2F%2Fcot.rs%2Fguide%2Flatest%2F&label=guide&up_message=online)](https://cot.rs/guide/latest/)
-[![Documentation](https://docs.rs/cot/badge.svg)](https://docs.rs/cot)
 <br>
 [![Discord chat](https://img.shields.io/discord/1330137289287925781?logo=Discord&logoColor=white)](https://discord.cot.rs)
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/cot-rs?label=GitHub%20sponsors)](https://github.com/sponsors/cot-rs)
 [![Open Collective backers](https://img.shields.io/opencollective/backers/cot?label=Open%20Collective%20backers)](https://opencollective.com/cot)
+<br>
+[![Guide](https://img.shields.io/website?url=https%3A%2F%2Fcot.rs%2Fguide%2Flatest%2F&label=guide&up_message=online)](https://cot.rs/guide/latest/)
+[![Documentation](https://docs.rs/cot/badge.svg)](https://docs.rs/cot)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/cot-rs/cot)
 </div>
 
 Cot is an easy to use, modern, and fast web framework for Rust. It has been designed to be familiar if you've ever


### PR DESCRIPTION
## Description

This is to prompt DeepWiki to automatically update their AI-generated docs. I think it's never too many resources that users can use, and it's actually pretty neat from what I looked: https://deepwiki.com/cot-rs/cot

I moved the guide and docs badges to separate line with DeepWiki to group all learning-resources in one place.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Other (describe above)
