### PR TITLE
fix: handle non conventional commits

### DIFF
--- a/.cargo/release-plz.toml
+++ b/.cargo/release-plz.toml
@@ -37,12 +37,12 @@ body = """
 {% for group, group_commits in commits | filter(attribute="remote.pr_number") | sort(attribute="remote.pr_number") | reverse | group_by(attribute="group") %}
 ### {{ group | striptags | trim | upper_first }}
 
-    {% for commit in group_commits | sort(attribute="breaking") | reverse %}
-        {%- if commit.scope -%}
-            - {% if commit.breaking %}[**breaking**] {% endif %}*({{commit.scope}})* \
-                {{ commit.message | upper_first }}{{ self::username(commit=commit) }}
-        {% else -%}
-            - {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}{{ self::username(commit=commit) }}
+    {% for commit in group_commits %}
+        {%- if commit.breaking -%}{{ self::commit_line(commit=commit) }}
+        {% endif -%}
+    {% endfor -%}
+    {% for commit in group_commits %}
+        {%- if not commit.breaking -%}{{ self::commit_line(commit=commit) }}
         {% endif -%}
     {% endfor -%}
 {% endfor %}
@@ -54,6 +54,15 @@ body = """
 {%- macro username(commit) -%}
     {% if commit.remote.username %} (by [@{{ commit.remote.username }}](https://github.com/{{ commit.remote.username }})){% endif -%}
 {% endmacro -%}
+{%- macro commit_line(commit) -%}
+- {% if commit.breaking %}
+    [**breaking**]
+  {% endif %}
+  {% if commit.scope %}
+    *({{commit.scope}})*
+  {% endif %}
+  {{ commit.message | upper_first }}{{ self::username(commit=commit) }}
+{%- endmacro -%}
 """
 
 protect_breaking_commits = true


### PR DESCRIPTION
## Related issue or discussion

https://github.com/cot-rs/cot/actions/runs/25354016140/job/74339428585#step:5:372

## Description

If a commit didn't follow the conventional commits format, the `sort(attribute="breaking")` Tera filter would break, since this commit would not have attributes set. The solution is to split the for loop and use if statements which handle null values in Tera.

The changelog generates correctly now:

```
## [0.7.0](https://github.com/cot-rs/cot/compare/cot-v0.6.0...cot-v0.7.0) - 2026-05-07

[View diff on diff.rs](https://diff.rs/cot/0.6.0/cot/0.7.0/Cargo.toml)

### New features

- Derive `Ord` and `PartialOrd` for `Auto` ([#544](https://github.com/cot-rs/cot/pull/544)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
- Allow accessing extra config ([#518](https://github.com/cot-rs/cot/pull/518)) (by [@m4tx](https://github.com/m4tx))

### Fixes

- Non-ASCII URLs can be properly routed now ([#561](https://github.com/cot-rs/cot/pull/561)) (by [@m4tx](https://github.com/m4tx))
- Place correct contributing guide link ([#557](https://github.com/cot-rs/cot/pull/557)) (by [@kingazm](https://github.com/kingazm))

### Other

- Fix clippy errors ([#560](https://github.com/cot-rs/cot/pull/560)) (by [@m4tx](https://github.com/m4tx))
- Add query macro docs ([#543](https://github.com/cot-rs/cot/pull/543)) (by [@ElijahAhianyo](https://github.com/ElijahAhianyo))
- *(deps)* Remove chumsky ([#538](https://github.com/cot-rs/cot/pull/538)) (by [@m4tx](https://github.com/m4tx))
- *(deps)* Use `grass_compiler` directly ([#537](https://github.com/cot-rs/cot/pull/537)) (by [@m4tx](https://github.com/m4tx))
- *(deps)* Bump fake from 4.4.0 to 5.1.0 ([#533](https://github.com/cot-rs/cot/pull/533)) (by [@dependabot[bot]](https://github.com/dependabot[bot]))
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Other (describe above)