### PR TITLE
feat(security): limit request body size

### DIFF
--- a/cot-core/src/body.rs
+++ b/cot-core/src/body.rs
@@ -162,11 +162,27 @@ impl Body {
     pub async fn into_bytes_limited(self, limit: usize) -> Result<Bytes> {
         use http_body_util::BodyExt;
 
-        Ok(http_body_util::Limited::new(self, limit)
+        http_body_util::Limited::new(self, limit)
             .collect()
             .await
             .map(http_body_util::Collected::to_bytes)
-            .map_err(ReadRequestBody)?)
+            .map_err(request_body_error)
+    }
+    #[must_use]
+    #[doc(hidden)]
+    pub fn with_limit(self, limit: usize) -> Self {
+        use http_body_util::BodyExt;
+
+        let body = http_body_util::Limited::new(self, limit)
+            .map_err(move |error| {
+                if error.is::<http_body_util::LengthLimitError>() {
+                    RequestBodyTooLarge { limit }.into()
+                } else {
+                    request_body_error(error)
+                }
+            })
+            .boxed();
+        Self::wrapper(body)
     }
 
     #[must_use]
@@ -195,8 +211,8 @@ impl http_body::Body for Body {
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<std::result::Result<Frame<Self::Data>, Self::Error>>> {
-        match self.get_mut().inner {
-            BodyInner::Fixed(ref mut data) => {
+        match &mut self.get_mut().inner {
+            BodyInner::Fixed(data) => {
                 if data.is_empty() {
                     Poll::Ready(None)
                 } else {
@@ -204,7 +220,7 @@ impl http_body::Body for Body {
                     Poll::Ready(Some(Ok(Frame::data(data))))
                 }
             }
-            BodyInner::Streaming(ref mut stream) => {
+            BodyInner::Streaming(stream) => {
                 let stream = Pin::as_mut(stream.get_mut());
                 match stream.poll_next(cx) {
                     Poll::Ready(Some(result)) => Poll::Ready(Some(result.map(Frame::data))),
@@ -212,15 +228,13 @@ impl http_body::Body for Body {
                     Poll::Pending => Poll::Pending,
                 }
             }
-            BodyInner::Axum(ref mut axum_body) => {
+            BodyInner::Axum(axum_body) => {
                 let axum_body = axum_body.get_mut();
                 Pin::new(axum_body)
                     .poll_frame(cx)
                     .map_err(|error| ReadRequestBody(Box::new(error)).into())
             }
-            BodyInner::Wrapper(ref mut http_body) => Pin::new(http_body)
-                .poll_frame(cx)
-                .map_err(|error| ReadRequestBody(Box::new(error)).into()),
+            BodyInner::Wrapper(http_body) => Pin::new(http_body).poll_frame(cx),
         }
     }
 
@@ -263,6 +277,23 @@ body_from_impl!(Bytes);
 #[error("could not retrieve request body: {0}")]
 struct ReadRequestBody(#[source] Box<dyn StdError + Send + Sync>);
 impl_into_cot_error!(ReadRequestBody, BAD_REQUEST);
+
+fn request_body_error(error: Box<dyn StdError + Send + Sync>) -> Error {
+    match error.downcast::<Error>() {
+        Ok(error) => *error,
+        Err(error) => ReadRequestBody(error).into(),
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "the max request body size of {limit} bytes has been exceeded; increase \
+     `max_request_body_size` in the project config if this request is expected"
+)]
+struct RequestBodyTooLarge {
+    limit: usize,
+}
+impl_into_cot_error!(RequestBodyTooLarge, PAYLOAD_TOO_LARGE);
 
 #[cfg(test)]
 mod tests {
@@ -358,5 +389,28 @@ mod tests {
         let content = "Hello, world!";
         let body = Body::fixed(content);
         assert_eq!(body.size_hint().exact(), Some(content.len() as u64));
+    }
+    #[cot::test]
+    async fn body_limit_enforces_aggregate_size() {
+        let bytes = Body::fixed("Hello")
+            .with_limit(5)
+            .into_bytes()
+            .await
+            .unwrap();
+        assert_eq!(bytes, "Hello");
+
+        let chunks = stream::iter([
+            Ok(Bytes::from_static(b"Hel")),
+            Ok(Bytes::from_static(b"lo!")),
+        ]);
+        let error = Body::streaming(chunks)
+            .with_limit(5)
+            .into_bytes()
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.status_code(), crate::StatusCode::PAYLOAD_TOO_LARGE);
+        assert!(error.to_string().contains("max request body size"));
+        assert!(error.to_string().contains("max_request_body_size"));
     }
 }

--- a/cot/src/config.rs
+++ b/cot/src/config.rs
@@ -86,6 +86,27 @@ pub struct ProjectConfig {
     /// # Ok::<(), cot::Error>(())
     /// ```
     pub register_panic_hook: bool,
+    /// The maximum allowed request body size, in bytes.
+    ///
+    /// Requests whose bodies exceed this limit fail with HTTP 413 Content Too
+    /// Large. This protects the process from unbounded memory use while
+    /// parsing forms, uploads, and other request bodies. The default is 2 MiB.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cot::config::ProjectConfig;
+    ///
+    /// let config = ProjectConfig::from_toml(
+    ///     r#"
+    /// max_request_body_size = 10485760
+    /// "#,
+    /// )?;
+    ///
+    /// assert_eq!(config.max_request_body_size, 10 * 1024 * 1024);
+    /// # Ok::<(), cot::Error>(())
+    /// ```
+    pub max_request_body_size: usize,
     /// The secret key used for signing cookies and other sensitive data. This
     /// is a cryptographic key, should be kept secret, and should be set to a
     /// random and unique value for each project.
@@ -311,6 +332,8 @@ const fn default_debug() -> bool {
     cfg!(debug_assertions)
 }
 
+const DEFAULT_MAX_REQUEST_BODY_SIZE: usize = 2 * 1024 * 1024;
+
 impl Default for ProjectConfig {
     fn default() -> Self {
         ProjectConfig::builder().build()
@@ -404,6 +427,9 @@ impl ProjectConfigBuilder {
         ProjectConfig {
             debug,
             register_panic_hook: self.register_panic_hook.unwrap_or(true),
+            max_request_body_size: self
+                .max_request_body_size
+                .unwrap_or(DEFAULT_MAX_REQUEST_BODY_SIZE),
             secret_key: self.secret_key.clone().unwrap_or_default(),
             fallback_secret_keys: self.fallback_secret_keys.clone().unwrap_or_default(),
             auth_backend: self.auth_backend.unwrap_or_default(),
@@ -2495,10 +2521,18 @@ impl From<&str> for EmailUrl {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use serde_json;
     use time::OffsetDateTime;
 
-    use super::*;
+    #[test]
+    fn request_body_limit_config() {
+        let default_config = ProjectConfig::default();
+        assert_eq!(default_config.max_request_body_size, 2 * 1024 * 1024);
+
+        let config = ProjectConfig::from_toml("max_request_body_size = 4096").unwrap();
+        assert_eq!(config.max_request_body_size, 4096);
+    }
 
     #[test]
     fn from_toml_valid() {

--- a/cot/src/config.rs
+++ b/cot/src/config.rs
@@ -2521,9 +2521,10 @@ impl From<&str> for EmailUrl {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_json;
     use time::OffsetDateTime;
+
+    use super::*;
 
     #[test]
     fn request_body_limit_config() {

--- a/cot/src/project.rs
+++ b/cot/src/project.rs
@@ -2335,6 +2335,9 @@ fn request_axum_to_cot(
 }
 
 pub(crate) fn prepare_request(request: &mut Request, context: Arc<ProjectContext>) {
+    let body =
+        std::mem::take(request.body_mut()).with_limit(context.config().max_request_body_size);
+    *request.body_mut() = body;
     request.extensions_mut().insert(context);
 }
 

--- a/cot/tests/project.rs
+++ b/cot/tests/project.rs
@@ -1,11 +1,13 @@
 use bytes::Bytes;
 use cot::config::ProjectConfig;
+use cot::error::handler::{DynErrorPageHandler, RequestError};
 use cot::html::Html;
 use cot::project::RegisterAppsContext;
 use cot::request::Request;
+use cot::response::IntoResponse;
 use cot::router::{Route, Router};
 use cot::test::Client;
-use cot::{App, AppBuilder, Project, StatusCode, reverse};
+use cot::{App, AppBuilder, Body, Project, StatusCode, reverse};
 
 #[cot::test]
 #[cfg_attr(
@@ -59,6 +61,63 @@ async fn cot_project_router_sub_path() {
 
     let response = client.get("/app/hello").await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[cot::test]
+#[cfg_attr(
+    miri,
+    ignore = "unsupported operation: can't call foreign function `sqlite3_open_v2`"
+)]
+async fn request_body_limit_uses_project_error_handler() {
+    async fn consume_body(request: Request) -> cot::Result<Html> {
+        request.into_body().into_bytes().await?;
+        Ok(Html::new("accepted"))
+    }
+
+    async fn error_handler(error: RequestError) -> impl IntoResponse {
+        Html::new("custom error handler").with_status(error.status_code())
+    }
+
+    struct TestApp;
+    impl App for TestApp {
+        fn name(&self) -> &'static str {
+            "test"
+        }
+
+        fn router(&self) -> Router {
+            Router::with_urls([Route::with_handler("/", consume_body)])
+        }
+    }
+
+    struct TestProject;
+    impl Project for TestProject {
+        fn config(&self, _config_name: &str) -> cot::Result<ProjectConfig> {
+            Ok(ProjectConfig::builder().max_request_body_size(5).build())
+        }
+
+        fn register_apps(&self, apps: &mut AppBuilder, _context: &RegisterAppsContext) {
+            apps.register_with_views(TestApp, "");
+        }
+
+        fn error_handler(&self) -> DynErrorPageHandler {
+            DynErrorPageHandler::new(error_handler)
+        }
+    }
+
+    let request = http::Request::post("/")
+        .body(Body::fixed("Hello, world!"))
+        .unwrap();
+    let response = Client::new(TestProject)
+        .await
+        .request(request)
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    assert_eq!(
+        response.into_body().into_bytes().await.unwrap(),
+        "custom error handler"
+    );
 }
 
 #[cot::test]


### PR DESCRIPTION
Closes #341.

Request bodies are currently unbounded at the project boundary. An upload or chunked request can therefore keep growing until the process runs out of memory.

This adds a global 2 MiB default and a `max_request_body_size` TOML setting for projects that need a different ceiling. Every incoming body is wrapped before it reaches routing or middleware, and the limit counts bytes across the full stream rather than trusting Content-Length.

When the limit is crossed, the body returns a Cot error with HTTP 413. The error keeps the normal project error path intact, so production uses the configured error handler; in debug diagnostics the message points directly at `max_request_body_size`. Existing body errors also keep their original Cot status instead of being flattened into a 400 while crossing the wrapper.

Coverage includes the exact boundary, a multi-chunk overflow, TOML/default configuration, and an end-to-end project test proving a custom error handler receives and returns the 413.

Checked with:
- `cargo test -p cot_core body::tests` (8 passed)
- `cargo test -p cot --all-features request_body_limit` (2 passed)
- `cargo clippy -p cot_core -p cot --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`