### PR TITLE
ci: attach cot-cli binaries to releases

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,53 @@
+name: Release binaries
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  upload-cot-cli:
+    if: startsWith(github.event.release.tag_name, 'cot-cli-v')
+    name: Upload cot-cli (${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cross
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        uses: taiki-e/install-action@v2.85.4
+        with:
+          tool: cross
+
+      - name: Build and upload cot-cli
+        uses: taiki-e/upload-rust-binary-action@v1.30.2
+        with:
+          bin: cot
+          package: cot-cli
+          target: ${{ matrix.target }}
+          archive: cot-cli-$target
+          locked: true

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -2,7 +2,7 @@ name: Release binaries
 
 on:
   release:
-    types: [published]
+    types: [created]
 
 permissions:
   contents: read
@@ -50,4 +50,6 @@ jobs:
           package: cot-cli
           target: ${{ matrix.target }}
           archive: cot-cli-$target
+          include: LICENSE-APACHE,LICENSE-MIT
+          checksum: sha256
           locked: true

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ target/
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
+# macOS metadata
+.DS_Store
+
 # Test databases
 *.db
 *.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,6 @@ target/
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
-# macOS metadata
-.DS_Store
-
 # Test databases
 *.db
 *.sqlite3

--- a/cot-cli/Cargo.toml
+++ b/cot-cli/Cargo.toml
@@ -16,6 +16,10 @@ authors.workspace = true
 name = "cot"
 path = "src/main.rs"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ name }-v{ version }/{ name }-{ target }{ archive-suffix }"
+bin-dir = "{ bin }{ binary-ext }"
+
 [lints]
 workspace = true
 


### PR DESCRIPTION
## Related issue or discussion

Fixes #590.

## Description

Build and attach `cot-cli` binaries when a `cot-cli-v…` GitHub release is created.

- Add a six-target matrix for Linux GNU, macOS, and Windows across x86_64 and ARM64.
- Start the build when release-plz creates the draft release, so the binaries are ready before publication.
- Use `cross` for Linux ARM64 and the standard upload action's native archive defaults: `.tar.gz` on Unix and `.zip` on Windows.
- Include the Apache 2.0 and MIT license texts in every archive and publish a SHA-256 checksum for every archive.
- Add cargo-binstall metadata whose tag, target, archive suffix, and internal binary path match those uploaded assets.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [x] Other: release automation

## Verification

- `actionlint 1.7.12` on the new workflow and the complete workflow set
- Repository-pinned `yamlfmt 0.21.0` on the new workflow and the complete workflow set
- Verified the pinned `taiki-e/upload-rust-binary-action@v1.30.2` inputs for additional archive files and SHA-256 output
- Parsed the updated Cargo manifest and expanded all six cargo-binstall URLs
- Simulated archive names and contents: four `cot-cli-<target>.tar.gz` archives containing `cot`, and two `.zip` archives containing `cot.exe`
- Resolved every referenced action tag against its upstream repository
- `git diff --check`

A full Rust cross-build was not run locally because the installed toolchain predates the workspace's Rust 1.94 requirement and local disk space was constrained. The remaining integration risk is the first real six-target release build, especially Windows ARM64; action/YAML/metadata wiring is validated above.

## Checklist

- [x] I've read the [contributing guide](CONTRIBUTING.md)
- [ ] Tests pass locally (`just test-all`) — no Rust source changed; see the toolchain limitation above
- [ ] Code passes clippy (`just clippy`) — no Rust source changed
- [x] Code is properly formatted (repository `yamlfmt`)
- [ ] New tests added — release workflow validated statically; no unit-testable Rust behavior added
- [x] Documentation updated where applicable (cargo-binstall package metadata)

AI disclosure: I used an AI coding assistant to inspect the release-plz and existing workflow conventions, implement this release matrix and cargo-binstall mapping, and run the static/semantic checks above. I reviewed the final workflow and understand the remaining first-cross-build risk before submitting.
