### PR TITLE
feat: add ProjectMetadata schema and internal cli metadata hook

### DIFF
--- a/cot/Cargo.toml
+++ b/cot/Cargo.toml
@@ -55,7 +55,7 @@ schemars = { workspace = true, optional = true, features = ["derive"] }
 sea-query = { workspace = true, optional = true }
 sea-query-sqlx = { workspace = true, features = ["with-chrono"], optional = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true, optional = true }
+serde_json.workspace = true
 sqlx = { workspace = true, features = ["runtime-tokio", "chrono"], optional = true }
 subtle = { workspace = true, features = ["std"] }
 swagger-ui-redist = { workspace = true, optional = true }
@@ -113,7 +113,7 @@ sqlite = ["db", "sea-query/backend-sqlite", "sea-query-sqlx/sqlx-sqlite", "sqlx/
 postgres = ["db", "sea-query/backend-postgres", "sea-query-sqlx/sqlx-postgres", "sqlx/postgres"]
 mysql = ["db", "sea-query/backend-mysql", "sea-query-sqlx/sqlx-mysql", "sqlx/mysql"]
 redis = ["cache", "dep:deadpool-redis", "dep:redis", "json"]
-json = ["dep:serde_json", "cot_core/json"]
+json = ["cot_core/json"]
 openapi = ["json", "cot_core/schemars", "dep:aide", "dep:schemars"]
 swagger-ui = ["openapi", "dep:swagger-ui-redist"]
 live-reload = ["dep:tower-livereload"]

--- a/cot/src/cli.rs
+++ b/cot/src/cli.rs
@@ -188,6 +188,10 @@ impl Cli {
         self.tasks.insert(Some(name), Box::new(task));
     }
 
+    pub(crate) fn command(&self) -> &Command {
+        &self.command
+    }
+
     #[must_use]
     pub(crate) fn common_options(&mut self) -> CommonOptions {
         let matches = self.command.get_matches_mut();

--- a/cot/src/lib.rs
+++ b/cot/src/lib.rs
@@ -69,6 +69,7 @@ pub mod config;
 #[cfg(feature = "email")]
 pub mod email;
 mod error_page;
+pub mod metadata;
 pub mod middleware;
 #[cfg(feature = "openapi")]
 pub mod openapi;

--- a/cot/src/metadata.rs
+++ b/cot/src/metadata.rs
@@ -1,0 +1,287 @@
+//! Metadata exported by Cot project binaries for the proxying `cot` CLI.
+
+use clap::{Arg, Command};
+use serde::{Deserialize, Serialize};
+
+/// The current version of the `ProjectMetadata` JSON schema.
+pub const METADATA_SCHEMA_VERSION: u32 = 1;
+
+/// Flag used to ask a Cot project binary to print its CLI metadata as JSON.
+pub const METADATA_FLAG: &str = "--cot-internal-cli-metadata";
+
+/// Metadata describing the commands exposed by a Cot project binary.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ProjectMetadata {
+    /// Schema version this metadata was serialized with.
+    pub version: u32,
+    /// Name of the project binary that produced the metadata.
+    pub binary_name: String,
+    /// Top-level commands exposed by the project binary.
+    pub commands: Vec<CommandMeta>,
+}
+
+impl ProjectMetadata {
+    /// Create new Project metadata
+    pub fn new(cmd: &Command) -> Self {
+        let mut cmd = cmd.clone();
+        cmd.build();
+
+        ProjectMetadata {
+            version: METADATA_SCHEMA_VERSION,
+            binary_name: cmd.get_name().to_string(),
+            commands: cmd
+                .get_subcommands()
+                .filter(|subcmd| !subcmd.is_hide_set() && subcmd.get_name() != "help")
+                .map(CommandMeta::from)
+                .collect(),
+        }
+    }
+}
+
+impl From<&Command> for ProjectMetadata {
+    fn from(cmd: &Command) -> Self {
+        Self::new(cmd)
+    }
+}
+
+/// Arguments for a CLI command
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArgMeta {
+    /// Argument Name.
+    pub name: String,
+    /// long option name.
+    pub long: Option<String>,
+    /// short option name.
+    pub short: Option<char>,
+    /// Help text for the argument.
+    pub help: Option<String>,
+    /// Whether the argument is required.
+    pub required: bool,
+    /// Whether the argument is a positional argument.
+    pub is_positional: bool,
+    /// Whether the argument takes a value.
+    pub takes_value: bool,
+    /// The value name for this argument.
+    pub value_name: Option<String>,
+}
+
+impl From<&Arg> for ArgMeta {
+    fn from(arg: &Arg) -> Self {
+        Self {
+            name: arg.get_id().to_string(),
+            long: arg.get_long().map(str::to_string),
+            short: arg.get_short(),
+            help: arg.get_help().map(ToString::to_string),
+            required: arg.is_required_set(),
+            is_positional: arg.is_positional(),
+            takes_value: arg.get_num_args().is_some_and(|n| n.takes_values()),
+            value_name: arg
+                .get_value_names()
+                .and_then(|v| v.first())
+                .map(ToString::to_string),
+        }
+    }
+}
+
+/// Metadata for a single CLI command.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CommandMeta {
+    /// Command name.
+    pub name: String,
+    /// Optional command description.
+    pub about: Option<String>,
+    /// Visible aliases accepted by the command.
+    pub aliases: Vec<String>,
+    /// Nested subcommands exposed by this command.
+    pub subcommands: Vec<CommandMeta>,
+    /// Arguments supported by the command.
+    pub args: Vec<ArgMeta>,
+}
+
+impl From<&Command> for CommandMeta {
+    fn from(cmd: &Command) -> Self {
+        CommandMeta {
+            name: cmd.get_name().to_string(),
+            about: cmd.get_about().map(ToString::to_string),
+            aliases: cmd.get_all_aliases().map(ToString::to_string).collect(),
+            subcommands: cmd
+                .get_subcommands()
+                .filter(|subcmd| !subcmd.is_hide_set() && subcmd.get_name() != "help")
+                .map(CommandMeta::from)
+                .collect(),
+            args: cmd
+                .get_arguments()
+                .filter(|a| a.get_id() != "help" && a.get_id() != "version")
+                .map(ArgMeta::from)
+                .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_project_metadata_from() {
+        let command = Command::new("demo")
+            .subcommand(Command::new("serve").about("Serve requests"))
+            .subcommand(Command::new("secret").hide(true));
+
+        let metadata = ProjectMetadata::from(&command);
+
+        assert_eq!(metadata.binary_name, "demo");
+        assert_eq!(metadata.commands.len(), 1);
+        assert_eq!(metadata.commands[0].name, "serve");
+        assert_eq!(
+            metadata.commands[0].about.as_deref(),
+            Some("Serve requests")
+        );
+    }
+
+    #[test]
+    fn test_from_command_with_visible_aliases() {
+        let command = Command::new("demo").subcommand(
+            Command::new("database")
+                .visible_alias("db")
+                .subcommand(Command::new("migrate").visible_alias("mig"))
+                .subcommand(Command::new("internal").hide(true)),
+        );
+
+        let metadata = ProjectMetadata::from(&command);
+        let database = &metadata.commands[0];
+
+        assert_eq!(database.name, "database");
+        assert_eq!(database.aliases, vec!["db"]);
+        assert_eq!(database.subcommands.len(), 1);
+        assert_eq!(database.subcommands[0].name, "migrate");
+        assert_eq!(database.subcommands[0].aliases, vec!["mig"]);
+    }
+
+    #[test]
+    fn test_from_command_with_no_about() {
+        let command = Command::new("demo").subcommand(Command::new("plain"));
+
+        let metadata = ProjectMetadata::from(&command);
+
+        assert_eq!(metadata.commands[0].about, None);
+    }
+
+    #[test]
+    fn command_meta_from_captures_args() {
+        let command = Command::new("demo").subcommand(
+            Command::new("rollback")
+                .arg(
+                    Arg::new("migration_name")
+                        .value_name("MIGRATION_NAME")
+                        .required(true),
+                )
+                .arg(
+                    Arg::new("dry-run")
+                        .long("dry-run")
+                        .action(clap::ArgAction::SetTrue),
+                ),
+        );
+
+        let metadata = ProjectMetadata::from(&command);
+        let rollback = &metadata.commands[0];
+
+        assert_eq!(rollback.args.len(), 2);
+
+        let positional = rollback
+            .args
+            .iter()
+            .find(|a| a.name == "migration_name")
+            .unwrap();
+        assert!(positional.is_positional);
+        assert!(positional.required);
+        assert_eq!(positional.value_name.as_deref(), Some("MIGRATION_NAME"));
+
+        let flag = rollback.args.iter().find(|a| a.name == "dry-run").unwrap();
+        assert!(!flag.is_positional);
+        assert_eq!(flag.long.as_deref(), Some("dry-run"));
+        assert!(!flag.takes_value);
+    }
+
+    #[test]
+    fn command_meta_from_excludes_help_and_version_ids() {
+        let command =
+            Command::new("demo").subcommand(Command::new("sub").arg(Arg::new("real").long("real")));
+
+        let metadata = ProjectMetadata::from(&command);
+        let sub = &metadata.commands[0];
+
+        assert_eq!(sub.args.len(), 1);
+        assert_eq!(sub.args[0].name, "real");
+        assert!(
+            !sub.args
+                .iter()
+                .any(|a| a.name == "help" || a.name == "version")
+        );
+    }
+
+    #[test]
+    fn arg_meta_from_flag_arg() {
+        let arg = Arg::new("verbose")
+            .short('v')
+            .long("verbose")
+            .action(clap::ArgAction::SetTrue);
+
+        let meta = ArgMeta::from(&arg);
+
+        assert_eq!(meta.name, "verbose");
+        assert_eq!(meta.short, Some('v'));
+        assert_eq!(meta.long.as_deref(), Some("verbose"));
+        assert!(!meta.takes_value);
+        assert!(!meta.is_positional);
+    }
+
+    #[test]
+    fn arg_meta_from_positional_arg() {
+        let arg = Arg::new("path").value_name("PATH").required(true);
+
+        let meta = ArgMeta::from(&arg);
+
+        assert!(meta.is_positional);
+        assert!(meta.required);
+        assert_eq!(meta.value_name.as_deref(), Some("PATH"));
+    }
+
+    #[test]
+    fn positional_arg_without_explicit_num_args_reports_takes_value() {
+        let command = Command::new("demo").subcommand(
+            Command::new("frobnicate")
+                .arg(Arg::new("target").required(true).help("What to frobnicate")),
+        );
+
+        let metadata = ProjectMetadata::from(&command);
+        let target = &metadata.commands[0].args[0];
+
+        assert!(target.is_positional);
+        assert!(target.takes_value);
+    }
+
+    #[test]
+    fn subcommand_required_group_excludes_injected_help_subcommand() {
+        let command = Command::new("demo").subcommand(
+            Command::new("group")
+                .subcommand_required(true)
+                .arg_required_else_help(true)
+                .subcommand(Command::new("sub-a"))
+                .subcommand(Command::new("sub-b")),
+        );
+
+        let metadata = ProjectMetadata::from(&command);
+        let group = &metadata.commands[0];
+
+        assert!(!group.subcommands.iter().any(|sc| sc.name == "help"));
+        assert_eq!(
+            group
+                .subcommands
+                .iter()
+                .map(|sc| sc.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["sub-a", "sub-b"]
+        );
+    }
+}

--- a/cot/src/project.rs
+++ b/cot/src/project.rs
@@ -60,6 +60,7 @@ use crate::error::UncaughtPanic;
 use crate::error::handler::{DynErrorPageHandler, RequestOuterError};
 use crate::error_page::Diagnostics;
 use crate::html::Html;
+use crate::metadata::{METADATA_FLAG, ProjectMetadata};
 use crate::middleware::{IntoCotError, IntoCotErrorLayer, IntoCotResponse, IntoCotResponseLayer};
 use crate::request::{Request, RequestExt, RequestHead};
 use crate::response::{IntoResponse, Response};
@@ -938,6 +939,23 @@ impl Bootstrapper<Uninitialized> {
 
         cli.set_metadata(self.project.cli_metadata());
         self.project.register_tasks(&mut cli);
+
+        let args = std::env::args().collect::<Vec<_>>();
+        // get all args before any double dash(--)
+        let cot_args = match args.iter().position(|a| a == "--") {
+            Some(idx) => &args[..idx],
+            None => args.as_slice(),
+        };
+
+        if cot_args.iter().any(|arg| arg == METADATA_FLAG) {
+            let meta = ProjectMetadata::from(cli.command());
+
+            println!(
+                "{}",
+                serde_json::to_string(&meta).expect("parsing metadata to string should not fail.")
+            );
+            std::process::exit(0);
+        }
 
         let common_options = cli.common_options();
         let self_with_context = self.with_config_name(common_options.config())?;


### PR DESCRIPTION
## Description
Add a feature to extract metadata from every cot-compiled binary. We obtain information about the cli commands shipped with the binary and the name of the binary. This will be used by the cot-cli crate to identify what CLI commands are present in the binary.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Other (describe above)
