### PR TITLE
feat!: Implement `Serialize`, `Deserialize`, and `JsonSchema` implementations for cot internal types

### DIFF
--- a/cot/src/common_types.rs
+++ b/cot/src/common_types.rs
@@ -16,6 +16,7 @@ use cot::db::impl_postgres::PostgresValueRef;
 use cot::db::impl_sqlite::SqliteValueRef;
 use cot::form::FormFieldValidationError;
 use email_address::EmailAddress;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[cfg(feature = "db")]
@@ -181,7 +182,7 @@ impl From<String> for Password {
 /// let url_string = url.into_string();
 /// assert_eq!(url_string, "https://example.com/");
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Url(url::Url);
 
 impl Url {
@@ -417,7 +418,7 @@ impl DatabaseField for Url {
 /// // Convert using TryFrom
 /// let email = Email::try_from("user@example.com").unwrap();
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Email(EmailAddress);
 
 impl Email {

--- a/cot/src/db.rs
+++ b/cot/src/db.rs
@@ -2073,7 +2073,7 @@ impl<T: Display> Display for Auto<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Fixed(value) => Display::fmt(value, f),
-            Self::Auto => write!(f, "Auto"),
+            Self::Auto => panic!("Auto values cannot be displayed"),
         }
     }
 }
@@ -2414,11 +2414,5 @@ mod tests {
         let deserialized: std::result::Result<Auto<i32>, serde_json::Error> =
             serde_json::from_str("null");
         assert!(deserialized.is_err());
-    }
-
-    #[test]
-    fn auto_display() {
-        assert_eq!(Auto::fixed(42).to_string(), "42");
-        assert_eq!(Auto::<i32>::Auto.to_string(), "Auto");
     }
 }

--- a/cot/src/db.rs
+++ b/cot/src/db.rs
@@ -188,6 +188,7 @@ use sea_query::{
     ColumnRef, Iden, IntoColumnRef, OnConflict, ReturningClause, SchemaStatementBuilder, SimpleExpr,
 };
 use sea_query_binder::{SqlxBinder, SqlxValues};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sqlx::{Type, TypeInfo};
 use thiserror::Error;
 use tracing::{Instrument, Level, span, trace};
@@ -2077,6 +2078,27 @@ impl<T: Display> Display for Auto<T> {
     }
 }
 
+impl<T: Serialize> Serialize for Auto<T> {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Fixed(value) => value.serialize(serializer),
+            Self::Auto => panic!("Auto values cannot be serialized"),
+        }
+    }
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for Auto<T> {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        T::deserialize(deserializer).map(Self::Fixed)
+    }
+}
+
 /// A wrapper over a string that has a limited length.
 ///
 /// This type is used to represent a string that has a limited length in the
@@ -2100,7 +2122,9 @@ impl<T: Display> Display for Auto<T> {
 /// let limited_string = LimitedString::<5>::new("too long");
 /// assert!(limited_string.is_err());
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deref, Display)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deref, Display, Serialize, Deserialize,
+)]
 pub struct LimitedString<const LIMIT: u32>(String);
 
 impl<const LIMIT: u32> PartialEq<&str> for LimitedString<LIMIT> {

--- a/cot/src/db.rs
+++ b/cot/src/db.rs
@@ -2073,7 +2073,7 @@ impl<T: Display> Display for Auto<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Fixed(value) => Display::fmt(value, f),
-            Self::Auto => panic!("Auto values cannot be displayed"),
+            Self::Auto => write!(f, "Auto"),
         }
     }
 }
@@ -2085,7 +2085,7 @@ impl<T: Serialize> Serialize for Auto<T> {
     {
         match self {
             Self::Fixed(value) => value.serialize(serializer),
-            Self::Auto => panic!("Auto values cannot be serialized"),
+            Self::Auto => panic!("Auto::Auto values cannot be serialized"),
         }
     }
 }
@@ -2387,5 +2387,38 @@ mod tests {
     fn db_field_value_expect_panic() {
         let auto_value = DbFieldValue::Auto;
         let _ = auto_value.expect_value("expected a value");
+    }
+
+    #[test]
+    fn auto_serialize_fixed() {
+        let auto = Auto::fixed(42i32);
+        let serialized = serde_json::to_string(&auto).unwrap();
+        assert_eq!(serialized, "42");
+    }
+
+    #[test]
+    #[should_panic(expected = "Auto::Auto values cannot be serialized")]
+    fn auto_serialize_auto() {
+        let auto = Auto::<i32>::Auto;
+        let _ = serde_json::to_string(&auto).unwrap();
+    }
+
+    #[test]
+    fn auto_deserialize_fixed() {
+        let deserialized: Auto<i32> = serde_json::from_str("42").unwrap();
+        assert_eq!(deserialized, Auto::fixed(42));
+    }
+
+    #[test]
+    fn auto_deserialize_auto() {
+        let deserialized: std::result::Result<Auto<i32>, serde_json::Error> =
+            serde_json::from_str("null");
+        assert!(deserialized.is_err());
+    }
+
+    #[test]
+    fn auto_display() {
+        assert_eq!(Auto::fixed(42).to_string(), "42");
+        assert_eq!(Auto::<i32>::Auto.to_string(), "Auto");
     }
 }

--- a/cot/src/db.rs
+++ b/cot/src/db.rs
@@ -2085,7 +2085,9 @@ impl<T: Serialize> Serialize for Auto<T> {
     {
         match self {
             Self::Fixed(value) => value.serialize(serializer),
-            Self::Auto => panic!("Auto::Auto values cannot be serialized"),
+            Self::Auto => Err(serde::ser::Error::custom(
+                "Auto::Auto values cannot be serialized",
+            )),
         }
     }
 }
@@ -2397,10 +2399,10 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Auto::Auto values cannot be serialized")]
     fn auto_serialize_auto() {
         let auto = Auto::<i32>::Auto;
-        let _ = serde_json::to_string(&auto).unwrap();
+        let value = serde_json::to_string(&auto);
+        assert!(value.is_err());
     }
 
     #[test]

--- a/cot/src/openapi.rs
+++ b/cot/src/openapi.rs
@@ -1172,12 +1172,11 @@ impl<const LIMIT: u32> JsonSchema for LimitedString<LIMIT> {
             let _ = object.insert(
                 ("type").into(),
                 ::serde_json::to_value("string")
-                    .expect("failed to serialize type for LimitedString schema"),
+                    .expect("serializing a fixed value should never fail"),
             );
             let _ = object.insert(
                 ("maxLength").into(),
-                ::serde_json::to_value(LIMIT)
-                    .expect("failed to serialize maxLength for LimitedString schema"),
+                ::serde_json::to_value(LIMIT).expect("serializing a fixed value should not fail"),
             );
             object
         }))
@@ -1224,11 +1223,11 @@ impl JsonSchema for Email {
             let mut object = serde_json::Map::new();
             let _ = object.insert(
                 ("type").into(),
-                serde_json::to_value("string").expect("failed to serialize type for Email schema"),
+                serde_json::to_value("string").expect("serializing a fixed value should not fail"),
             );
             let _ = object.insert(
                 ("format").into(),
-                serde_json::to_value("email").expect("failed to serialize format for Email schema"),
+                serde_json::to_value("email").expect("serializing a fixed value should not fail"),
             );
             object
         }))
@@ -1250,11 +1249,11 @@ impl JsonSchema for Url {
             let mut object = serde_json::Map::new();
             let _ = object.insert(
                 ("type").into(),
-                serde_json::to_value("string").expect("failed to serialize type for Url schema"),
+                serde_json::to_value("string").expect("serializing a fixed value should not fail"),
             );
             let _ = object.insert(
                 ("format").into(),
-                serde_json::to_value("uri").expect("failed to serialize format for Url schema"),
+                serde_json::to_value("uri").expect("serializing a fixed value should not fail"),
             );
             object
         }))

--- a/cot/src/openapi.rs
+++ b/cot/src/openapi.rs
@@ -1190,7 +1190,7 @@ impl<T: JsonSchema + Model> JsonSchema for ForeignKey<T> {
         Schema::try_from(Value::Object({
             let mut object = ::serde_json::Map::new();
             let _ = object.insert(("type").into(), ::serde_json::to_value("integer").unwrap());
-            let _ = object.insert(("format").into(), ::serde_json::to_value("int64").unwrap());
+            let _ = object.insert(("format").into(), ::serde_json::to_value("int").unwrap());
             object
         }))
         .expect("invalid schema for ForeignKey")
@@ -1692,48 +1692,74 @@ mod tests {
     }
 
     #[test]
-    fn json_schema_for_custom_types() {
-        #[derive(Debug, Clone, PartialEq, schemars::JsonSchema)]
-        #[model]
-        struct TestModel {
-            #[model(primary_key)]
-            id: Auto<i32>,
-            limited_str: LimitedString<10>,
-            email: Email,
-            url: Url,
-        }
-
+    fn json_schema_for_auto() {
         let mut generator = SchemaGenerator::default();
 
         let schema = <Auto<i32>>::json_schema(&mut generator);
         let value = serde_json::to_value(&schema).unwrap();
         assert_eq!(value["type"], "integer");
         assert_eq!(<Auto<i32>>::schema_name(), "Auto_int32");
+        assert_eq!(<Auto<i32>>::schema_id(), "Auto<int32>");
+    }
+
+    #[test]
+    fn json_schema_for_limited_string() {
+        let mut generator = SchemaGenerator::default();
 
         let schema = <LimitedString<10>>::json_schema(&mut generator);
         let value = serde_json::to_value(&schema).unwrap();
         assert_eq!(value["type"], "string");
         assert_eq!(<LimitedString<10>>::schema_name(), "LimitedString_10");
+        assert_eq!(<LimitedString<10>>::schema_id(), "LimitedString<10>");
+    }
+
+    #[test]
+    fn json_schema_for_foreign_key() {
+        #[derive(Debug, Clone, PartialEq, schemars::JsonSchema)]
+        #[model]
+        struct TestModel {
+            #[model(primary_key)]
+            id: Auto<i32>,
+        }
+
+        let mut generator = SchemaGenerator::default();
 
         let schema = <ForeignKey<TestModel>>::json_schema(&mut generator);
+
         let value = serde_json::to_value(&schema).unwrap();
         assert_eq!(value["type"], "integer");
-        assert_eq!(value["format"], "int64");
+        assert_eq!(value["format"], "int");
         assert_eq!(
             <ForeignKey<TestModel>>::schema_name(),
             "ForeignKey_TestModel"
         );
+        assert_eq!(
+            <ForeignKey<TestModel>>::schema_id(),
+            format!("ForeignKey<{}>", TestModel::schema_id())
+        );
+    }
+
+    #[test]
+    fn json_schema_for_email() {
+        let mut generator = SchemaGenerator::default();
 
         let schema = Email::json_schema(&mut generator);
         let value = serde_json::to_value(&schema).unwrap();
         assert_eq!(value["type"], "string");
         assert_eq!(value["format"], "email");
         assert_eq!(Email::schema_name(), "Email");
+        assert_eq!(Email::schema_id(), "Email");
+    }
+
+    #[test]
+    fn json_schema_for_url() {
+        let mut generator = SchemaGenerator::default();
 
         let schema = Url::json_schema(&mut generator);
         let value = serde_json::to_value(&schema).unwrap();
         assert_eq!(value["type"], "string");
         assert_eq!(value["format"], "uri");
         assert_eq!(Url::schema_name(), "Url");
+        assert_eq!(Url::schema_id(), "Url");
     }
 }

--- a/cot/src/openapi.rs
+++ b/cot/src/openapi.rs
@@ -105,6 +105,7 @@
 #[cfg(feature = "swagger-ui")]
 pub mod swagger_ui;
 
+use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::pin::Pin;
 
@@ -112,6 +113,8 @@ use aide::openapi::{
     MediaType, Operation, Parameter, ParameterData, ParameterSchemaOrContent, PathItem, PathStyle,
     QueryStyle, ReferenceOr, RequestBody, StatusCode,
 };
+use cot::common_types::Email;
+use cot::db::{ForeignKey, LimitedString, Model};
 use cot_core::handler::{BoxRequestHandler, RequestHandler, handle_all_parameters};
 /// Derive macro for the [`ApiOperationResponse`] trait.
 ///
@@ -207,6 +210,8 @@ use schemars::{JsonSchema, Schema, SchemaGenerator};
 use serde_json::Value;
 
 use crate::auth::Auth;
+use crate::common_types::Url;
+use crate::db::Auto;
 use crate::form::Form;
 use crate::json::Json;
 use crate::request::extractors::{FromRequest, FromRequestHead, Path, RequestForm, UrlQuery};
@@ -1134,10 +1139,104 @@ where
     }
 }
 
+impl<T: JsonSchema> JsonSchema for Auto<T> {
+    fn schema_name() -> Cow<'static, str> {
+        format!("Auto_{}", T::schema_name()).into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        format!("Auto<{}>", T::schema_id()).into()
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        T::json_schema(generator)
+    }
+}
+
+impl<const LIMIT: u32> JsonSchema for LimitedString<LIMIT> {
+    fn schema_name() -> Cow<'static, str> {
+        format!("LimitedString_{LIMIT}").into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        format!("LimitedString<{LIMIT}>").into()
+    }
+
+    fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+        Schema::try_from(Value::Object({
+            let mut object = ::serde_json::Map::new();
+            let _ = object.insert(("type").into(), ::serde_json::to_value("string").unwrap());
+            object
+        }))
+        .expect("invalid schema for LimitedString")
+    }
+}
+
+impl<T: JsonSchema + Model> JsonSchema for ForeignKey<T> {
+    fn schema_name() -> Cow<'static, str> {
+        format!("ForeignKey_{}", T::schema_name()).into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        format!("ForeignKey<{}>", T::schema_id()).into()
+    }
+
+    fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+        Schema::try_from(Value::Object({
+            let mut object = ::serde_json::Map::new();
+            let _ = object.insert(("type").into(), ::serde_json::to_value("integer").unwrap());
+            let _ = object.insert(("format").into(), ::serde_json::to_value("int64").unwrap());
+            object
+        }))
+        .expect("invalid schema for ForeignKey")
+    }
+}
+
+impl JsonSchema for Email {
+    fn schema_name() -> Cow<'static, str> {
+        "Email".into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        "Email".into()
+    }
+
+    fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+        Schema::try_from(Value::Object({
+            let mut object = ::serde_json::Map::new();
+            let _ = object.insert(("type").into(), ::serde_json::to_value("string").unwrap());
+            let _ = object.insert(("format").into(), ::serde_json::to_value("email").unwrap());
+            object
+        }))
+        .expect("invalid schema for Email")
+    }
+}
+
+impl JsonSchema for Url {
+    fn schema_name() -> Cow<'static, str> {
+        "Url".into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        "Url".into()
+    }
+
+    fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+        Schema::try_from(Value::Object({
+            let mut object = ::serde_json::Map::new();
+            let _ = object.insert(("type").into(), ::serde_json::to_value("string").unwrap());
+            let _ = object.insert(("format").into(), ::serde_json::to_value("uri").unwrap());
+            object
+        }))
+        .expect("invalid schema for Url")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use aide::openapi::{Operation, Parameter};
-    use schemars::SchemaGenerator;
+    use cot_macros::model;
+    use schemars::{JsonSchema, SchemaGenerator};
     use serde::{Deserialize, Serialize};
 
     use super::*;
@@ -1585,5 +1684,51 @@ mod tests {
         let (status_code_2, response_2) = &responses[1];
         assert_eq!(status_code_2, &Some(StatusCode::Code(400)));
         assert_eq!(response_2.description, "Bad Request");
+    }
+
+    #[test]
+    fn json_schema_for_custom_types() {
+        #[derive(Debug, Clone, PartialEq, schemars::JsonSchema)]
+        #[model]
+        struct TestModel {
+            #[model(primary_key)]
+            id: Auto<i32>,
+            limited_str: LimitedString<10>,
+            email: Email,
+            url: Url,
+        }
+
+        let mut generator = SchemaGenerator::default();
+
+        let schema = <Auto<i32>>::json_schema(&mut generator);
+        let value = serde_json::to_value(&schema).unwrap();
+        assert_eq!(value["type"], "integer");
+        assert_eq!(<Auto<i32>>::schema_name(), "Auto_int32");
+
+        let schema = <LimitedString<10>>::json_schema(&mut generator);
+        let value = serde_json::to_value(&schema).unwrap();
+        assert_eq!(value["type"], "string");
+        assert_eq!(<LimitedString<10>>::schema_name(), "LimitedString_10");
+
+        let schema = <ForeignKey<TestModel>>::json_schema(&mut generator);
+        let value = serde_json::to_value(&schema).unwrap();
+        assert_eq!(value["type"], "integer");
+        assert_eq!(value["format"], "int64");
+        assert_eq!(
+            <ForeignKey<TestModel>>::schema_name(),
+            "ForeignKey_TestModel"
+        );
+
+        let schema = Email::json_schema(&mut generator);
+        let value = serde_json::to_value(&schema).unwrap();
+        assert_eq!(value["type"], "string");
+        assert_eq!(value["format"], "email");
+        assert_eq!(Email::schema_name(), "Email");
+
+        let schema = Url::json_schema(&mut generator);
+        let value = serde_json::to_value(&schema).unwrap();
+        assert_eq!(value["type"], "string");
+        assert_eq!(value["format"], "uri");
+        assert_eq!(Url::schema_name(), "Url");
     }
 }

--- a/cot/src/openapi.rs
+++ b/cot/src/openapi.rs
@@ -1169,7 +1169,16 @@ impl<const LIMIT: u32> JsonSchema for LimitedString<LIMIT> {
     fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
         Schema::try_from(Value::Object({
             let mut object = ::serde_json::Map::new();
-            let _ = object.insert(("type").into(), ::serde_json::to_value("string").unwrap());
+            let _ = object.insert(
+                ("type").into(),
+                ::serde_json::to_value("string")
+                    .expect("failed to serialize type for LimitedString schema"),
+            );
+            let _ = object.insert(
+                ("maxLength").into(),
+                ::serde_json::to_value(LIMIT)
+                    .expect("failed to serialize maxLength for LimitedString schema"),
+            );
             object
         }))
         .expect("invalid schema for LimitedString")
@@ -1177,7 +1186,10 @@ impl<const LIMIT: u32> JsonSchema for LimitedString<LIMIT> {
 }
 
 #[cfg(feature = "db")]
-impl<T: JsonSchema + Model> JsonSchema for ForeignKey<T> {
+impl<T: JsonSchema + Model> JsonSchema for ForeignKey<T>
+where
+    T::PrimaryKey: JsonSchema,
+{
     fn schema_name() -> Cow<'static, str> {
         format!("ForeignKey_{}", T::schema_name()).into()
     }
@@ -1186,14 +1198,15 @@ impl<T: JsonSchema + Model> JsonSchema for ForeignKey<T> {
         format!("ForeignKey<{}>", T::schema_id()).into()
     }
 
-    fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
-        Schema::try_from(Value::Object({
-            let mut object = ::serde_json::Map::new();
-            let _ = object.insert(("type").into(), ::serde_json::to_value("integer").unwrap());
-            let _ = object.insert(("format").into(), ::serde_json::to_value("int").unwrap());
-            object
-        }))
-        .expect("invalid schema for ForeignKey")
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        let mut schema = T::PrimaryKey::json_schema(generator);
+        if let Some(obj) = schema.as_object_mut() {
+            let _ = obj.insert(
+                ("description").into(),
+                Value::String(format!("Primary key for {}", T::schema_name())),
+            );
+        }
+        schema
     }
 }
 
@@ -1208,9 +1221,15 @@ impl JsonSchema for Email {
 
     fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
         Schema::try_from(Value::Object({
-            let mut object = ::serde_json::Map::new();
-            let _ = object.insert(("type").into(), ::serde_json::to_value("string").unwrap());
-            let _ = object.insert(("format").into(), ::serde_json::to_value("email").unwrap());
+            let mut object = serde_json::Map::new();
+            let _ = object.insert(
+                ("type").into(),
+                serde_json::to_value("string").expect("failed to serialize type for Email schema"),
+            );
+            let _ = object.insert(
+                ("format").into(),
+                serde_json::to_value("email").expect("failed to serialize format for Email schema"),
+            );
             object
         }))
         .expect("invalid schema for Email")
@@ -1228,9 +1247,15 @@ impl JsonSchema for Url {
 
     fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
         Schema::try_from(Value::Object({
-            let mut object = ::serde_json::Map::new();
-            let _ = object.insert(("type").into(), ::serde_json::to_value("string").unwrap());
-            let _ = object.insert(("format").into(), ::serde_json::to_value("uri").unwrap());
+            let mut object = serde_json::Map::new();
+            let _ = object.insert(
+                ("type").into(),
+                serde_json::to_value("string").expect("failed to serialize type for Url schema"),
+            );
+            let _ = object.insert(
+                ("format").into(),
+                serde_json::to_value("uri").expect("failed to serialize format for Url schema"),
+            );
             object
         }))
         .expect("invalid schema for Url")
@@ -1709,6 +1734,7 @@ mod tests {
         let schema = <LimitedString<10>>::json_schema(&mut generator);
         let value = serde_json::to_value(&schema).unwrap();
         assert_eq!(value["type"], "string");
+        assert_eq!(value["maxLength"], 10);
         assert_eq!(<LimitedString<10>>::schema_name(), "LimitedString_10");
         assert_eq!(<LimitedString<10>>::schema_id(), "LimitedString<10>");
     }
@@ -1728,7 +1754,8 @@ mod tests {
 
         let value = serde_json::to_value(&schema).unwrap();
         assert_eq!(value["type"], "integer");
-        assert_eq!(value["format"], "int");
+        assert_eq!(value["format"], "int32");
+        assert_eq!(value["description"], "Primary key for TestModel");
         assert_eq!(
             <ForeignKey<TestModel>>::schema_name(),
             "ForeignKey_TestModel"

--- a/cot/src/openapi.rs
+++ b/cot/src/openapi.rs
@@ -114,6 +114,7 @@ use aide::openapi::{
     QueryStyle, ReferenceOr, RequestBody, StatusCode,
 };
 use cot::common_types::Email;
+#[cfg(feature = "db")]
 use cot::db::{ForeignKey, LimitedString, Model};
 use cot_core::handler::{BoxRequestHandler, RequestHandler, handle_all_parameters};
 /// Derive macro for the [`ApiOperationResponse`] trait.
@@ -211,6 +212,7 @@ use serde_json::Value;
 
 use crate::auth::Auth;
 use crate::common_types::Url;
+#[cfg(feature = "db")]
 use crate::db::Auto;
 use crate::form::Form;
 use crate::json::Json;
@@ -1139,6 +1141,7 @@ where
     }
 }
 
+#[cfg(feature = "db")]
 impl<T: JsonSchema> JsonSchema for Auto<T> {
     fn schema_name() -> Cow<'static, str> {
         format!("Auto_{}", T::schema_name()).into()
@@ -1153,6 +1156,7 @@ impl<T: JsonSchema> JsonSchema for Auto<T> {
     }
 }
 
+#[cfg(feature = "db")]
 impl<const LIMIT: u32> JsonSchema for LimitedString<LIMIT> {
     fn schema_name() -> Cow<'static, str> {
         format!("LimitedString_{LIMIT}").into()
@@ -1172,6 +1176,7 @@ impl<const LIMIT: u32> JsonSchema for LimitedString<LIMIT> {
     }
 }
 
+#[cfg(feature = "db")]
 impl<T: JsonSchema + Model> JsonSchema for ForeignKey<T> {
     fn schema_name() -> Cow<'static, str> {
         format!("ForeignKey_{}", T::schema_name()).into()


### PR DESCRIPTION


## Related issue or discussion

This should allow the use of cot's internal types in structs where `schemas::JsonSchema` is derived:

```rust
#[derive(Debug, Clone, Serialize, schemars::JsonSchema)]
#[model] // needed only for `ForeignKey`
struct Foo {
  id: Auto<i64>,
  limited_str: LimitedString<128>,
  fk: ForeignKey<Bar>,
  email: Email,
  url: Url
}

```

## Description

<!-- What does this PR do and why? -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Other (describe above)

## Checklist

- [ ] I've read the [contributing guide](CONTRIBUTING.md)
- [ ] Tests pass locally (`just test-all`)
- [ ] Code passes clippy (`just clippy`)
- [ ] Code is properly formatted (`cargo fmt`)
- [ ] New tests added (regression test for bugs, coverage for new features)
- [ ] Documentation (both code and site) updated (if applicable)

<!-- Please mark the PR as in progress if you haven't completed the checklist -->
