### PR TITLE
chore: update Star History chart links with tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ The guide served at the [official website](https://cot.rs/guide/latest/) is buil
 
 ## Star History
 
-<a href="https://star-history.com/#cot-rs/cot&Date">
+<a href="https://www.star-history.com/?repos=cot-rs%2Fcot&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=cot-rs/cot&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=cot-rs/cot&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=cot-rs/cot&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=cot-rs/cot&type=date&theme=dark&legend=top-left&sealed_token=f19Y88C-akDqgnKA83bdAa2kynB_tXjd24Q542FijwbM42YmtFImSQGoX7W2L6bGYDRbk-U4lm2J8mSWGPCx0klmHDV2wXPyrtnevwonQLDUfxbffHYedBjMxwQpyoIH8f-966Nuf4sZV00_51frhUQnDvNCrrm0qiiL5fZSURKzGzENMyzi_pFk5-f8" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=cot-rs/cot&type=date&legend=top-left&sealed_token=f19Y88C-akDqgnKA83bdAa2kynB_tXjd24Q542FijwbM42YmtFImSQGoX7W2L6bGYDRbk-U4lm2J8mSWGPCx0klmHDV2wXPyrtnevwonQLDUfxbffHYedBjMxwQpyoIH8f-966Nuf4sZV00_51frhUQnDvNCrrm0qiiL5fZSURKzGzENMyzi_pFk5-f8" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=cot-rs/cot&type=date&legend=top-left&sealed_token=f19Y88C-akDqgnKA83bdAa2kynB_tXjd24Q542FijwbM42YmtFImSQGoX7W2L6bGYDRbk-U4lm2J8mSWGPCx0klmHDV2wXPyrtnevwonQLDUfxbffHYedBjMxwQpyoIH8f-966Nuf4sZV00_51frhUQnDvNCrrm0qiiL5fZSURKzGzENMyzi_pFk5-f8" />
  </picture>
 </a>
 


### PR DESCRIPTION
## Description

> Star History reads star data from the GitHub API. Since GitHub restricted the stargazers endpoint (July 2026) to a repository's own admins and collaborators, star history is now only available for repos you own or collaborate on — and you'll need an access token that can read them.
src: https://www.star-history.com/blog/how-to-use-github-star-history#how-to-add-your-github-access-token

It's fine-grained token scoped to only `cot-rs/cot` with only `Metadata -> Read-only` permission encrypted by star history.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Other (describe above)
