### PR TITLE
fix: remove extra spaces from release-plz macro

### DIFF
--- a/.cargo/release-plz.toml
+++ b/.cargo/release-plz.toml
@@ -55,12 +55,10 @@ body = """
     {% if commit.remote.username %} (by [@{{ commit.remote.username }}](https://github.com/{{ commit.remote.username }})){% endif -%}
 {% endmacro -%}
 {%- macro commit_line(commit) -%}
-- {% if commit.breaking %}
-    [**breaking**]
-  {% endif %}
-  {% if commit.scope %}
-    *({{commit.scope}})*
-  {% endif %}
+- {% if commit.breaking -%}
+    [**breaking**] {% endif -%}
+  {%- if commit.scope -%}
+    *({{commit.scope}})* {% endif -%}
   {{ commit.message | upper_first }}{{ self::username(commit=commit) }}
 {%- endmacro -%}
 """


### PR DESCRIPTION
## Related issue or discussion

https://github.com/cot-rs/cot/pull/571

## Description

Adding dashes stops Tera from adding newlines after those blocks.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Other (describe above)
