### PR TITLE
refactor: add index route to JSON example

### DIFF
--- a/cot/src/openapi/swagger_ui.rs
+++ b/cot/src/openapi/swagger_ui.rs
@@ -112,7 +112,7 @@ impl App for SwaggerUi {
             Ok::<_, crate::Error>(Html::new(swagger))
         };
 
-        let mut urls = vec![Route::with_handler("/", swagger_handler)];
+        let mut urls = vec![Route::with_handler_and_name("/", swagger_handler, "index")];
         if self.serve_openapi {
             urls.push(Route::with_handler("/openapi.json", openapi_json));
         }

--- a/examples/json/src/main.rs
+++ b/examples/json/src/main.rs
@@ -4,11 +4,11 @@ use cot::error::handler::{DynErrorPageHandler, RequestError};
 use cot::json::Json;
 use cot::openapi::swagger_ui::SwaggerUi;
 use cot::project::{MiddlewareContext, RegisterAppsContext, RootHandler, RootHandlerBuilder};
-use cot::response::IntoResponse;
+use cot::response::{IntoResponse, Response};
 use cot::router::method::openapi::api_post;
-use cot::router::{Route, Router};
+use cot::router::{Route, Router, Urls};
 use cot::static_files::StaticFilesMiddleware;
-use cot::{App, AppBuilder, Project};
+use cot::{App, AppBuilder, Project, reverse_redirect};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, schemars::JsonSchema)]
@@ -30,6 +30,10 @@ async fn add(Json(add_request): Json<AddRequest>) -> Json<AddResponse> {
     Json(response)
 }
 
+async fn index(urls: Urls) -> cot::Result<Response> {
+    Ok(reverse_redirect!(urls, "swagger-ui:index")?)
+}
+
 struct AddApp;
 
 impl App for AddApp {
@@ -38,7 +42,10 @@ impl App for AddApp {
     }
 
     fn router(&self) -> Router {
-        Router::with_urls([Route::with_api_handler("/add/", api_post(add))])
+        Router::with_urls([
+            Route::with_api_handler_and_name("/add/", api_post(add), "add"),
+            Route::with_handler_and_name("/", index, "index"),
+        ])
     }
 }
 


### PR DESCRIPTION
## Description
Currently, the json example only has the `/swagger` route, so the `/` route doesnt work. It's nice to have a root route that just redirects to the `/swagger` route. This PR does exactly that.

As a bonus, it adds a view name to the index route of the internal `SwaggerUI` app so downstream users can `reverse_redirect` to it


## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / cleanup
- [ ] Performance improvement
- [ ] Other (describe above)

