### PR TITLE
feat: preserve glob imports in generated migrations

### DIFF
--- a/cot-cli/src/migration_generator.rs
+++ b/cot-cli/src/migration_generator.rs
@@ -373,6 +373,7 @@ impl MigrationGenerator {
         trace!("Processing file: {:?}", &path);
 
         let symbol_resolver = SymbolResolver::from_file(&file, &path);
+        let glob_imports = SymbolResolver::glob_imports(&file, &path);
 
         let mut migration_models = Vec::new();
         for item in file.items {
@@ -387,6 +388,7 @@ impl MigrationGenerator {
                             item,
                             &args,
                             &symbol_resolver,
+                            glob_imports.clone(),
                         )?;
 
                         match args.model_type {
@@ -534,12 +536,20 @@ impl MigrationGenerator {
             }
         };
 
+        let mut seen_glob_imports = HashSet::new();
+        let glob_imports = migration
+            .modified_models
+            .iter()
+            .flat_map(|model| model.glob_imports.iter())
+            .filter(|import| seen_glob_imports.insert(import.to_token_stream().to_string()))
+            .collect::<Vec<_>>();
         let models = migration
             .modified_models
             .iter()
             .map(Self::model_to_migration_model)
             .collect::<Vec<_>>();
         let models_def = quote! {
+            #(#glob_imports)*
             #(#models)*
         };
 
@@ -1009,6 +1019,7 @@ impl MigrationProcessor {
 pub struct ModelInSource {
     model_item: syn::ItemStruct,
     model: Model,
+    glob_imports: Vec<syn::ItemUse>,
 }
 
 impl ModelInSource {
@@ -1017,6 +1028,7 @@ impl ModelInSource {
         item: syn::ItemStruct,
         args: &ModelArgs,
         symbol_resolver: &SymbolResolver,
+        glob_imports: Vec<syn::ItemUse>,
     ) -> anyhow::Result<Self> {
         let input: syn::DeriveInput = item.clone().into();
         let opts = ModelOpts::new_from_derive_input(&input)
@@ -1027,6 +1039,7 @@ impl ModelInSource {
         Ok(Self {
             model_item: item,
             model,
+            glob_imports,
         })
     }
 }
@@ -1962,6 +1975,7 @@ mod tests {
                     foreign_key: None,
                 }],
             },
+            glob_imports: Vec::new(),
         }
     }
     fn get_bigger_test_model() -> ModelInSource {
@@ -2011,6 +2025,7 @@ mod tests {
                     },
                 ],
             },
+            glob_imports: Vec::new(),
         }
     }
 

--- a/cot-cli/tests/migration_generator.rs
+++ b/cot-cli/tests/migration_generator.rs
@@ -223,6 +223,60 @@ fn create_model_keywords_source() {
     );
 }
 
+#[test]
+fn create_model_source_preserves_glob_imports() {
+    let generator = test_generator();
+    let src = r"
+use crate::model_types::*;
+use super::shared::*;
+
+#[model]
+struct MyModel {
+    #[model(primary_key)]
+    id: Auto<i32>,
+}
+";
+    let source_files = vec![SourceFile::parse(PathBuf::from("models/my_model.rs"), src).unwrap()];
+
+    let migration = generator
+        .generate_migrations_as_source_from_files(source_files)
+        .unwrap()
+        .unwrap();
+
+    assert!(migration.content.contains("use crate::model_types::*;"));
+    assert!(migration.content.contains("use crate::models::shared::*;"));
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "unsupported operation: extern static `pidfd_spawnp` is not supported by Miri"
+)]
+fn create_model_with_glob_import_compiles() {
+    let generator = test_generator();
+    let src = r"
+mod model_types {
+    pub use cot::db::{model, Auto};
+}
+use crate::model_types::*;
+
+#[model]
+struct MyModel {
+    #[model(primary_key)]
+    id: Auto<i32>,
+}
+
+fn main() {}
+";
+    let source_files = vec![SourceFile::parse(PathBuf::from("main.rs"), src).unwrap()];
+    let migration = generator
+        .generate_migrations_as_source_from_files(source_files)
+        .unwrap()
+        .unwrap();
+
+    compile_test(src, &migration.name, &migration.content);
+}
+
 /// Test that the migration generator can generate a "create model" migration
 /// for a given model which compiles successfully.
 #[test]

--- a/cot-codegen/src/symbol_resolver.rs
+++ b/cot-codegen/src/symbol_resolver.rs
@@ -8,8 +8,6 @@ use std::path::Path;
 use quote::format_ident;
 #[cfg(feature = "symbol-resolver")]
 use syn::UseTree;
-#[cfg(feature = "symbol-resolver")]
-use tracing::warn;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SymbolResolver {
@@ -35,6 +33,41 @@ impl SymbolResolver {
     pub fn from_file(file: &syn::File, module_path: &Path) -> Self {
         let imports = Self::get_imports(file, &ModulePath::from_fs_path(module_path));
         Self::new(imports)
+    }
+
+    /// Returns top-level glob imports with paths resolved relative to the
+    /// source module.
+    #[cfg(feature = "symbol-resolver")]
+    #[must_use]
+    pub fn glob_imports(file: &syn::File, module_path: &Path) -> Vec<syn::ItemUse> {
+        let module_path = ModulePath::from_fs_path(module_path);
+        file.items
+            .iter()
+            .filter_map(|item| match item {
+                syn::Item::Use(item_use) => Some(item_use),
+                _ => None,
+            })
+            .flat_map(|item_use| {
+                let mut paths = Vec::new();
+                collect_glob_paths(&item_use.tree, &module_path, Vec::new(), &mut paths);
+
+                paths.into_iter().map(|path| {
+                    let leading_colon = if item_use.leading_colon.is_some()
+                        && path.first().is_some_and(|segment| segment != "crate")
+                    {
+                        "::"
+                    } else {
+                        ""
+                    };
+                    let path = path.join("::");
+                    let mut import =
+                        syn::parse_str::<syn::ItemUse>(&format!("use {leading_colon}{path}::*;"))
+                            .expect("collected glob path should be a valid use statement");
+                    import.attrs.clone_from(&item_use.attrs);
+                    import
+                })
+            })
+            .collect()
     }
 
     /// Return the list of top-level `use` statements, structs, and constants as
@@ -279,9 +312,7 @@ impl VisibleSymbol {
                     &rename.ident.to_string(),
                 )];
             }
-            UseTree::Glob(_) => {
-                warn!("Glob imports are not supported");
-            }
+            UseTree::Glob(_) => {}
             UseTree::Group(group) => {
                 return group
                     .items
@@ -292,6 +323,39 @@ impl VisibleSymbol {
         }
 
         vec![]
+    }
+}
+
+#[cfg(feature = "symbol-resolver")]
+fn collect_glob_paths(
+    tree: &UseTree,
+    current_module: &ModulePath,
+    mut path: Vec<String>,
+    paths: &mut Vec<Vec<String>>,
+) {
+    match tree {
+        UseTree::Path(segment) => {
+            match segment.ident.to_string().as_str() {
+                "crate" => path = vec![String::from("crate")],
+                "self" if path.is_empty() => path.clone_from(&current_module.parts),
+                "self" => {}
+                "super" => {
+                    if path.is_empty() {
+                        path.clone_from(&current_module.parts);
+                    }
+                    path.pop();
+                }
+                ident => path.push(ident.to_owned()),
+            }
+            collect_glob_paths(&segment.tree, current_module, path, paths);
+        }
+        UseTree::Group(group) => {
+            for tree in &group.items {
+                collect_glob_paths(tree, current_module, path.clone(), paths);
+            }
+        }
+        UseTree::Glob(_) => paths.push(path),
+        UseTree::Name(_) | UseTree::Rename(_) => {}
     }
 }
 
@@ -442,6 +506,42 @@ const MY_CONSTANT: u8 = 42;
             },
         ];
         assert_eq!(imports, expected);
+    }
+
+    #[test]
+    fn glob_imports_resolve_relative_paths() {
+        let source = r"
+#[cfg(test)]
+use crate::{types::*, constants::VALUE};
+use super::shared::*;
+use self::local::*;
+        ";
+        let file = syn::parse_file(source).unwrap();
+
+        let imports = SymbolResolver::glob_imports(&file, Path::new("foo/bar.rs"))
+            .iter()
+            .map(ToTokens::to_token_stream)
+            .map(|tokens| tokens.to_string())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            imports,
+            [
+                quote!(
+                    #[cfg(test)]
+                    use crate::types::*;
+                )
+                .to_string(),
+                quote!(
+                    use crate::foo::shared::*;
+                )
+                .to_string(),
+                quote!(
+                    use crate::foo::bar::local::*;
+                )
+                .to_string(),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
The symbol resolver cannot enumerate names introduced by a glob import, so model field types reached generated migrations without either a fully resolved path or the import that made the name visible. It also emitted a warning even though the generator can preserve the original scope another way.

The resolver now extracts top-level glob branches from ordinary and grouped `use` trees. It rewrites `self` and `super` prefixes to stable crate-relative paths, preserves attributes such as `cfg`, and leaves explicit imports on the existing symbol-resolution path. Models carry those imports into generated migrations; imports from multiple changed models are deduplicated before emission.

Verification:
- red/green regression for crate-relative and `super` glob imports
- generated migration compile regression using a model whose macro and field type come from a glob
- Cot Codegen suites: 59 passed
- Cot CLI library suite: 52 passed
- migration generator integration suite: 15 passed
- `cargo +1.94.0 fmt --all -- --check`
- Cot Codegen and CLI Clippy across all targets/features with warnings denied (`unknown-lints` allowed for the upstream toolchain compatibility issue)

Closes #69.