### PR TITLE
fix(db): classify foreign key violations

### DIFF
--- a/cot/src/db.rs
+++ b/cot/src/db.rs
@@ -555,6 +555,9 @@ pub enum DatabaseError {
     /// was not found.
     #[error("{ERROR_PREFIX} error retrieving a Foreign Key from the database: record not found")]
     ForeignKeyNotFound,
+    /// Error when a foreign key constraint is violated in the database.
+    #[error("{ERROR_PREFIX} foreign key constraint violation")]
+    ForeignKeyViolation,
     /// Error when a unique constraint is violated in the database.
     #[error("{ERROR_PREFIX} unique constraint violation")]
     UniqueViolation,

--- a/cot/src/db/sea_query_db.rs
+++ b/cot/src/db/sea_query_db.rs
@@ -185,11 +185,13 @@ macro_rules! impl_sea_query_db_backend {
 }
 
 pub(crate) fn map_sqlx_error(err: sqlx::Error) -> crate::db::DatabaseError {
-    if err
-        .as_database_error()
-        .is_some_and(sqlx::error::DatabaseError::is_unique_violation)
-    {
-        return crate::db::DatabaseError::UniqueViolation;
+    if let Some(database_error) = err.as_database_error() {
+        if database_error.is_unique_violation() {
+            return crate::db::DatabaseError::UniqueViolation;
+        }
+        if database_error.is_foreign_key_violation() {
+            return crate::db::DatabaseError::ForeignKeyViolation;
+        }
     }
 
     crate::db::DatabaseError::from(err)

--- a/cot/src/db/sea_query_db.rs
+++ b/cot/src/db/sea_query_db.rs
@@ -189,12 +189,20 @@ pub(crate) fn map_sqlx_error(err: sqlx::Error) -> crate::db::DatabaseError {
         if database_error.is_unique_violation() {
             return crate::db::DatabaseError::UniqueViolation;
         }
-        if database_error.is_foreign_key_violation() {
+        if is_foreign_key_violation(database_error) {
             return crate::db::DatabaseError::ForeignKeyViolation;
         }
     }
 
     crate::db::DatabaseError::from(err)
+}
+
+fn is_foreign_key_violation(error: &dyn sqlx::error::DatabaseError) -> bool {
+    error.is_foreign_key_violation()
+        // SQLite reports ON DELETE RESTRICT as SQLITE_CONSTRAINT_TRIGGER instead of
+        // SQLITE_CONSTRAINT_FOREIGNKEY.
+        || (error.code().as_deref() == Some("1811")
+            && error.message() == "FOREIGN KEY constraint failed")
 }
 
 pub(crate) use impl_sea_query_db_backend;

--- a/cot/tests/db_testing/relations.rs
+++ b/cot/tests/db_testing/relations.rs
@@ -87,8 +87,7 @@ async fn foreign_keys(db: &mut TestDatabase) {
         .delete(&**db)
         .await
         .unwrap_err();
-    // expected foreign key violation
-    assert!(matches!(error, DatabaseError::DatabaseEngineError(_)));
+    assert!(matches!(error, DatabaseError::ForeignKeyViolation));
 
     query!(Track, $artist == &artist)
         .delete(&**db)

--- a/cot/tests/db_testing/relations.rs
+++ b/cot/tests/db_testing/relations.rs
@@ -58,6 +58,14 @@ async fn foreign_keys(db: &mut TestDatabase) {
 
     run_migrations!(db, CREATE_ARTIST, CREATE_TRACK);
 
+    let mut track = Track {
+        id: Auto::auto(),
+        artist: ForeignKey::PrimaryKey(Auto::fixed(42)),
+        name: "track".to_owned(),
+    };
+    let error = track.save(&**db).await.unwrap_err();
+    assert!(matches!(error, DatabaseError::ForeignKeyViolation));
+
     let mut artist = Artist {
         id: Auto::auto(),
         name: "artist".to_owned(),


### PR DESCRIPTION
Fixes #541

## Description

`map_sqlx_error` normalized unique constraint failures but left foreign key failures as backend errors. Saving a model with a missing referenced primary key therefore produced the wrong public error.

This adds `DatabaseError::ForeignKeyViolation`, maps SQLx's foreign-key classification to it, and covers the missing-parent insert through the model API.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Other (describe above)

## Validation

- `cargo test -p cot --all-features --test db db_testing::relations::foreign_keys_sqlite -- --exact`
- `cargo test -p cot --all-features --test db` (55 passed, 104 external-database tests ignored)
- `cargo clippy --no-deps --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check upstream/master...HEAD`

I did not run the ignored PostgreSQL/MySQL tests locally; those require the Docker Compose services and remain covered by CI.

## Checklist

- [x] I've read the [contributing guide](CONTRIBUTING.md)
- [ ] Tests pass locally (`just test-all`)
- [x] Code passes clippy (`just clippy`)
- [x] Code is properly formatted (`cargo fmt`)
- [x] New tests added (regression test for bugs, coverage for new features)
- [x] Documentation (both code and site) updated (if applicable)
