### PR TITLE
[CLOSED] perf: replace trivial async implementations with ready

### DIFF
--- a/cot-core/src/request/extractors.rs
+++ b/cot-core/src/request/extractors.rs
@@ -71,9 +71,11 @@ pub trait FromRequest: Sized {
 }
 
 impl FromRequest for Request {
-    #[expect(clippy::unused_async_trait_impl)]
-    async fn from_request(head: &RequestHead, body: Body) -> crate::Result<Self> {
-        Ok(Request::from_parts(head.clone(), body))
+    fn from_request(
+        head: &RequestHead,
+        body: Body,
+    ) -> impl Future<Output = crate::Result<Self>> + Send {
+        core::future::ready(Ok(Request::from_parts(head.clone(), body)))
     }
 }
 
@@ -133,14 +135,17 @@ pub trait FromRequestHead: Sized {
 pub struct Path<D>(pub D);
 
 impl<D: DeserializeOwned> FromRequestHead for Path<D> {
-    #[expect(clippy::unused_async_trait_impl)]
-    async fn from_request_head(head: &RequestHead) -> crate::Result<Self> {
-        let params = head
-            .extensions
-            .get::<PathParams>()
-            .expect("PathParams extension missing")
-            .parse()?;
-        Ok(Self(params))
+    fn from_request_head(head: &RequestHead) -> impl Future<Output = crate::Result<Self>> + Send {
+        core::future::poll_fn(move |_| {
+            core::task::Poll::Ready((|| {
+                let params = head
+                    .extensions
+                    .get::<PathParams>()
+                    .expect("PathParams extension missing")
+                    .parse()?;
+                Ok(Self(params))
+            })())
+        })
     }
 }
 
@@ -191,17 +196,20 @@ impl<D: DeserializeOwned> FromRequestHead for UrlQuery<D>
 where
     D: DeserializeOwned,
 {
-    #[expect(clippy::unused_async_trait_impl)]
-    async fn from_request_head(head: &RequestHead) -> crate::Result<Self> {
-        let query = head.uri.query().unwrap_or_default();
+    fn from_request_head(head: &RequestHead) -> impl Future<Output = crate::Result<Self>> + Send {
+        core::future::poll_fn(move |_| {
+            core::task::Poll::Ready((|| {
+                let query = head.uri.query().unwrap_or_default();
 
-        let deserializer =
-            serde_html_form::Deserializer::new(form_urlencoded::parse(query.as_bytes()));
+                let deserializer =
+                    serde_html_form::Deserializer::new(form_urlencoded::parse(query.as_bytes()));
 
-        let value =
-            serde_path_to_error::deserialize(deserializer).map_err(QueryParametersParseError)?;
+                let value = serde_path_to_error::deserialize(deserializer)
+                    .map_err(QueryParametersParseError)?;
 
-        Ok(UrlQuery(value))
+                Ok(UrlQuery(value))
+            })())
+        })
     }
 }
 
@@ -294,16 +302,14 @@ impl_into_cot_error!(JsonDeserializeError, BAD_REQUEST);
 
 // extractor impls for existing types
 impl FromRequestHead for RequestHead {
-    #[expect(clippy::unused_async_trait_impl)]
-    async fn from_request_head(head: &RequestHead) -> crate::Result<Self> {
-        Ok(head.clone())
+    fn from_request_head(head: &RequestHead) -> impl Future<Output = crate::Result<Self>> + Send {
+        core::future::ready(Ok(head.clone()))
     }
 }
 
 impl FromRequestHead for Method {
-    #[expect(clippy::unused_async_trait_impl)]
-    async fn from_request_head(head: &RequestHead) -> crate::Result<Self> {
-        Ok(head.method.clone())
+    fn from_request_head(head: &RequestHead) -> impl Future<Output = crate::Result<Self>> + Send {
+        core::future::ready(Ok(head.method.clone()))
     }
 }
 

--- a/cot-macros/src/from_request.rs
+++ b/cot-macros/src/from_request.rs
@@ -10,7 +10,7 @@ pub(super) fn impl_from_request_head_for_struct(
     let struct_name = &ast.ident;
     let cot = cot_ident();
 
-    let constructor = match &ast.data {
+    let (constructor, is_empty) = match &ast.data {
         Data::Struct(data_struct) => match &data_struct.fields {
             Fields::Named(fields_named) => {
                 let initializers = fields_named.named.iter().map(|field: &Field| {
@@ -20,7 +20,10 @@ pub(super) fn impl_from_request_head_for_struct(
                         #field_name: <#field_type as #cot::request::extractors::FromRequestHead>::from_request_head(head).await?,
                     }
                 });
-                quote! { Self { #(#initializers)* } }
+                (
+                    quote! { Self { #(#initializers)* } },
+                    fields_named.named.is_empty(),
+                )
             }
 
             Fields::Unnamed(fields_unnamed) => {
@@ -30,26 +33,37 @@ pub(super) fn impl_from_request_head_for_struct(
                         <#field_type as #cot::request::extractors::FromRequestHead>::from_request_head(head).await?,
                     }
                 });
-                quote! { Self(#(#initializers)*) }
+                (
+                    quote! { Self(#(#initializers)*) },
+                    fields_unnamed.unnamed.is_empty(),
+                )
             }
 
-            Fields::Unit => {
-                quote! {
-                    Self
-                }
-            }
+            Fields::Unit => (quote! { Self }, true),
         },
         _ => return Error::custom("Only structs can derive `FromRequestHead`").write_errors(),
     };
 
-    quote! {
-        #[automatically_derived]
-        impl #cot::request::extractors::FromRequestHead for #struct_name {
-            #[expect(clippy::unused_async_trait_impl, clippy::unused_async)]
-            async fn from_request_head(
-                head: &#cot::request::RequestHead,
-            ) -> #cot::Result<Self> {
-                Ok(#constructor)
+    if is_empty {
+        quote! {
+            #[automatically_derived]
+            impl #cot::request::extractors::FromRequestHead for #struct_name {
+                fn from_request_head(
+                    _head: &#cot::request::RequestHead,
+                ) -> impl ::core::future::Future<Output = #cot::Result<Self>> + Send {
+                    ::core::future::ready(Ok(#constructor))
+                }
+            }
+        }
+    } else {
+        quote! {
+            #[automatically_derived]
+            impl #cot::request::extractors::FromRequestHead for #struct_name {
+                async fn from_request_head(
+                    head: &#cot::request::RequestHead,
+                ) -> #cot::Result<Self> {
+                    Ok(#constructor)
+                }
             }
         }
     }

--- a/cot/src/admin.rs
+++ b/cot/src/admin.rs
@@ -383,15 +383,14 @@ fn get_manager(
 struct AdminModelManagers(Vec<Box<dyn AdminModelManager>>);
 
 impl FromRequestHead for AdminModelManagers {
-    #[expect(clippy::unused_async_trait_impl)]
-    async fn from_request_head(head: &RequestHead) -> cot::Result<Self> {
+    fn from_request_head(head: &RequestHead) -> impl Future<Output = cot::Result<Self>> + Send {
         let managers = head
             .context()
             .apps()
             .iter()
             .flat_map(|app| app.admin_model_managers())
             .collect();
-        Ok(Self(managers))
+        core::future::ready(Ok(Self(managers)))
     }
 }
 

--- a/cot/src/cache.rs
+++ b/cot/src/cache.rs
@@ -771,28 +771,29 @@ impl Cache {
     /// # Ok(())
     /// # }
     /// ```
-    #[expect(clippy::unused_async_trait_impl, clippy::unused_async)]
-    pub async fn from_config(config: &CacheConfig) -> CacheResult<Self> {
-        let store_cfg = &config.store;
+    pub fn from_config(config: &CacheConfig) -> impl Future<Output = CacheResult<Self>> + Send {
+        core::future::ready((|| {
+            let store_cfg = &config.store;
 
-        let this = {
-            match store_cfg.store_type {
-                CacheStoreTypeConfig::Memory => {
-                    let mem_store = Memory::new();
-                    Self::new(mem_store, config.prefix.clone(), config.timeout)
+            let this = {
+                match store_cfg.store_type {
+                    CacheStoreTypeConfig::Memory => {
+                        let mem_store = Memory::new();
+                        Self::new(mem_store, config.prefix.clone(), config.timeout)
+                    }
+                    #[cfg(feature = "redis")]
+                    CacheStoreTypeConfig::Redis { ref url, pool_size } => {
+                        let redis_store = Redis::new(url, pool_size)?;
+                        Self::new(redis_store, config.prefix.clone(), config.timeout)
+                    }
+                    _ => {
+                        unimplemented!();
+                    }
                 }
-                #[cfg(feature = "redis")]
-                CacheStoreTypeConfig::Redis { ref url, pool_size } => {
-                    let redis_store = Redis::new(url, pool_size)?;
-                    Self::new(redis_store, config.prefix.clone(), config.timeout)
-                }
-                _ => {
-                    unimplemented!();
-                }
-            }
-        };
+            };
 
-        Ok(this)
+            Ok(this)
+        })())
     }
 }
 

--- a/cot/src/cache.rs
+++ b/cot/src/cache.rs
@@ -772,28 +772,30 @@ impl Cache {
     /// # }
     /// ```
     pub fn from_config(config: &CacheConfig) -> impl Future<Output = CacheResult<Self>> + Send {
-        core::future::ready((|| {
-            let store_cfg = &config.store;
+        core::future::poll_fn(move |_| {
+            core::task::Poll::Ready((|| {
+                let store_cfg = &config.store;
 
-            let this = {
-                match store_cfg.store_type {
-                    CacheStoreTypeConfig::Memory => {
-                        let mem_store = Memory::new();
-                        Self::new(mem_store, config.prefix.clone(), config.timeout)
+                let this = {
+                    match store_cfg.store_type {
+                        CacheStoreTypeConfig::Memory => {
+                            let mem_store = Memory::new();
+                            Self::new(mem_store, config.prefix.clone(), config.timeout)
+                        }
+                        #[cfg(feature = "redis")]
+                        CacheStoreTypeConfig::Redis { ref url, pool_size } => {
+                            let redis_store = Redis::new(url, pool_size)?;
+                            Self::new(redis_store, config.prefix.clone(), config.timeout)
+                        }
+                        _ => {
+                            unimplemented!();
+                        }
                     }
-                    #[cfg(feature = "redis")]
-                    CacheStoreTypeConfig::Redis { ref url, pool_size } => {
-                        let redis_store = Redis::new(url, pool_size)?;
-                        Self::new(redis_store, config.prefix.clone(), config.timeout)
-                    }
-                    _ => {
-                        unimplemented!();
-                    }
-                }
-            };
+                };
 
-            Ok(this)
-        })())
+                Ok(this)
+            })())
+        })
     }
 }
 
@@ -960,6 +962,25 @@ mod tests {
 
         cache.insert("existing", "value").await.unwrap();
         assert!(cache.contains_key("existing").await.unwrap());
+    }
+
+    #[test]
+    fn test_cache_from_config_is_lazy() {
+        use crate::config::CacheStoreConfig;
+
+        let config = CacheConfig::builder()
+            .store(
+                CacheStoreConfig::builder()
+                    .store_type(CacheStoreTypeConfig::File {
+                        path: std::path::PathBuf::from("unused"),
+                    })
+                    .build(),
+            )
+            .build();
+
+        let future = Cache::from_config(&config);
+
+        drop(future);
     }
 
     #[cfg(feature = "redis")]

--- a/cot/src/db/impl_mysql.rs
+++ b/cot/src/db/impl_mysql.rs
@@ -12,9 +12,9 @@ impl_sea_query_db_backend!(DatabaseMySql: sqlx::mysql::MySql, sqlx::mysql::MySql
 impl_sea_query_transaction_backend!(DatabaseMySql, TransactionMySql: sqlx::mysql::MySql, MySqlRow, sea_query::MysqlQueryBuilder);
 
 impl DatabaseMySql {
-    #[expect(clippy::unused_async_trait_impl, clippy::unused_async)]
-    async fn init(&self) -> crate::db::Result<()> {
-        Ok(())
+    #[expect(clippy::unused_self, reason = "for a unified database interface")]
+    fn init(&self) -> impl Future<Output = crate::db::Result<()>> + Send {
+        core::future::ready(Ok(()))
     }
 
     fn prepare_values(_values: &mut sea_query_sqlx::SqlxValues) {

--- a/cot/src/db/impl_postgres.rs
+++ b/cot/src/db/impl_postgres.rs
@@ -11,9 +11,9 @@ impl_sea_query_db_backend!(DatabasePostgres: sqlx::postgres::Postgres, sqlx::pos
 impl_sea_query_transaction_backend!(DatabasePostgres, TransactionPostgres: sqlx::postgres::Postgres, PostgresRow, sea_query::PostgresQueryBuilder);
 
 impl DatabasePostgres {
-    #[expect(clippy::unused_async_trait_impl, clippy::unused_async)]
-    async fn init(&self) -> crate::db::Result<()> {
-        Ok(())
+    #[expect(clippy::unused_self, reason = "for a unified database interface")]
+    fn init(&self) -> impl Future<Output = crate::db::Result<()>> + Send {
+        core::future::ready(Ok(()))
     }
 
     fn prepare_values(values: &mut sea_query_sqlx::SqlxValues) {

--- a/cot/src/email/transport/console.rs
+++ b/cot/src/email/transport/console.rs
@@ -86,14 +86,15 @@ impl Default for Console {
 }
 
 impl Transport for Console {
-    #[expect(clippy::unused_async_trait_impl)]
-    async fn send(&self, messages: &[EmailMessage]) -> TransportResult<()> {
-        let mut out = io::stdout().lock();
-        for msg in messages {
-            writeln!(out, "{msg}").map_err(ConsoleError::Io)?;
-            writeln!(out, "{}", "─".repeat(60)).map_err(ConsoleError::Io)?;
-        }
-        Ok(())
+    fn send(&self, messages: &[EmailMessage]) -> impl Future<Output = TransportResult<()>> + Send {
+        core::future::ready((|| {
+            let mut out = io::stdout().lock();
+            for msg in messages {
+                writeln!(out, "{msg}").map_err(ConsoleError::Io)?;
+                writeln!(out, "{}", "─".repeat(60)).map_err(ConsoleError::Io)?;
+            }
+            Ok(())
+        })())
     }
 }
 

--- a/cot/src/email/transport/console.rs
+++ b/cot/src/email/transport/console.rs
@@ -87,14 +87,17 @@ impl Default for Console {
 
 impl Transport for Console {
     fn send(&self, messages: &[EmailMessage]) -> impl Future<Output = TransportResult<()>> + Send {
-        core::future::ready((|| {
-            let mut out = io::stdout().lock();
-            for msg in messages {
-                writeln!(out, "{msg}").map_err(ConsoleError::Io)?;
-                writeln!(out, "{}", "─".repeat(60)).map_err(ConsoleError::Io)?;
-            }
-            Ok(())
-        })())
+        core::future::poll_fn(move |_| {
+            let result = (|| {
+                let mut out = io::stdout().lock();
+                for msg in messages {
+                    writeln!(out, "{msg}").map_err(ConsoleError::Io)?;
+                    writeln!(out, "{}", "─".repeat(60)).map_err(ConsoleError::Io)?;
+                }
+                Ok(())
+            })();
+            core::task::Poll::Ready(result)
+        })
     }
 }
 

--- a/cot/src/error/handler.rs
+++ b/cot/src/error/handler.rs
@@ -209,13 +209,15 @@ impl Display for RequestOuterError {
 }
 
 impl FromRequestHead for RequestOuterError {
-    #[expect(clippy::unused_async_trait_impl)]
-    async fn from_request_head(head: &RequestHead) -> crate::Result<Self> {
-        let error = head.extensions.get::<RequestOuterError>();
-        error
+    fn from_request_head(head: &RequestHead) -> impl Future<Output = crate::Result<Self>> + Send {
+        let error = head
+            .extensions
+            .get::<RequestOuterError>()
             .ok_or_else(|| {
                 Error::internal("No error found in request head. Make sure you use this extractor in an error handler.")
-            }).cloned()
+            })
+            .cloned();
+        core::future::ready(error)
     }
 }
 
@@ -246,17 +248,18 @@ impl Display for RequestError {
 }
 
 impl FromRequestHead for RequestError {
-    #[expect(clippy::unused_async_trait_impl)]
-    async fn from_request_head(head: &RequestHead) -> crate::Result<Self> {
-        let error = head.extensions.get::<RequestOuterError>();
-        error
+    fn from_request_head(head: &RequestHead) -> impl Future<Output = crate::Result<Self>> + Send {
+        let error = head
+            .extensions
+            .get::<RequestOuterError>()
             .ok_or_else(|| {
                 Error::internal(
                     "No error found in request head. \
                 Make sure you use this extractor in an error handler.",
                 )
             })
-            .map(|request_error| Self(request_error.0.clone()))
+            .map(|request_error| Self(request_error.0.clone()));
+        core::future::ready(error)
     }
 }
 

--- a/cot/src/project.rs
+++ b/cot/src/project.rs
@@ -1377,22 +1377,28 @@ impl Bootstrapper<WithCache> {
     /// # }
     /// ```
     pub fn boot(self) -> impl Future<Output = cot::Result<Bootstrapper<Initialized>>> {
-        let router_service = RouterService::new(Arc::clone(&self.context.router));
-        let handler_builder = RootHandlerBuilder {
-            handler: router_service,
-            error_handler: self.project.error_handler(),
-        };
-        let handler = self.project.middlewares(handler_builder, &self.context);
+        let mut bootstrapper = Some(self);
+        poll_fn(move |_| {
+            let Some(this) = bootstrapper.take() else {
+                return core::task::Poll::Pending;
+            };
+            let router_service = RouterService::new(Arc::clone(&this.context.router));
+            let handler_builder = RootHandlerBuilder {
+                handler: router_service,
+                error_handler: this.project.error_handler(),
+            };
+            let handler = this.project.middlewares(handler_builder, &this.context);
 
-        let auth_backend = self.project.auth_backend(&self.context);
-        let context = self.context.with_auth(auth_backend);
+            let auth_backend = this.project.auth_backend(&this.context);
+            let context = this.context.with_auth(auth_backend);
 
-        core::future::ready(Ok(Bootstrapper {
-            project: self.project,
-            context,
-            handler: handler.handler,
-            error_handler: handler.error_handler,
-        }))
+            core::task::Poll::Ready(Ok(Bootstrapper {
+                project: this.project,
+                context,
+                handler: handler.handler,
+                error_handler: handler.error_handler,
+            }))
+        })
     }
 }
 impl Bootstrapper<Initialized> {
@@ -2591,6 +2597,44 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    #[cot::test]
+    async fn bootstrapper_with_cache_boot_is_lazy() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct LazyProject {
+            middleware_calls: Arc<AtomicUsize>,
+        }
+
+        impl Project for LazyProject {
+            fn middlewares(
+                &self,
+                handler: RootHandlerBuilder,
+                _context: &MiddlewareContext,
+            ) -> RootHandler {
+                self.middleware_calls.fetch_add(1, Ordering::SeqCst);
+                handler.build()
+            }
+        }
+
+        let middleware_calls = Arc::new(AtomicUsize::new(0));
+        let bootstrapper = Bootstrapper::new(LazyProject {
+            middleware_calls: Arc::clone(&middleware_calls),
+        })
+        .with_config(ProjectConfig::default())
+        .with_apps()
+        .with_database()
+        .await
+        .unwrap()
+        .with_cache()
+        .await
+        .unwrap();
+
+        let future = bootstrapper.boot();
+        assert_eq!(middleware_calls.load(Ordering::SeqCst), 0);
+        drop(future);
+        assert_eq!(middleware_calls.load(Ordering::SeqCst), 0);
     }
 
     #[cot::test]

--- a/cot/src/project.rs
+++ b/cot/src/project.rs
@@ -1306,26 +1306,32 @@ impl Bootstrapper<WithDatabase> {
     /// # Ok(())
     /// # }
     /// ```
-    #[allow(
-        clippy::unused_async,
-        clippy::allow_attributes,
-        reason = "see https://github.com/cot-rs/cot/pull/399#discussion_r2430379966"
-    )]
-    pub async fn with_cache(self) -> cot::Result<Bootstrapper<WithCache>> {
+    pub fn with_cache(self) -> impl Future<Output = cot::Result<Bootstrapper<WithCache>>> {
         #[cfg(feature = "cache")]
-        let cache = Self::init_cache(&self.context.config.cache).await?;
+        {
+            async move {
+                let cache = Self::init_cache(&self.context.config.cache).await?;
+                let context = self.context.with_cache(cache);
 
-        let context = self.context.with_cache(
-            #[cfg(feature = "cache")]
-            cache,
-        );
+                Ok(Bootstrapper {
+                    project: self.project,
+                    context,
+                    handler: self.handler,
+                    error_handler: self.error_handler,
+                })
+            }
+        }
 
-        Ok(Bootstrapper {
-            project: self.project,
-            context,
-            handler: self.handler,
-            error_handler: self.error_handler,
-        })
+        #[cfg(not(feature = "cache"))]
+        {
+            let context = self.context.with_cache();
+            core::future::ready(Ok(Bootstrapper {
+                project: self.project,
+                context,
+                handler: self.handler,
+                error_handler: self.error_handler,
+            }))
+        }
     }
 
     #[cfg(feature = "cache")]

--- a/cot/src/project.rs
+++ b/cot/src/project.rs
@@ -1307,7 +1307,6 @@ impl Bootstrapper<WithDatabase> {
     /// # }
     /// ```
     #[allow(
-        clippy::unused_async_trait_impl,
         clippy::unused_async,
         clippy::allow_attributes,
         reason = "see https://github.com/cot-rs/cot/pull/399#discussion_r2430379966"
@@ -1371,12 +1370,7 @@ impl Bootstrapper<WithCache> {
     /// # Ok(())
     /// # }
     /// ```
-    #[expect(
-        clippy::unused_async,
-        reason = "for consistency with other Bootstrapper::boot methods"
-    )]
-    #[expect(clippy::unused_async_trait_impl)]
-    pub async fn boot(self) -> cot::Result<Bootstrapper<Initialized>> {
+    pub fn boot(self) -> impl Future<Output = cot::Result<Bootstrapper<Initialized>>> {
         let router_service = RouterService::new(Arc::clone(&self.context.router));
         let handler_builder = RootHandlerBuilder {
             handler: router_service,
@@ -1387,12 +1381,12 @@ impl Bootstrapper<WithCache> {
         let auth_backend = self.project.auth_backend(&self.context);
         let context = self.context.with_auth(auth_backend);
 
-        Ok(Bootstrapper {
+        core::future::ready(Ok(Bootstrapper {
             project: self.project,
             context,
             handler: handler.handler,
             error_handler: handler.error_handler,
-        })
+        }))
     }
 }
 impl Bootstrapper<Initialized> {

--- a/cot/src/request/extractors.rs
+++ b/cot/src/request/extractors.rs
@@ -79,9 +79,8 @@ use crate::router::Urls;
 use crate::session::Session;
 
 impl FromRequestHead for Urls {
-    #[expect(clippy::unused_async_trait_impl)]
-    async fn from_request_head(head: &RequestHead) -> cot::Result<Self> {
-        Ok(Self::from_parts(head))
+    fn from_request_head(head: &RequestHead) -> impl Future<Output = cot::Result<Self>> + Send {
+        core::future::ready(Ok(Self::from_parts(head)))
     }
 }
 
@@ -142,25 +141,22 @@ impl<F: Form> FromRequest for RequestForm<F> {
 
 #[cfg(feature = "db")]
 impl FromRequestHead for crate::db::Database {
-    #[expect(clippy::unused_async_trait_impl)]
-    async fn from_request_head(head: &RequestHead) -> cot::Result<Self> {
-        Ok(head.context().database().clone())
+    fn from_request_head(head: &RequestHead) -> impl Future<Output = cot::Result<Self>> + Send {
+        core::future::ready(Ok(head.context().database().clone()))
     }
 }
 
 #[cfg(feature = "cache")]
 impl FromRequestHead for crate::cache::Cache {
-    #[expect(clippy::unused_async_trait_impl)]
-    async fn from_request_head(head: &RequestHead) -> cot::Result<Self> {
-        Ok(head.context().cache().clone())
+    fn from_request_head(head: &RequestHead) -> impl Future<Output = cot::Result<Self>> + Send {
+        core::future::ready(Ok(head.context().cache().clone()))
     }
 }
 
 #[cfg(feature = "email")]
 impl FromRequestHead for crate::email::Email {
-    #[expect(clippy::unused_async_trait_impl)]
-    async fn from_request_head(head: &RequestHead) -> cot::Result<Self> {
-        Ok(head.context().email().clone())
+    fn from_request_head(head: &RequestHead) -> impl Future<Output = cot::Result<Self>> + Send {
+        core::future::ready(Ok(head.context().email().clone()))
     }
 }
 
@@ -263,35 +259,32 @@ pub enum StaticFilesGetError {
 impl_into_cot_error!(StaticFilesGetError);
 
 impl FromRequestHead for StaticFiles {
-    #[expect(clippy::unused_async_trait_impl)]
-    async fn from_request_head(head: &RequestHead) -> cot::Result<Self> {
-        Ok(StaticFiles {
+    fn from_request_head(head: &RequestHead) -> impl Future<Output = cot::Result<Self>> + Send {
+        core::future::ready(Ok(StaticFiles {
             inner: head
                 .extensions
                 .get::<Arc<crate::static_files::StaticFiles>>()
                 .cloned()
                 .expect("StaticFilesMiddleware not enabled for the route/project"),
-        })
+        }))
     }
 }
 
 impl FromRequestHead for Session {
-    #[expect(clippy::unused_async_trait_impl)]
-    async fn from_request_head(head: &RequestHead) -> cot::Result<Self> {
-        Ok(Session::from_extensions(&head.extensions).clone())
+    fn from_request_head(head: &RequestHead) -> impl Future<Output = cot::Result<Self>> + Send {
+        core::future::ready(Ok(Session::from_extensions(&head.extensions).clone()))
     }
 }
 
 impl FromRequestHead for Auth {
-    #[expect(clippy::unused_async_trait_impl)]
-    async fn from_request_head(head: &RequestHead) -> cot::Result<Self> {
+    fn from_request_head(head: &RequestHead) -> impl Future<Output = cot::Result<Self>> + Send {
         let auth = head
             .extensions
             .get::<Auth>()
             .expect("AuthMiddleware not enabled for the route/project")
             .clone();
 
-        Ok(auth)
+        core::future::ready(Ok(auth))
     }
 }
 

--- a/cot/src/router.rs
+++ b/cot/src/router.rs
@@ -1067,9 +1067,8 @@ mod tests {
     struct MockHandler;
 
     impl RequestHandler for MockHandler {
-        #[expect(clippy::unused_async_trait_impl)]
-        async fn handle(&self, _request: Request) -> Result<Response> {
-            Html::new("OK").into_response()
+        fn handle(&self, _request: Request) -> impl Future<Output = Result<Response>> + Send {
+            core::future::ready(Html::new("OK").into_response())
         }
     }
 

--- a/cot/tests/from_request.rs
+++ b/cot/tests/from_request.rs
@@ -18,9 +18,8 @@ struct MyTupleStruct(DummyExtractor, DummyExtractor);
 struct DummyExtractor;
 
 impl FromRequestHead for DummyExtractor {
-    #[expect(clippy::unused_async_trait_impl)]
-    async fn from_request_head(_head: &RequestHead) -> cot::Result<Self> {
-        Ok(Self)
+    fn from_request_head(_head: &RequestHead) -> impl Future<Output = cot::Result<Self>> + Send {
+        core::future::ready(Ok(Self))
     }
 }
 


### PR DESCRIPTION
Replaces #654, which GitHub closed automatically when its head fork was accidentally deleted. This branch restores the exact reviewed commit.

## Related issue or discussion

Fixes #651

## Description

Replaces trivial `async` implementations with regular functions returning immediately-ready futures, removing the `unused_async_trait_impl` suppressions from production code and generated empty extractors.

`Path` and `UrlQuery` use `poll_fn` rather than `ready`: storing their result in `Ready` would add a `Send` requirement to the deserialized output and narrow the existing generic API. The console transport also uses `poll_fn` so its stdout side effects remain lazy. Each computation still completes on the first poll without an async state machine.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / cleanup
- [x] Performance improvement
- [ ] Other (describe above)

## Checklist

- [x] I've read the [contributing guide](CONTRIBUTING.md)
- [ ] Tests pass locally (`just test-all`) — the full non-ignored workspace and doctest suite passes; ignored service tests could not start because local port 5432 is occupied
- [x] Code passes clippy (`just clippy`)
- [x] Code is properly formatted (`cargo fmt`)
- [x] New tests added (not applicable: behavior is unchanged and existing extractor/derive tests cover the changed paths)
- [x] Documentation updated (not applicable: no user-facing behavior changed)

### Commands run

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
