### PR TITLE
chore: prioritize doc-code-blocks tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,3 +7,7 @@ doc-code-blocks = { max-threads = 1 }
 [[profile.default.overrides]]
 filter = 'package(cot-test)'
 test-group = 'doc-code-blocks'
+# Prioritize running the doc-code-blocks tests early to avoid a long
+# critical path. These tests must run sequentially, so starting them
+# as soon as possible avoids waiting for only them at the end.
+priority = 100


### PR DESCRIPTION
Guide code blocks tests are quite often the last tests that we need to wait for.

Prioritizing them so that they are run very early should reduce the critical path length and therefore shorten the test runtime (especially in the CI, where the resources we have are fairly constrained).

Note that this does not affect the number of tests ran at a time - multiple tests are still run in parallel, this just moves the `cot-test` to the front of the queue.