### PR TITLE
docs: clarify session and auth middleware order

### DIFF
--- a/cot/src/middleware.rs
+++ b/cot/src/middleware.rs
@@ -453,10 +453,14 @@ where
 /// user to the request extensions. This adds the [`crate::auth::Auth`] object
 /// to the request which can be accessed by the request handlers.
 ///
+/// This middleware requires [`SessionMiddleware`]. Since each
+/// [`RootHandlerBuilder::middleware`] call wraps the existing handler, register
+/// `SessionMiddleware` after `AuthMiddleware` so session handling runs first.
+///
 /// # Examples
 ///
 /// ```
-/// use cot::middleware::AuthMiddleware;
+/// use cot::middleware::{AuthMiddleware, SessionMiddleware};
 /// use cot::project::{MiddlewareContext, RootHandler, RootHandlerBuilder};
 /// use cot::{Project, ProjectContext};
 ///
@@ -467,7 +471,10 @@ where
 ///         handler: RootHandlerBuilder,
 ///         context: &MiddlewareContext,
 ///     ) -> RootHandler {
-///         handler.middleware(AuthMiddleware::new()).build()
+///         handler
+///             .middleware(AuthMiddleware::new())
+///             .middleware(SessionMiddleware::from_context(context))
+///             .build()
 ///     }
 /// }
 /// ```
@@ -663,7 +670,7 @@ mod tests {
 
     #[cot::test]
     #[should_panic(
-        expected = "Session extension missing. Did you forget to add the SessionMiddleware?"
+        expected = "Session extension missing. Add SessionMiddleware, and if using AuthMiddleware, register SessionMiddleware after AuthMiddleware."
     )]
     async fn auth_middleware_requires_session() {
         let svc = tower::service_fn(|_req: Request<Body>| async move {

--- a/cot/src/project.rs
+++ b/cot/src/project.rs
@@ -491,6 +491,12 @@ where
     /// This method is used to add middleware to the project. The middleware
     /// will be applied to all routes in the project.
     ///
+    /// Each call wraps the handler built so far. Middleware registered later
+    /// therefore runs earlier while processing a request. Register middleware
+    /// dependencies after the middleware that needs them; for example,
+    /// [`crate::middleware::SessionMiddleware`] must be registered after
+    /// [`crate::middleware::AuthMiddleware`] so that session handling runs first.
+    ///
     /// # Examples
     ///
     /// ```

--- a/cot/src/session.rs
+++ b/cot/src/session.rs
@@ -143,7 +143,7 @@ impl Session {
     pub(crate) fn from_extensions(extensions: &http::Extensions) -> &Self {
         extensions
             .get::<Self>()
-            .expect("Session extension missing. Did you forget to add the SessionMiddleware?")
+            .expect("Session extension missing. Add SessionMiddleware, and if using AuthMiddleware, register SessionMiddleware after AuthMiddleware.")
     }
 }
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -296,7 +296,7 @@ This registers all the apps that your project is using.
 # }
 ```
 
-This registers the middlewares that will be applied to all routes in the project. Note that the [`LiveReloadMiddleware`](struct@cot::middleware::LiveReloadMiddleware) may be dynamically disabled in runtime using config!
+This registers the middlewares that will be applied to all routes in the project. Each `.middleware(...)` call wraps the handler built so far, so middleware listed later runs earlier while processing a request. Register middleware dependencies after the middleware that needs them; for example, register [`SessionMiddleware`](struct@cot::middleware::SessionMiddleware) after [`AuthMiddleware`](struct@cot::middleware::AuthMiddleware). Note that the [`LiveReloadMiddleware`](struct@cot::middleware::LiveReloadMiddleware) may be dynamically disabled in runtime using config!
 
 ```rust,has_main
 # use cot::Project;


### PR DESCRIPTION
The panic correctly indicates that the session extension is missing, but the old suggestion to “add SessionMiddleware” is misleading when both middlewares are already present in the wrong builder order.

The diagnostic now explains both cases: add `SessionMiddleware`, and when authentication is enabled, register it after `AuthMiddleware`. The `RootHandlerBuilder::middleware` API docs, `AuthMiddleware` example, and project introduction now explain the wrapping rule: later registrations run earlier for each request. The panic regression pins the actionable wording.

Verification:
- focused middleware panic regression: 1 passed
- Cot library suite with all features: 555 passed, 36 ignored
- Cot doctests with all features: 696 passed, 3 ignored
- `cargo +1.94.0 fmt --all -- --check`
- Cot Clippy across all targets/features with warnings denied (`unknown-lints` allowed because Clippy 1.94 predates an upstream lint)

Closes #276.