### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/cot-rs/cot/compare/cot-v0.6.0...cot-v0.7.0) - 2026-07-11
+
+[View diff on diff.rs](https://diff.rs/cot/0.6.0/cot/0.7.0/Cargo.toml)
+
+### New features
+
+- [**breaking**] Expose `on_delete` and `on_update` fields for ForeignKey field ([#576](https://github.com/cot-rs/cot/pull/576)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
+- [**breaking**] Implement `Serialize`, `Deserialize`, and `JsonSchema` implementations for cot internal types ([#575](https://github.com/cot-rs/cot/pull/575)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
+- [**breaking**] More form attributes ([#352](https://github.com/cot-rs/cot/pull/352)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
+- Implement DbField for Bytes ([#596](https://github.com/cot-rs/cot/pull/596)) (by [@firas-yangui](https://github.com/firas-yangui))
+- Support custom cache and email in TestRequestBuilder ([#582](https://github.com/cot-rs/cot/pull/582)) (by [@m4tx](https://github.com/m4tx))
+- Add `set_username` and `set_password` to `DatabaseUser` ([#579](https://github.com/cot-rs/cot/pull/579)) (by [@m4tx](https://github.com/m4tx))
+- Implement `From<DbFieldValue>` for Non primitive types ([#562](https://github.com/cot-rs/cot/pull/562)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
+- Add tests for guide code snippets ([#552](https://github.com/cot-rs/cot/pull/552)) (by [@m4tx](https://github.com/m4tx))
+- Derive `Ord` and `PartialOrd` for `Auto` ([#544](https://github.com/cot-rs/cot/pull/544)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
+- Allow accessing extra config ([#518](https://github.com/cot-rs/cot/pull/518)) (by [@m4tx](https://github.com/m4tx))
+- Use securer_string for more secure Password and SecretKey ([#328](https://github.com/cot-rs/cot/pull/328)) (by [@eibrahim95](https://github.com/eibrahim95))
+
+### Fixes
+
+- Normalize route paths with a leading slash ([#591](https://github.com/cot-rs/cot/pull/591)) (by [@firas-yangui](https://github.com/firas-yangui))
+- Non-ASCII URLs can be properly routed now ([#561](https://github.com/cot-rs/cot/pull/561)) (by [@m4tx](https://github.com/m4tx))
+- Place correct contributing guide link ([#557](https://github.com/cot-rs/cot/pull/557)) (by [@kingazm](https://github.com/kingazm))
+
+### Other
+
+- Update Star History chart links with tokens ([#606](https://github.com/cot-rs/cot/pull/606)) (by [@seqre](https://github.com/seqre))
+- *(deps)* Bump all dependencies; bump MSRV to 1.92 ([#592](https://github.com/cot-rs/cot/pull/592)) (by [@m4tx](https://github.com/m4tx))
+- *(deps)* Bump sea-query from 0.32.7 to 1.0.1 ([#585](https://github.com/cot-rs/cot/pull/585)) (by [@dependabot[bot]](https://github.com/dependabot[bot]))
+- Add index route to JSON example ([#572](https://github.com/cot-rs/cot/pull/572)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
+- Add DeepWiki badge ([#568](https://github.com/cot-rs/cot/pull/568)) (by [@seqre](https://github.com/seqre))
+- Fix clippy errors ([#560](https://github.com/cot-rs/cot/pull/560)) (by [@m4tx](https://github.com/m4tx))
+- Add query macro docs ([#543](https://github.com/cot-rs/cot/pull/543)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
+- *(deps)* Remove chumsky ([#538](https://github.com/cot-rs/cot/pull/538)) (by [@m4tx](https://github.com/m4tx))
+- *(deps)* Use `grass_compiler` directly ([#537](https://github.com/cot-rs/cot/pull/537)) (by [@m4tx](https://github.com/m4tx))
+- *(deps)* Bump fake from 4.4.0 to 5.1.0 ([#533](https://github.com/cot-rs/cot/pull/533)) (by [@dependabot[bot]](https://github.com/dependabot[bot]))
+
 ## [0.6.0](https://github.com/cot-rs/cot/compare/cot-v0.5.0...cot-v0.6.0) - 2026-03-18
 
 [View diff on diff.rs](https://diff.rs/cot/0.5.0/cot/0.6.0/Cargo.toml)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "cot"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "aide",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "cot-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "cot_codegen"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "darling 0.23.0",
  "heck",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "cot_core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "askama",
  "async-stream",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "cot_macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "askama_derive",
  "cot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,11 +83,11 @@ clap-verbosity-flag = { version = "3", default-features = false }
 clap_complete = "4"
 clap_mangen = "0.3.0"
 comrak = { version = "0.52", default-features = false }
-cot = { version = "0.6.0", path = "cot" }
-cot-cli = { version = "0.6.0", path = "cot-cli" }
-cot_codegen = { version = "0.6.0", path = "cot-codegen" }
-cot_core = { version = "0.6.0", path = "cot-core" }
-cot_macros = { version = "0.6.0", path = "cot-macros" }
+cot = { version = "0.7.0", path = "cot" }
+cot-cli = { version = "0.7.0", path = "cot-cli" }
+cot_codegen = { version = "0.7.0", path = "cot-codegen" }
+cot_core = { version = "0.7.0", path = "cot-core" }
+cot_macros = { version = "0.7.0", path = "cot-macros" }
 criterion = "0.8"
 darling = "0.23"
 deadpool-redis = { version = "0.23", default-features = false }

--- a/cot-cli/CHANGELOG.md
+++ b/cot-cli/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/cot-rs/cot/compare/cot-cli-v0.6.0...cot-cli-v0.7.0) - 2026-07-11
+
+[View diff on diff.rs](https://diff.rs/cot-cli/0.6.0/cot-cli/0.7.0/Cargo.toml)
+
+### New features
+
+- [**breaking**] Expose `on_delete` and `on_update` fields for ForeignKey field ([#576](https://github.com/cot-rs/cot/pull/576)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
+- [**breaking**] More form attributes ([#352](https://github.com/cot-rs/cot/pull/352)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
+
+### Fixes
+
+- Place correct contributing guide link ([#557](https://github.com/cot-rs/cot/pull/557)) (by [@kingazm](https://github.com/kingazm))
+
+### Other
+
+- Update Star History chart links with tokens ([#606](https://github.com/cot-rs/cot/pull/606)) (by [@seqre](https://github.com/seqre))
+- *(deps)* Bump the dependencies group across 1 directory with 7 updates ([#602](https://github.com/cot-rs/cot/pull/602)) (by [@dependabot[bot]](https://github.com/dependabot[bot]))
+- *(deps)* Bump all dependencies; bump MSRV to 1.92 ([#592](https://github.com/cot-rs/cot/pull/592)) (by [@m4tx](https://github.com/m4tx))
+- Add DeepWiki badge ([#568](https://github.com/cot-rs/cot/pull/568)) (by [@seqre](https://github.com/seqre))
+- *(deps)* Bump the dependencies group with 11 updates ([#564](https://github.com/cot-rs/cot/pull/564)) (by [@dependabot[bot]](https://github.com/dependabot[bot]))
+- *(deps)* Remove chumsky ([#538](https://github.com/cot-rs/cot/pull/538)) (by [@m4tx](https://github.com/m4tx))
+
 ## [0.6.0](https://github.com/cot-rs/cot/compare/cot-cli-v0.5.0...cot-cli-v0.6.0) - 2026-03-18
 
 [View diff on diff.rs](https://diff.rs/cot-cli/0.5.0/cot-cli/0.6.0/Cargo.toml)

--- a/cot-cli/Cargo.toml
+++ b/cot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cot-cli"
-version = "0.6.0"
+version = "0.7.0"
 description = "Command-line interface for the Cot web framework"
 categories = ["command-line-utilities", "web-programming"]
 edition.workspace = true

--- a/cot-codegen/Cargo.toml
+++ b/cot-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cot_codegen"
-version = "0.6.0"
+version = "0.7.0"
 description = "The Rust web framework for lazy developers - code generation utils."
 edition.workspace = true
 rust-version.workspace = true

--- a/cot-core/Cargo.toml
+++ b/cot-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cot_core"
-version = "0.6.0"
+version = "0.7.0"
 description = "The Rust web framework for lazy developers - framework core."
 categories = ["web-programming", "web-programming::http-server", "network-programming"]
 edition.workspace = true

--- a/cot-macros/Cargo.toml
+++ b/cot-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cot_macros"
-version = "0.6.0"
+version = "0.7.0"
 description = "The Rust web framework for lazy developers - macros."
 edition.workspace = true
 rust-version.workspace = true

--- a/cot/Cargo.toml
+++ b/cot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cot"
-version = "0.6.0"
+version = "0.7.0"
 description = "The Rust web framework for lazy developers."
 categories = ["web-programming", "web-programming::http-server", "network-programming"]
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `cot_codegen`: 0.6.0 -> 0.7.0 (⚠ API breaking changes)
* `cot_macros`: 0.6.0 -> 0.7.0
* `cot_core`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `cot`: 0.6.0 -> 0.7.0 (⚠ API breaking changes)
* `cot-cli`: 0.6.0 -> 0.7.0 (✓ API compatible changes)

### ⚠ `cot_codegen` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field FieldOpts.field_name in /tmp/.tmpaFsR0b/cot/cot-codegen/src/model.rs:217
  field FieldOpts.foreign_key in /tmp/.tmpaFsR0b/cot/cot-codegen/src/model.rs:218
  field ForeignKeySpec.on_delete in /tmp/.tmpaFsR0b/cot/cot-codegen/src/model.rs:408
  field ForeignKeySpec.on_update in /tmp/.tmpaFsR0b/cot/cot-codegen/src/model.rs:409
```

### ⚠ `cot` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type SqliteValueRef is no longer Send, in /tmp/.tmpaFsR0b/cot/cot/src/db/impl_sqlite.rs:7
  type SqliteValueRef is no longer Sync, in /tmp/.tmpaFsR0b/cot/cot/src/db/impl_sqlite.rs:7
  type SqliteValueRef is no longer UnwindSafe, in /tmp/.tmpaFsR0b/cot/cot/src/db/impl_sqlite.rs:7
  type SqliteValueRef is no longer RefUnwindSafe, in /tmp/.tmpaFsR0b/cot/cot/src/db/impl_sqlite.rs:7
  type SqliteRow is no longer RefUnwindSafe, in /tmp/.tmpaFsR0b/cot/cot/src/db/impl_sqlite.rs:7
  type Row is no longer RefUnwindSafe, in /tmp/.tmpaFsR0b/cot/cot/src/db.rs:826

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type EmailFieldOptions no longer derives Copy, in /tmp/.tmpaFsR0b/cot/cot/src/form/fields.rs:420
  type ProjectConfig no longer derives PartialEq, in /tmp/.tmpaFsR0b/cot/cot/src/config.rs:41
  type ProjectConfig no longer derives Eq, in /tmp/.tmpaFsR0b/cot/cot/src/config.rs:41
  type StringFieldOptions no longer derives Copy, in /tmp/.tmpaFsR0b/cot/cot/src/form/fields.rs:162
  type PasswordFieldOptions no longer derives Copy, in /tmp/.tmpaFsR0b/cot/cot/src/form/fields.rs:305
  type IntegerFieldOptions no longer derives Copy, in /tmp/.tmpaFsR0b/cot/cot/src/form/fields.rs:566
  type FloatFieldOptions no longer derives Copy, in /tmp/.tmpaFsR0b/cot/cot/src/form/fields.rs:953
  type UrlFieldOptions no longer derives Copy, in /tmp/.tmpaFsR0b/cot/cot/src/form/fields.rs:1105

--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum Step in /tmp/.tmpaFsR0b/cot/cot/src/form/fields/attrs.rs:10

--- failure struct_marked_non_exhaustive: struct marked #[non_exhaustive] ---

Description:
A public struct has been marked #[non_exhaustive], which will prevent it from being constructed using a struct literal outside of its crate. It previously had no private fields, so a struct literal could be used to construct it outside its crate.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_marked_non_exhaustive.ron

Failed in:
  struct FileFieldOptions in /tmp/.tmpaFsR0b/cot/cot/src/form/fields/files.rs:61
  struct PasswordFieldOptions in /tmp/.tmpaFsR0b/cot/cot/src/form/fields.rs:305
  struct SelectFieldOptions in /tmp/.tmpaFsR0b/cot/cot/src/form/fields/select.rs:192
  struct FloatFieldOptions in /tmp/.tmpaFsR0b/cot/cot/src/form/fields.rs:953
  struct DateFieldOptions in /tmp/.tmpaFsR0b/cot/cot/src/form/fields/chrono.rs:611
  struct UrlFieldOptions in /tmp/.tmpaFsR0b/cot/cot/src/form/fields.rs:1105
  struct TimeFieldOptions in /tmp/.tmpaFsR0b/cot/cot/src/form/fields/chrono.rs:487
  struct FormFieldOptions in /tmp/.tmpaFsR0b/cot/cot/src/form.rs:515
  struct StringFieldOptions in /tmp/.tmpaFsR0b/cot/cot/src/form/fields.rs:162
  struct DateTimeWithTimezoneFieldOptions in /tmp/.tmpaFsR0b/cot/cot/src/form/fields/chrono.rs:299
  struct IntegerFieldOptions in /tmp/.tmpaFsR0b/cot/cot/src/form/fields.rs:566
  struct SelectMultipleFieldOptions in /tmp/.tmpaFsR0b/cot/cot/src/form/fields/select.rs:293
  struct EmailFieldOptions in /tmp/.tmpaFsR0b/cot/cot/src/form/fields.rs:420
  struct DateTimeFieldOptions in /tmp/.tmpaFsR0b/cot/cot/src/form/fields/chrono.rs:152
  struct BoolFieldOptions in /tmp/.tmpaFsR0b/cot/cot/src/form/fields.rs:765

--- failure unit_struct_changed_kind: unit struct changed kind ---

Description:
A public unit struct has been changed to a normal (curly-braces) struct, which cannot be constructed using the same struct literal syntax.
        ref: https://github.com/rust-lang/cargo/pull/10871
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/unit_struct_changed_kind.ron

Failed in:
  struct UrlFieldOptions in /tmp/.tmpaFsR0b/cot/cot/src/form/fields.rs:1105
```

<details><summary><i><b>Changelog</b></i></summary><p>




## `cot`

<blockquote>

## [0.7.0](https://github.com/cot-rs/cot/compare/cot-v0.6.0...cot-v0.7.0) - 2026-07-11

[View diff on diff.rs](https://diff.rs/cot/0.6.0/cot/0.7.0/Cargo.toml)

### New features

- [**breaking**] Expose `on_delete` and `on_update` fields for ForeignKey field ([#576](https://github.com/cot-rs/cot/pull/576)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
- [**breaking**] Implement `Serialize`, `Deserialize`, and `JsonSchema` implementations for cot internal types ([#575](https://github.com/cot-rs/cot/pull/575)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
- [**breaking**] More form attributes ([#352](https://github.com/cot-rs/cot/pull/352)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
- Implement DbField for Bytes ([#596](https://github.com/cot-rs/cot/pull/596)) (by [@firas-yangui](https://github.com/firas-yangui))
- Support custom cache and email in TestRequestBuilder ([#582](https://github.com/cot-rs/cot/pull/582)) (by [@m4tx](https://github.com/m4tx))
- Add `set_username` and `set_password` to `DatabaseUser` ([#579](https://github.com/cot-rs/cot/pull/579)) (by [@m4tx](https://github.com/m4tx))
- Implement `From<DbFieldValue>` for Non primitive types ([#562](https://github.com/cot-rs/cot/pull/562)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
- Add tests for guide code snippets ([#552](https://github.com/cot-rs/cot/pull/552)) (by [@m4tx](https://github.com/m4tx))
- Derive `Ord` and `PartialOrd` for `Auto` ([#544](https://github.com/cot-rs/cot/pull/544)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
- Allow accessing extra config ([#518](https://github.com/cot-rs/cot/pull/518)) (by [@m4tx](https://github.com/m4tx))
- Use securer_string for more secure Password and SecretKey ([#328](https://github.com/cot-rs/cot/pull/328)) (by [@eibrahim95](https://github.com/eibrahim95))

### Fixes

- Normalize route paths with a leading slash ([#591](https://github.com/cot-rs/cot/pull/591)) (by [@firas-yangui](https://github.com/firas-yangui))
- Non-ASCII URLs can be properly routed now ([#561](https://github.com/cot-rs/cot/pull/561)) (by [@m4tx](https://github.com/m4tx))
- Place correct contributing guide link ([#557](https://github.com/cot-rs/cot/pull/557)) (by [@kingazm](https://github.com/kingazm))

### Other

- Update Star History chart links with tokens ([#606](https://github.com/cot-rs/cot/pull/606)) (by [@seqre](https://github.com/seqre))
- *(deps)* Bump all dependencies; bump MSRV to 1.92 ([#592](https://github.com/cot-rs/cot/pull/592)) (by [@m4tx](https://github.com/m4tx))
- *(deps)* Bump sea-query from 0.32.7 to 1.0.1 ([#585](https://github.com/cot-rs/cot/pull/585)) (by [@dependabot[bot]](https://github.com/dependabot[bot]))
- Add index route to JSON example ([#572](https://github.com/cot-rs/cot/pull/572)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
- Add DeepWiki badge ([#568](https://github.com/cot-rs/cot/pull/568)) (by [@seqre](https://github.com/seqre))
- Fix clippy errors ([#560](https://github.com/cot-rs/cot/pull/560)) (by [@m4tx](https://github.com/m4tx))
- Add query macro docs ([#543](https://github.com/cot-rs/cot/pull/543)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
- *(deps)* Remove chumsky ([#538](https://github.com/cot-rs/cot/pull/538)) (by [@m4tx](https://github.com/m4tx))
- *(deps)* Use `grass_compiler` directly ([#537](https://github.com/cot-rs/cot/pull/537)) (by [@m4tx](https://github.com/m4tx))
- *(deps)* Bump fake from 4.4.0 to 5.1.0 ([#533](https://github.com/cot-rs/cot/pull/533)) (by [@dependabot[bot]](https://github.com/dependabot[bot]))
</blockquote>

## `cot-cli`

<blockquote>

## [0.7.0](https://github.com/cot-rs/cot/compare/cot-cli-v0.6.0...cot-cli-v0.7.0) - 2026-07-11

[View diff on diff.rs](https://diff.rs/cot-cli/0.6.0/cot-cli/0.7.0/Cargo.toml)

### New features

- [**breaking**] Expose `on_delete` and `on_update` fields for ForeignKey field ([#576](https://github.com/cot-rs/cot/pull/576)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
- [**breaking**] More form attributes ([#352](https://github.com/cot-rs/cot/pull/352)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))

### Fixes

- Place correct contributing guide link ([#557](https://github.com/cot-rs/cot/pull/557)) (by [@kingazm](https://github.com/kingazm))

### Other

- Update Star History chart links with tokens ([#606](https://github.com/cot-rs/cot/pull/606)) (by [@seqre](https://github.com/seqre))
- *(deps)* Bump the dependencies group across 1 directory with 7 updates ([#602](https://github.com/cot-rs/cot/pull/602)) (by [@dependabot[bot]](https://github.com/dependabot[bot]))
- *(deps)* Bump all dependencies; bump MSRV to 1.92 ([#592](https://github.com/cot-rs/cot/pull/592)) (by [@m4tx](https://github.com/m4tx))
- Add DeepWiki badge ([#568](https://github.com/cot-rs/cot/pull/568)) (by [@seqre](https://github.com/seqre))
- *(deps)* Bump the dependencies group with 11 updates ([#564](https://github.com/cot-rs/cot/pull/564)) (by [@dependabot[bot]](https://github.com/dependabot[bot]))
- *(deps)* Remove chumsky ([#538](https://github.com/cot-rs/cot/pull/538)) (by [@m4tx](https://github.com/m4tx))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).