### PR TITLE
fix(ci): fix coverage failure

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ env:
 
   _RUST_STABLE: &rust_stable stable
   # Pinning the nightly version to a "stable" version to avoid CI breakages.
-  _RUST_NIGHTLY: &rust_nightly nightly-2026-08-08
+  _RUST_NIGHTLY: &rust_nightly nightly-2026-08-28
 
 # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
 # This will ensure that only one commit will be running tests at a time on each PR.
@@ -191,7 +191,7 @@ jobs:
 
     name: Test coverage checks
     runs-on: ubuntu-latest
-    needs: ["build"]
+    needs: ["check"]
     steps:
       - name: Checkout source
         uses: actions/checkout@v7
@@ -206,13 +206,7 @@ jobs:
           components: llvm-tools-preview
 
       - name: Reclaim disk space
-        run: >
-          sudo rm -rf \
-              /opt/hostedtoolcache/CodeQL \
-              /usr/local/.ghcup \
-              /usr/local/lib/android \
-              /usr/local/lib/dotnet \
-              /usr/local/lib/swift
+        uses: insightsengineering/disk-space-reclaimer@v1
 
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,8 @@ authors = [
 ]
 
 [workspace.lints.rust]
-deprecated-safe = "warn"
-keyword-idents = "warn"
+deprecated_safe = "warn"
+keyword_idents = "warn"
 missing_copy_implementations = "warn"
 missing_debug_implementations = "warn"
 trivial_casts = "warn"

--- a/cot/tests/ui/unimplemented_admin_model.stderr
+++ b/cot/tests/ui/unimplemented_admin_model.stderr
@@ -16,5 +16,11 @@ help: the trait `AdminModel` is implemented for `DatabaseUser`
   | #[derive(Debug, Clone, Form, AdminModel)]
   |                              ^^^^^^^^^^
   = note: required for `DefaultAdminModelManager<Model>` to implement `AdminModelManager`
+note: required because it appears within the type `DefaultAdminModelManager<Model>`
+ --> src/admin.rs
+  |
+  | pub struct DefaultAdminModelManager<T> {
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^
+  = note: required for `Box<DefaultAdminModelManager<Model>>` to implement `CoerceUnsized<Box<dyn AdminModelManager>>`
   = note: required for the cast from `Box<DefaultAdminModelManager<Model>>` to `Box<dyn AdminModelManager>`
   = note: this error originates in the derive macro `AdminModel` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/cot/tests/ui/unimplemented_form.stderr
+++ b/cot/tests/ui/unimplemented_form.stderr
@@ -16,3 +16,22 @@ help: the trait `cot::form::Form` is implemented for `DatabaseUser`
   | #[derive(Debug, Clone, Form, AdminModel)]
   |                        ^^^^
   = note: this error originates in the derive macro `Form` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `MyForm` does not implement the `Form` trait
+ --> tests/ui/unimplemented_form.rs:6:13
+  |
+6 |     let _ = <<MyForm as Form>::Context as FormContext>::new();
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MyForm` is not a form
+  |
+help: the trait `cot::form::Form` is not implemented for `MyForm`
+ --> tests/ui/unimplemented_form.rs:3:1
+  |
+3 | struct MyForm {}
+  | ^^^^^^^^^^^^^
+  = note: add #[derive(cot::form::Form)] to the struct to automatically derive the trait
+help: the trait `cot::form::Form` is implemented for `DatabaseUser`
+ --> src/auth/db.rs
+  |
+  | #[derive(Debug, Clone, Form, AdminModel)]
+  |                        ^^^^
+  = note: this error originates in the derive macro `Form` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This also:

* Updates the Rust nightly version
* Changes the coverage job to depend on `check` instead of `build` to avoid a very long wait for it