### PR TITLE
fix(db): reject application models in migrations

### DIFF
--- a/cot-macros/src/model.rs
+++ b/cot-macros/src/model.rs
@@ -75,7 +75,7 @@ struct ModelBuilder {
     name: Ident,
     vis: syn::Visibility,
     table_name: String,
-    is_application_model: bool,
+    model_type: ModelType,
     pk_field: Field,
     fields_struct_name: Ident,
     fields_as_columns: Vec<TokenStream>,
@@ -110,7 +110,7 @@ impl ModelBuilder {
             name: model.name.clone(),
             vis: model.vis,
             table_name,
-            is_application_model: model.model_type == ModelType::Application,
+            model_type: model.model_type,
             pk_field: model.pk_field.clone(),
             fields_struct_name: format_ident!("{}Fields", model.name),
             fields_as_columns: Vec::with_capacity(field_count),
@@ -168,7 +168,11 @@ impl ModelBuilder {
         let name = &self.name;
         let app_name = &self.app_name;
         let table_name = &self.table_name;
-        let is_application_model = self.is_application_model;
+        let model_type = match self.model_type {
+            ModelType::Application => quote!(#orm_ident::ModelType::Application),
+            ModelType::Migration => quote!(#orm_ident::ModelType::Migration),
+            ModelType::Internal => quote!(#orm_ident::ModelType::Internal),
+        };
         let fields_struct_name = &self.fields_struct_name;
         let fields_as_columns = &self.fields_as_columns;
         let pk_field_name = &self.pk_field.name;
@@ -188,8 +192,7 @@ impl ModelBuilder {
                 const COLUMNS: &'static [#orm_ident::Column] = &[
                     #(#fields_as_columns,)*
                 ];
-                #[doc(hidden)]
-                const IS_APPLICATION_MODEL: bool = #is_application_model;
+                const MODEL_TYPE: #orm_ident::ModelType = #model_type;
                 const APP_NAME: &'static str = #app_name;
                 const TABLE_NAME: #orm_ident::Identifier = #orm_ident::Identifier::new(#table_name);
                 const PRIMARY_KEY_NAME: #orm_ident::Identifier = #orm_ident::Identifier::new(#pk_column_name);

--- a/cot-macros/src/model.rs
+++ b/cot-macros/src/model.rs
@@ -75,6 +75,7 @@ struct ModelBuilder {
     name: Ident,
     vis: syn::Visibility,
     table_name: String,
+    is_application_model: bool,
     pk_field: Field,
     fields_struct_name: Ident,
     fields_as_columns: Vec<TokenStream>,
@@ -109,6 +110,7 @@ impl ModelBuilder {
             name: model.name.clone(),
             vis: model.vis,
             table_name,
+            is_application_model: model.model_type == ModelType::Application,
             pk_field: model.pk_field.clone(),
             fields_struct_name: format_ident!("{}Fields", model.name),
             fields_as_columns: Vec::with_capacity(field_count),
@@ -166,6 +168,7 @@ impl ModelBuilder {
         let name = &self.name;
         let app_name = &self.app_name;
         let table_name = &self.table_name;
+        let is_application_model = self.is_application_model;
         let fields_struct_name = &self.fields_struct_name;
         let fields_as_columns = &self.fields_as_columns;
         let pk_field_name = &self.pk_field.name;
@@ -185,6 +188,8 @@ impl ModelBuilder {
                 const COLUMNS: &'static [#orm_ident::Column] = &[
                     #(#fields_as_columns,)*
                 ];
+                #[doc(hidden)]
+                const IS_APPLICATION_MODEL: bool = #is_application_model;
                 const APP_NAME: &'static str = #app_name;
                 const TABLE_NAME: #orm_ident::Identifier = #orm_ident::Identifier::new(#table_name);
                 const PRIMARY_KEY_NAME: #orm_ident::Identifier = #orm_ident::Identifier::new(#pk_column_name);

--- a/cot/src/db.rs
+++ b/cot/src/db.rs
@@ -1387,6 +1387,12 @@ impl Database {
                     std::any::type_name::<T>()
                 ))),
             ),
+            (DatabaseContext::Default, ModelType::Migration) => Err(DatabaseError::MigrationError(
+                migrations::MigrationEngineError::Custom(format!(
+                    "migration model `{}` cannot be used outside migrations; use an application model",
+                    std::any::type_name::<T>()
+                )),
+            )),
             _ => Ok(()),
         }
     }

--- a/cot/src/db.rs
+++ b/cot/src/db.rs
@@ -656,6 +656,9 @@ pub trait Model: Sized + Send + 'static {
     /// The columns of the model.
     const COLUMNS: &'static [Column];
 
+    #[doc(hidden)]
+    const IS_APPLICATION_MODEL: bool = true;
+
     /// Creates a model instance from a database row.
     ///
     /// # Errors
@@ -1266,6 +1269,7 @@ pub trait TextField: ToDbFieldValue {}
 #[derive(Debug, Clone)]
 pub struct Database {
     inner: Arc<DatabaseImpl>,
+    migration_context: bool,
 }
 
 #[derive(Debug)]
@@ -1328,6 +1332,7 @@ impl Database {
             let inner = DatabaseSqlite::new(&url).await?;
             return Ok(Self {
                 inner: Arc::new(DatabaseImpl::Sqlite(inner)),
+                migration_context: false,
             });
         }
 
@@ -1336,6 +1341,7 @@ impl Database {
             let inner = DatabasePostgres::new(&url).await?;
             return Ok(Self {
                 inner: Arc::new(DatabaseImpl::Postgres(inner)),
+                migration_context: false,
             });
         }
 
@@ -1344,10 +1350,30 @@ impl Database {
             let inner = DatabaseMySql::new(&url).await?;
             return Ok(Self {
                 inner: Arc::new(DatabaseImpl::MySql(inner)),
+                migration_context: false,
             });
         }
 
         panic!("Unsupported database URL: {url}");
+    }
+
+    fn for_migration(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            migration_context: true,
+        }
+    }
+
+    fn ensure_model_allowed<T: Model>(&self) -> Result<()> {
+        if self.migration_context && T::IS_APPLICATION_MODEL {
+            return Err(DatabaseError::MigrationError(
+                migrations::MigrationEngineError::Custom(format!(
+                    "application model `{}` cannot be used in migrations; use a migration model",
+                    std::any::type_name::<T>()
+                )),
+            ));
+        }
+        Ok(())
     }
 
     /// Closes the database connection.
@@ -1419,6 +1445,7 @@ impl Database {
     }
 
     async fn insert_or_update_impl<T: Model>(&self, data: &mut T, update: bool) -> Result<()> {
+        self.ensure_model_allowed::<T>()?;
         let column_identifiers = T::COLUMNS
             .iter()
             .map(|column| Identifier::from(column.name.as_str()));
@@ -1526,6 +1553,7 @@ impl Database {
     }
 
     async fn update_impl<T: Model>(&self, data: &mut T) -> Result<()> {
+        self.ensure_model_allowed::<T>()?;
         let column_identifiers = T::COLUMNS
             .iter()
             .map(|column| Identifier::from(column.name.as_str()));
@@ -1606,6 +1634,7 @@ impl Database {
     }
 
     async fn bulk_insert_impl<T: Model>(&self, data: &mut [T], update: bool) -> Result<()> {
+        self.ensure_model_allowed::<T>()?;
         // TODO: add transactions when implemented
 
         if data.is_empty() {
@@ -1818,6 +1847,7 @@ impl Database {
     ///
     /// Can return an error if the database connection is lost.
     pub async fn query<T: Model>(&self, query: &Query<T>) -> Result<Vec<T>> {
+        self.ensure_model_allowed::<T>()?;
         let columns_to_get: Vec<_> = T::COLUMNS.iter().map(|column| column.name).collect();
         let mut select = sea_query::Query::select();
         select.columns(columns_to_get).from(T::TABLE_NAME);
@@ -1844,6 +1874,7 @@ impl Database {
     ///
     /// Can return an error if the database connection is lost.
     pub async fn get<T: Model>(&self, query: &Query<T>) -> Result<Option<T>> {
+        self.ensure_model_allowed::<T>()?;
         let columns_to_get: Vec<_> = T::COLUMNS.iter().map(|column| column.name).collect();
         let mut select = sea_query::Query::select();
         select.columns(columns_to_get).from(T::TABLE_NAME);
@@ -1871,6 +1902,7 @@ impl Database {
     ///
     /// Can return an error if the database connection is lost.
     pub async fn exists<T: Model>(&self, query: &Query<T>) -> Result<bool> {
+        self.ensure_model_allowed::<T>()?;
         let mut select = sea_query::Query::select();
         select.expr(sea_query::Expr::value(1)).from(T::TABLE_NAME);
         query.add_filter_to_statement(&mut select, self)?;
@@ -1893,6 +1925,7 @@ impl Database {
     ///
     /// Can return an error if the database connection is lost.
     pub async fn delete<T: Model>(&self, query: &Query<T>) -> Result<StatementResult> {
+        self.ensure_model_allowed::<T>()?;
         let mut delete = sea_query::Query::delete();
         delete.from_table(T::TABLE_NAME);
         query.add_filter_to_statement(&mut delete, self)?;
@@ -2094,6 +2127,7 @@ impl Database {
         query: &str,
         values: &[&dyn ToDbValue],
     ) -> Result<Vec<T>> {
+        self.ensure_model_allowed::<T>()?;
         let values = values
             .iter()
             .map(ToDbValue::to_db_value)

--- a/cot/src/db.rs
+++ b/cot/src/db.rs
@@ -599,6 +599,15 @@ impl DatabaseError {
 /// An alias for [`Result`] that uses [`DatabaseError`] as the error type.
 pub type Result<T> = std::result::Result<T, DatabaseError>;
 
+#[expect(missing_docs)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum ModelType {
+    Application,
+    Migration,
+    Internal,
+}
+
 /// A model trait for database models.
 ///
 /// This trait is used to define a model that can be stored in a database.
@@ -656,8 +665,8 @@ pub trait Model: Sized + Send + 'static {
     /// The columns of the model.
     const COLUMNS: &'static [Column];
 
-    #[doc(hidden)]
-    const IS_APPLICATION_MODEL: bool = true;
+    #[expect(missing_docs)]
+    const MODEL_TYPE: ModelType = ModelType::Application;
 
     /// Creates a model instance from a database row.
     ///
@@ -1261,6 +1270,12 @@ pub trait SqlxValueRef<'r>: Sized {
 /// Marker trait for DB field types that behave like texts.
 pub trait TextField: ToDbFieldValue {}
 
+#[derive(Debug, Clone, Copy)]
+enum DatabaseContext {
+    Default,
+    InMigration,
+}
+
 /// A database connection structure that holds the connection to the database.
 ///
 /// It is used to execute queries and interact with the database. The connection
@@ -1269,7 +1284,7 @@ pub trait TextField: ToDbFieldValue {}
 #[derive(Debug, Clone)]
 pub struct Database {
     inner: Arc<DatabaseImpl>,
-    migration_context: bool,
+    context: DatabaseContext,
 }
 
 #[derive(Debug)]
@@ -1332,7 +1347,7 @@ impl Database {
             let inner = DatabaseSqlite::new(&url).await?;
             return Ok(Self {
                 inner: Arc::new(DatabaseImpl::Sqlite(inner)),
-                migration_context: false,
+                context: DatabaseContext::Default,
             });
         }
 
@@ -1341,7 +1356,7 @@ impl Database {
             let inner = DatabasePostgres::new(&url).await?;
             return Ok(Self {
                 inner: Arc::new(DatabaseImpl::Postgres(inner)),
-                migration_context: false,
+                context: DatabaseContext::Default,
             });
         }
 
@@ -1350,7 +1365,7 @@ impl Database {
             let inner = DatabaseMySql::new(&url).await?;
             return Ok(Self {
                 inner: Arc::new(DatabaseImpl::MySql(inner)),
-                migration_context: false,
+                context: DatabaseContext::Default,
             });
         }
 
@@ -1360,20 +1375,20 @@ impl Database {
     fn for_migration(&self) -> Self {
         Self {
             inner: Arc::clone(&self.inner),
-            migration_context: true,
+            context: DatabaseContext::InMigration,
         }
     }
 
     fn ensure_model_allowed<T: Model>(&self) -> Result<()> {
-        if self.migration_context && T::IS_APPLICATION_MODEL {
-            return Err(DatabaseError::MigrationError(
-                migrations::MigrationEngineError::Custom(format!(
+        match (self.context, T::MODEL_TYPE) {
+            (DatabaseContext::InMigration, ModelType::Application) => Err(
+                DatabaseError::MigrationError(migrations::MigrationEngineError::Custom(format!(
                     "application model `{}` cannot be used in migrations; use a migration model",
                     std::any::type_name::<T>()
-                )),
-            ));
+                ))),
+            ),
+            _ => Ok(()),
         }
-        Ok(())
     }
 
     /// Closes the database connection.

--- a/cot/src/db/migrations.rs
+++ b/cot/src/db/migrations.rs
@@ -532,7 +532,8 @@ impl Operation {
                 forwards,
                 backwards: _,
             } => {
-                let context = MigrationContext::new(database);
+                let database = database.for_migration();
+                let context = MigrationContext::new(&database);
                 forwards(context).await?;
             }
         }
@@ -617,7 +618,8 @@ impl Operation {
                 backwards,
             } => {
                 if let Some(backwards) = backwards {
-                    let context = MigrationContext::new(database);
+                    let database = database.for_migration();
+                    let context = MigrationContext::new(&database);
                     backwards(context).await?;
                 } else {
                     return Err(crate::db::DatabaseError::MigrationError(
@@ -2025,7 +2027,19 @@ mod tests {
     use cot::test::TestDatabase;
 
     use super::*;
-    use crate::db::{ColumnType, DatabaseField, Identifier};
+    use crate::db::{ColumnType, DatabaseError, DatabaseField, Identifier, Model};
+
+    #[model]
+    struct ApplicationModel {
+        #[model(primary_key)]
+        id: i32,
+    }
+
+    #[model(model_type = "migration")]
+    struct _MigrationModel {
+        #[model(primary_key)]
+        id: i32,
+    }
 
     struct TestMigration;
 
@@ -2166,6 +2180,50 @@ mod tests {
 
         let result = test_db.database().raw("SELECT * FROM custom_test").await;
         assert!(result.is_ok());
+    }
+
+    #[cot::test]
+    #[cfg_attr(
+        miri,
+        ignore = "unsupported operation: can't call foreign function `sqlite3_open_v2`"
+    )]
+    async fn operation_custom_model_access() {
+        let test_db = TestDatabase::new_sqlite().await.unwrap();
+
+        #[migration_op]
+        async fn application_model(ctx: MigrationContext<'_>) -> Result<()> {
+            ApplicationModel::objects().all(ctx.db).await?;
+            Ok(())
+        }
+
+        let result = Operation::custom(application_model)
+            .build()
+            .forwards(&test_db.database())
+            .await;
+        assert!(matches!(
+            result,
+            Err(DatabaseError::MigrationError(MigrationEngineError::Custom(
+                _
+            )))
+        ));
+
+        test_db
+            .database()
+            .raw("CREATE TABLE cot__migration_model (id INTEGER PRIMARY KEY)")
+            .await
+            .unwrap();
+
+        #[migration_op]
+        async fn migration_model(ctx: MigrationContext<'_>) -> Result<()> {
+            _MigrationModel::objects().all(ctx.db).await?;
+            Ok(())
+        }
+
+        Operation::custom(migration_model)
+            .build()
+            .forwards(&test_db.database())
+            .await
+            .unwrap();
     }
 
     #[cot::test]

--- a/cot/src/db/migrations.rs
+++ b/cot/src/db/migrations.rs
@@ -2190,6 +2190,14 @@ mod tests {
     async fn operation_custom_model_access() {
         let test_db = TestDatabase::new_sqlite().await.unwrap();
 
+        let result = _MigrationModel::objects().all(&test_db.database()).await;
+        assert!(matches!(
+            result,
+            Err(DatabaseError::MigrationError(MigrationEngineError::Custom(
+                _
+            )))
+        ));
+
         #[migration_op]
         async fn application_model(ctx: MigrationContext<'_>) -> Result<()> {
             ApplicationModel::objects().all(ctx.db).await?;


### PR DESCRIPTION
Fixes #623. Custom migrations now reject application models before they can access the database. Migration models and raw SQL keep working. Tested with the full cot suite, the macro suite, and clippy.